### PR TITLE
Support different date formats

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeRequest.java
@@ -43,7 +43,7 @@ public class GitLabMergeRequest {
     
     private static final String[] DATE_FORMATS = new String[] {
     	"yyyy-MM-dd HH:mm:ss Z",
-    	"yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+    	"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
     };
 
 


### PR DESCRIPTION
The format of dates in JSON payloads coming from Gitlab web hooks is inconsistent between versions and/or server configurations.
