### PR TITLE
Fix project search d

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     </parent>
 
   <artifactId>gitlab-plugin</artifactId>
-  <version>1.1.2-SNAPSHOT</version>
+  <version>1.1.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>GitLab Plugin</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/GitLab+Plugin</url>


### PR DESCRIPTION
On a maven project with multiple modules, I get the following result (found by debugging the application) :
Calling the url http://localhost:8080/jenkins/project/myProject/builds/myhash/status.json?token=111
- projectName = myProject
- item is a hudson.maven.MavenModuleSet, which make the test item instance ItemGroup<?> succeed. It happens to be also a AbstractProject (and the project we try to find).
- item.getItems() is a list of hudson.maven.MavenModule (none of them are a AbstractProject).
- resetOfPathParts.next() is "builds"
- so jenkins.getItem(resetOfPathParts.next(), item) is null.
  Therefore the result is item is set to null, and the rest of the function getDynamic fail.
  I fixed this issue by adding a stop condition on the loop if item is a instance of AbstractProject. I don't think of a case of a project being also a collection of projects so it might be the easier way to deal with this.
