### PR TITLE
fix bug of settings page while not show any branch if gitlab repo uses http protocol

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -294,7 +294,8 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
         		if (!gitlabHostUrl.isEmpty() && (null != sourceRepository)) {
         			List<GitlabProject> projects = getGitlab().instance().getProjects();
         			for (GitlabProject project : projects) {
-						if(project.getSshUrl().equalsIgnoreCase(sourceRepository.toString())){
+						if(project.getSshUrl().equalsIgnoreCase(sourceRepository.toString()) ||
+							project.getHttpUrl().equalsIgnoreCase(sourceRepository.toString())){
 							//Get all branches of project
 							List<GitlabBranch> branches = getGitlab().instance().getBranches(project);
 							for (GitlabBranch branch : branches){


### PR DESCRIPTION
I found a bug that our gitlab uses http protocol to access gitlab repo, and "filter branch" checkbox is always empty. The code only compares ssh url without http.
