### PR TITLE
Added "commits" to be redirected to build page. 

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -140,9 +140,11 @@ public class GitLabWebHook implements UnprotectedRootAction {
                 e.printStackTrace();
                 throw HttpResponses.error(500,"Could not generate an image.");
             }
-        } else if(firstPath.equals("builds") && !lastPath.equals("status.json")) {
+        } else if((firstPath.equals("commits") || firstPath.equals("builds")) && !lastPath.equals("status.json")) {
             AbstractBuild build = this.getBuildBySHA1(project, lastPath, true);
             redirectToBuildPage(res, build);
+        } else{
+            LOGGER.warning("Dynamic request mot met: First path: '" + firstPath + "' late path: '" + lastPath + "'");
         }
 
         throw HttpResponses.ok();


### PR DESCRIPTION
This URL is called from gitlab merge request page with a link next to the jenkins build status.

An example the link target: http://jenkins.home/project/test-project/commits/c220c0a5008bc47a3868287282e20e80428cc040

Furthermore added a logger warning to notify when a url is not matched.
