### PR TITLE
Found that the id from the ObjectAttribute dit not point to the id of th...

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeCause.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeCause.java
@@ -28,7 +28,7 @@ public class GitLabMergeCause extends SCMTrigger.SCMTriggerCause {
 
     @Override
     public String getShortDescription() {
-        return "GitLab Merge Request #" + this.mergeRequest.getObjectAttribute().getId() + " : " + this.mergeRequest.getObjectAttribute().getSourceBranch() +
+        return "GitLab Merge Request #" + this.mergeRequest.getObjectAttribute().getIid() + " : " + this.mergeRequest.getObjectAttribute().getSourceBranch() +
                 " => " + this.mergeRequest.getObjectAttribute().getTargetBranch();
     }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeRequest.java
@@ -64,6 +64,8 @@ public class GitLabMergeRequest extends GitLabRequest {
 
         private Integer id;
 
+        private Integer iid;
+
         private String targetBranch;
 
         private String sourceBranch;
@@ -103,6 +105,14 @@ public class GitLabMergeRequest extends GitLabRequest {
 
         public void setId(Integer id) {
             this.id = id;
+        }
+
+        public Integer getIid() {
+            return iid;
+        }
+
+        public void setIid(Integer iid) {
+            this.iid = iid;
         }
 
         public String getTargetBranch() {


### PR DESCRIPTION
Found that the id from the ObjectAttribute dit not point to the id of the merge request. In my cases the iid has the number of the merge request.

This commit adds the iid to the ObjectAttribute and changes the GitLabMergerCause description to us this instead of the id.

The current implementation will show builds prior to this updates as #null as we don't have the correct data available  (GitLab Merge Request #null : testing => master)
