### PR TITLE
make allowAllBranches use the saved state in job configuration

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -88,6 +88,11 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
     public List<String> getAllowedBranches() {
     	return allowedBranches;
     }
+    
+    public boolean getAllowAllBranches() {
+        return allowAllBranches;
+    }
+    
 
     public void onPost(final GitLabPushRequest req) {
     	boolean allowBuild = allowAllBranches || (allowedBranches.isEmpty() || allowedBranches.contains(getSourceBranch(req)));


### PR DESCRIPTION
The current value of allowAllBranches is not properly restored from job configuration when reconfiguring an existing job.It always defaults to false.This should fix it.