### PR TITLE
Pull just open merges from gitlab instead of first page of all of them

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -350,7 +350,7 @@ public class GitLabWebHook implements UnprotectedRootAction {
 	protected void buildOpenMergeRequests(GitLabPushTrigger trigger, Integer projectId, String projectRef) {
 		try {
 			GitLab api = new GitLab();
-			List<org.gitlab.api.models.GitlabMergeRequest> reqs = api.instance().getMergeRequests(projectId);
+			List<org.gitlab.api.models.GitlabMergeRequest> reqs = api.instance().getOpenMergeRequests(api.instance().getProject(projectId));
 			for (org.gitlab.api.models.GitlabMergeRequest mr : reqs) {
 				if (!mr.isClosed() && !mr.isMerged()&& projectRef.endsWith(mr.getSourceBranch())) {
 					LOGGER.log(Level.FINE,


### PR DESCRIPTION
getMergeRequests returns only the first page (20) of the merge requests,
which means most of the time the one related to the push won't be found
getOpenMergeRequests return all open merge requests, which not only
results in smaller array, but also should guarantee a match (if there
should be one).

Unfortunately the java-git api does not provide a overload with just
projectId, though the extra instance() call.