### PR TITLE
Adding parameters to merge request builds

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -194,6 +194,8 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
                     LOGGER.log(Level.INFO, "Trying to get name and URL for job: {0} using project {1}", new String[]{job.getName(), getDesc().project.getName()});
                     String sourceRepoName = getDesc().getSourceRepoNameDefault(job);
                     String sourceRepoURL = getDesc().getSourceRepoURLDefault(job).toString();
+                    String mergeRequestID = req.getObjectAttribute().getId().toString();
+                    String targetProjectID = req.getObjectAttribute().getTargetProjectId().toString();
                     
                     if (!getDescriptor().getGitlabHostUrl().isEmpty()) {                                        
                     	// Get source repository if communication to Gitlab is possible
@@ -208,6 +210,8 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
                     values.put("gitlabSourceRepoName", new StringParameterValue("gitlabSourceRepoName", sourceRepoName));
                 	values.put("gitlabSourceRepoURL", new StringParameterValue("gitlabSourceRepoURL", sourceRepoURL));
 
+                    values.put("gitlabMergeRequestID", new StringParameterValue("gitlabMergeRequestID", mergeRequestID));
+                    values.put("gitlabTargetProjectID", new StringParameterValue("gitlabTargetProjectID", targetProjectID));
                     List<ParameterValue> listValues = new ArrayList<ParameterValue>(values.values());
 
                     ParametersAction parametersAction = new ParametersAction(listValues);


### PR DESCRIPTION
gitlabMergeRequestID and gitlabTargetProjectID will now show up as parameters when a job is kicked off before of the merge request trigger. This allows interaction through the gitlab API within the job. To lookup the merge request or perform any other actions see the gitlab API doc: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/merge_requests.md#get-single-mr
Conflicts:
    src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
