### PR TITLE
Add buildUrl in the description of the merge message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Current Supported GitLabCI Functions
 
 Help Needed
 =====================
-* I am currently looking for someone to help maintain this project. This includes keeping up a Changelog, releasing builds, accepting merge requests, etc. If you are interested let @bass_rock know and I can add you as a maintainer.
+* I am currently looking for someone to help maintain this project. This includes keeping up a Changelog, releasing builds, accepting merge requests, etc. If you are interested let @bassrock know and I can add you as a maintainer.
 
 Configuring access to Gitlab
 =======================================

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -412,7 +412,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
             msg.append(" Jenkins Build ").append(run.getResult().color.getDescription());
             String buildUrl = Jenkins.getInstance().getRootUrl() + run.getUrl();
             msg.append("\n\nResults available at: ")
-                    .append("[").append("Jenkins").append("](").append(buildUrl).append(")");
+                    .append("[").append("Jenkins " + buildUrl).append("](").append(buildUrl).append(")");
             try {
                 GitlabProject proj = new GitlabProject();
                 proj.setId(cause.getMergeRequest().getObjectAttribute().getTargetProjectId());


### PR DESCRIPTION
When you have more than one project which takes part in a merge request,
it would be feasible to see directly which job voted in favor or not
for the merge request. So add it it directly in the visible output.