### PR TITLE
Rebuild open merge requests if target branch changed too

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -385,7 +385,7 @@ public class GitLabWebHook implements UnprotectedRootAction {
 			List<GitlabMergeRequest> mergeRequests = api.instance().retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
 
 			for (org.gitlab.api.models.GitlabMergeRequest mr : mergeRequests) {
-				if (projectRef.endsWith(mr.getSourceBranch())) {
+				if (projectRef.endsWith(mr.getSourceBranch()) || projectRef.endsWith(mr.getTargetBranch())) {
 					LOGGER.log(Level.FINE,
 							"Generating new merge trigger from "
 									+ mr.toString() + "\n source: "


### PR DESCRIPTION
It makes sense, since changes in target branch might affect build status after merge.