### PR TITLE
Cache Project Branches for each Job

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -458,6 +458,8 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
         private transient final SequentialExecutionQueue queue = new SequentialExecutionQueue(Jenkins.MasterComputer.threadPoolForRemoting);
         private transient GitLab gitlab;
 
+        private final Map<String, List<String>> projectBranches = new HashMap<String, List<String>>();
+
         public DescriptorImpl() {
         	load();
         }
@@ -512,6 +514,10 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
         }
 
         private List<String> getProjectBranches(final Job<?, ?> job) throws IOException, IllegalStateException {
+            if (projectBranches.containsKey(job.getName())){
+                return projectBranches.get(job.getName());
+            }
+
             if (!(job instanceof AbstractProject<?, ?>)) {
                 return Lists.newArrayList();
             }
@@ -541,6 +547,7 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
                     }
                 }
 
+                projectBranches.put(job.getName(), branchNames);
                 return branchNames;
             } catch (final Error error) {
                 /* WTF WTF WTF */

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -564,10 +564,25 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
             return Lists.newArrayList(Splitter.on(',').omitEmptyStrings().trimResults().split(spec));
         }
 
-        private AutoCompletionCandidates doAutoCompleteBranchesSpec(final Job<?, ?> job) {
+        private AutoCompletionCandidates doAutoCompleteBranchesSpec(final Job<?, ?> job, @QueryParameter final String value) {
+            String query = value.toLowerCase();
+
             final AutoCompletionCandidates ac = new AutoCompletionCandidates();
-            try {
-                ac.getValues().addAll(this.getProjectBranches(job));
+            List<String> values = ac.getValues();
+
+            try {  
+                List<String> branches = this.getProjectBranches(job);
+                // show all suggestions for short strings
+                if (query.length() < 2){
+                    values.addAll(branches);              
+                }
+                else {
+                    for (String branch : branches){
+                      if (branch.toLowerCase().indexOf(query) > -1){
+                        values.add(branch);
+                      }
+                    }
+                }
             } catch (final IllegalStateException ex) {
                 /* no-op */
             } catch (final IOException ex) {
@@ -577,12 +592,12 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
             return ac;
         }
 
-        public AutoCompletionCandidates doAutoCompleteIncludeBranchesSpec(@AncestorInPath final Job<?, ?> job) {
-            return this.doAutoCompleteBranchesSpec(job);
+        public AutoCompletionCandidates doAutoCompleteIncludeBranchesSpec(@AncestorInPath final Job<?, ?> job, @QueryParameter final String value) {
+            return this.doAutoCompleteBranchesSpec(job, value);
         }
 
-        public AutoCompletionCandidates doAutoCompleteExcludeBranchesSpec(@AncestorInPath final Job<?, ?> job) {
-            return this.doAutoCompleteBranchesSpec(job);
+        public AutoCompletionCandidates doAutoCompleteExcludeBranchesSpec(@AncestorInPath final Job<?, ?> job, @QueryParameter final String value) {
+            return this.doAutoCompleteBranchesSpec(job, value);
         }
 
         private FormValidation doCheckBranchesSpec(@AncestorInPath final Job<?, ?> project, @QueryParameter final String value) {


### PR DESCRIPTION
Currently, the inclusion and exclusion branch filters are excruciatingly slow, especially when backed by gitlab repos with hundreds of projects. Requests to gitlab are made on every keypress - every call to getProjectBranches makes a series of requests. 

This modification caches the list of branches for each project name.

There is one caveat - if a branch is changed on gitlab, the Jenkins project page will have to be refreshed before it reflects the new branch information.