### PR TITLE
Added support for the GitLab 8.1 commit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,16 @@ Using it With A Job
 * In GitLab go to you primary repository's project *Settings*
     * Click on *Web Hooks*
         * Add a Web Hook for *Merge Request Events* and *Push Events* to ``http://JENKINS_URL/project/PROJECT_NAME`` <br/>
-        **Note:** Currently GitLab 8.0 does not have a commit status api. Once this is added we should be able to add the commit status to Gitlab.
 
 If you plan to use forked repositories, you will need to enable the GitLab CI integration on **each fork**.
 * Go to the Settings page in each developer's fork
 * Click on *Services*
     * Click on *Web Hooks*
         * Add a Web Hook for *Merge Request Events* and *Push Events* to ``http://JENKINS_URL/project/PROJECT_NAME`` <br/>
-        **Note:** Currently GitLab 8.0 does not have a commit status api. Once this is added we should be able to add the commit status to Gitlab.
         **Note:** You do not need to select any "Trigger Events" as the Web Hook for Merge Request Events will alert Jenkins.
+## Gitlab Configuration (≥ 8.1)
+GitLab 8.1 uses the same configuration as GitLab 8.0
+* GitLab 8.1 has implemented a commit status api. To enable this check the ``Use GitLab CI features`` under the project settings.
 
 ### GitLab Configuration (< 8.0)
 * In GitLab go to you primary repository's project *Settings*

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
       <dependency>
           <groupId>org.gitlab</groupId>
           <artifactId>java-gitlab-api</artifactId>
-          <version>1.1.9</version>
+          <version>1.1.10-SNAPSHOT</version>
       </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
       <dependency>
           <groupId>org.gitlab</groupId>
           <artifactId>java-gitlab-api</artifactId>
-          <version>1.1.10-SNAPSHOT</version>
+          <version>1.1.11</version>
       </dependency>
   </dependencies>
 </project>

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeRequest.java
@@ -5,6 +5,9 @@ import java.util.Date;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
+import org.gitlab.api.GitlabAPI;
+import org.gitlab.api.models.GitlabCommitStatus;
+import org.gitlab.api.models.GitlabMergeRequest;
 import org.gitlab.api.models.GitlabProject;
 
 /**
@@ -58,6 +61,19 @@ public class GitLabMergeRequest extends GitLabRequest {
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this, ToStringStyle.MULTI_LINE_STYLE);
+    }
+
+    public GitlabCommitStatus createCommitStatus(GitlabAPI api, String status, String targetUrl) {
+        try {
+            GitlabMergeRequest mergeRequest = api.getMergeRequest(sourceProject, objectAttributes.getId());
+            if(objectAttributes.lastCommit!=null) {
+                return api.createCommitStatus(sourceProject, objectAttributes.getLastCommit().getId(), status, mergeRequest.getSourceBranch(), "Jenkins", targetUrl, null);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return null;
     }
 
     public static class ObjectAttributes {

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeRequest.java
@@ -65,9 +65,8 @@ public class GitLabMergeRequest extends GitLabRequest {
 
     public GitlabCommitStatus createCommitStatus(GitlabAPI api, String status, String targetUrl) {
         try {
-            GitlabMergeRequest mergeRequest = api.getMergeRequest(sourceProject, objectAttributes.getId());
             if(objectAttributes.lastCommit!=null) {
-                return api.createCommitStatus(sourceProject, objectAttributes.getLastCommit().getId(), status, mergeRequest.getSourceBranch(), "Jenkins", targetUrl, null);
+                return api.createCommitStatus(sourceProject, objectAttributes.getLastCommit().getId(), status, objectAttributes.getLastCommit().getId(), "Jenkins", targetUrl, null);
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushCause.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushCause.java
@@ -10,24 +10,35 @@ import java.io.IOException;
  */
 public class GitLabPushCause extends SCMTrigger.SCMTriggerCause {
 
-    private final String pushedBy;
+    private final GitLabPushRequest pushRequest;
 
-    public GitLabPushCause(String pushedBy) {
-        this.pushedBy = pushedBy;
+    public GitLabPushCause(GitLabPushRequest pushRequest) {
+        this.pushRequest=pushRequest;
     }
 
-    public GitLabPushCause(String pushedBy, File logFile) throws IOException {
+    public GitLabPushCause(GitLabPushRequest pushRequest, File logFile) throws IOException{
         super(logFile);
-        this.pushedBy = pushedBy;
+        this.pushRequest=pushRequest;
     }
 
-    public GitLabPushCause(String pushedBy, String pollingLog) {
+    public GitLabPushCause(GitLabPushRequest pushRequest, String pollingLog) {
         super(pollingLog);
-        this.pushedBy = pushedBy;
+        this.pushRequest=pushRequest;
+    }
+
+    public GitLabPushRequest getPushRequest() {
+        return pushRequest;
     }
 
     @Override
     public String getShortDescription() {
+        String pushedBy;
+        if (pushRequest.getCommits().size() > 0){
+            pushedBy = pushRequest.getCommits().get(0).getAuthor().getName();
+        } else {
+            pushedBy = pushRequest.getUser_name();
+        }
+
         if (pushedBy == null) {
             return "Started by GitLab push";
         } else {

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushRequest.java
@@ -39,7 +39,7 @@ public class GitLabPushRequest extends GitLabRequest {
     public GitlabCommitStatus createCommitStatus(GitlabAPI api, String status, String targetUrl) {
         try {
             if(getLastCommit()!=null) {
-                return api.createCommitStatus(sourceProject, getLastCommit().getId(), status, checkout_sha, "Jenkins", targetUrl, null);
+                return api.createCommitStatus(sourceProject, checkout_sha, status, checkout_sha, "Jenkins", targetUrl, null);
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushRequest.java
@@ -1,9 +1,13 @@
 package com.dabsquared.gitlabjenkins;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
+import org.gitlab.api.GitlabAPI;
+import org.gitlab.api.models.GitlabCommitStatus;
+import org.gitlab.api.models.GitlabProject;
 
 /**
  * Represents for WebHook payload
@@ -23,6 +27,25 @@ public class GitLabPushRequest extends GitLabRequest {
     public GitLabPushRequest() {
     }
 
+    private GitlabProject sourceProject = null;
+
+    public GitlabProject getSourceProject (GitLab api) throws IOException {
+        if (sourceProject == null) {
+            sourceProject = api.instance().getProject(project_id);
+        }
+        return sourceProject;
+    }
+
+    public GitlabCommitStatus createCommitStatus(GitlabAPI api, String status, String targetUrl) {
+        try {
+            if(getLastCommit()!=null) {
+                return api.createCommitStatus(sourceProject, getLastCommit().getId(), status, checkout_sha, "Jenkins", targetUrl, null);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
 
     private String before;
     private String after;

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -207,7 +207,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
             		}
 
                     if(addCiMessage) {
-                        req.createCommitStatus(getDescriptor().getGitlab().instance(), "pending", getDescriptor().gitlabHostUrl);
+                        req.createCommitStatus(getDescriptor().getGitlab().instance(), "pending", Jenkins.getInstance().getRootUrl() + job.getUrl());
                     }
                 }
 
@@ -311,7 +311,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 	                }
 
                     if(addCiMessage) {
-                        req.createCommitStatus(getDescriptor().getGitlab().instance(), "pending", getDescriptor().gitlabHostUrl);
+                        req.createCommitStatus(getDescriptor().getGitlab().instance(), "pending", Jenkins.getInstance().getRootUrl() + job.getUrl());
                     }
                 }
 
@@ -411,7 +411,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 
     private void onCompletedPushRequest(Run run, GitLabPushCause cause) {
         if(addCiMessage) {
-            cause.getPushRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), run.getResult()==Result.SUCCESS?"success":"failure", this.getDescriptor().gitlabHostUrl);
+            cause.getPushRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), run.getResult()==Result.SUCCESS?"success":"failure", Jenkins.getInstance().getRootUrl() + run.getUrl());
         }
     }
 
@@ -452,7 +452,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         }
 
         if(addCiMessage) {
-            cause.getMergeRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), run.getResult()==Result.SUCCESS?"success":"failure", this.getDescriptor().gitlabHostUrl);
+            cause.getMergeRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), run.getResult()==Result.SUCCESS?"success":"failure", Jenkins.getInstance().getRootUrl() + run.getUrl());
         }
     }
 
@@ -472,13 +472,13 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 
     private void onStartedPushRequest(Run run, GitLabPushCause cause) {
         if(addCiMessage) {
-            cause.getPushRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), "running", this.getDescriptor().gitlabHostUrl);
+            cause.getPushRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), "running", Jenkins.getInstance().getRootUrl() + run.getUrl());
         }
     }
 
     private void onStartedMergeRequest(Run run, GitLabMergeCause cause) {
         if(addCiMessage) {
-            cause.getMergeRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), "running", this.getDescriptor().gitlabHostUrl);
+            cause.getMergeRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), "running", Jenkins.getInstance().getRootUrl() + run.getUrl());
         }
     }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -40,7 +40,6 @@ import jenkins.model.ParameterizedJobMixIn;
 import jenkins.triggers.SCMTriggerItem;
 import jenkins.triggers.SCMTriggerItem.SCMTriggerItems;
 import net.sf.json.JSONObject;
-import javax.annotation.Nullable;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.transport.RemoteConfig;
@@ -82,6 +81,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
     private boolean ciSkip = true;
     private boolean setBuildDescription = true;
     private boolean addNoteOnMergeRequest = true;
+    private boolean addCiMessage = false;
     private boolean addVoteOnMergeRequest = true;
     private boolean allowAllBranches = false;
     private final String includeBranchesSpec;
@@ -89,14 +89,15 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
     private boolean acceptMergeRequestOnSuccess = false;
 
     @DataBoundConstructor
-    public GitLabPushTrigger(boolean triggerOnPush, boolean triggerOnMergeRequest, String triggerOpenMergeRequestOnPush, boolean ciSkip, boolean setBuildDescription, boolean addNoteOnMergeRequest, boolean addVoteOnMergeRequest, boolean acceptMergeRequestOnSuccess, boolean allowAllBranches,
+    public GitLabPushTrigger(boolean triggerOnPush, boolean triggerOnMergeRequest, String triggerOpenMergeRequestOnPush, boolean ciSkip, boolean setBuildDescription, boolean addNoteOnMergeRequest, boolean addCiMessage, boolean addVoteOnMergeRequest, boolean acceptMergeRequestOnSuccess, boolean allowAllBranches,
             String includeBranchesSpec, String excludeBranchesSpec) {
         this.triggerOnPush = triggerOnPush;
         this.triggerOnMergeRequest = triggerOnMergeRequest;
         this.triggerOpenMergeRequestOnPush = triggerOpenMergeRequestOnPush;
         this.ciSkip = ciSkip;
         this.setBuildDescription = setBuildDescription;
-	this.addNoteOnMergeRequest = addNoteOnMergeRequest;
+        this.addNoteOnMergeRequest = addNoteOnMergeRequest;
+        this.addCiMessage = addCiMessage;
         this.addVoteOnMergeRequest = addVoteOnMergeRequest;
         this.allowAllBranches = allowAllBranches;
         this.includeBranchesSpec = includeBranchesSpec;
@@ -200,20 +201,18 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
             		} else {
             			LOGGER.log(Level.INFO, "GitLab Push Request detected in {0}. Job is already in the queue.", job.getName());
             		}
+
+                    if(addCiMessage) {
+                        req.createCommitStatus(getDescriptor().getGitlab().instance(), "pending", getDescriptor().gitlabHostUrl);
+                    }
                 }
 
                 private GitLabPushCause createGitLabPushCause(GitLabPushRequest req) {
                     GitLabPushCause cause;
-                    String triggeredByUser;
-                    if (req.getCommits().size() > 0){
-                        triggeredByUser = req.getCommits().get(0).getAuthor().getName();
-                    } else {
-                        triggeredByUser = req.getUser_name();
-                    }
                     try {
-                        cause = new GitLabPushCause(triggeredByUser, getLogFile());
+                        cause = new GitLabPushCause(req, getLogFile());
                     } catch (IOException ex) {
-                        cause = new GitLabPushCause(triggeredByUser);
+                        cause = new GitLabPushCause(req);
                     }
                     return cause;
                 }
@@ -230,14 +229,24 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
                     values.put("gitlabTargetBranch", new StringParameterValue("gitlabTargetBranch", branch));
                     values.put("gitlabBranch", new StringParameterValue("gitlabBranch", branch));
 
-                    if (job instanceof AbstractProject<?,?>){
-                        LOGGER.log(Level.INFO, "Trying to get name and URL for job: {0} using project {1} (push)", new String[]{job.getName(), ((AbstractProject<?, ?>) job).getRootProject().getName()});
-                    }else{
-                        LOGGER.log(Level.INFO, "Trying to get name and URL for job: {0} (push)", new String[]{job.getName()});
-                    }
-                    values.put("gitlabSourceRepoName", new StringParameterValue("gitlabSourceRepoName", getDesc().getSourceRepoNameDefault(job)));
-                	values.put("gitlabSourceRepoURL", new StringParameterValue("gitlabSourceRepoURL", getDesc().getSourceRepoURLDefault(job).toString()));
                     values.put("gitlabActionType", new StringParameterValue("gitlabActionType", "PUSH"));
+
+                    LOGGER.log(Level.INFO, "Trying to get name and URL for job: {0}", job.getName());
+                    String sourceRepoName = getDesc().getSourceRepoNameDefault(job);
+                    String sourceRepoURL = getDesc().getSourceRepoURLDefault(job).toString();
+
+                    if (!getDescriptor().getGitlabHostUrl().isEmpty()) {
+                        // Get source repository if communication to Gitlab is possible
+                        try {
+                            sourceRepoName = req.getSourceProject(getDesc().getGitlab()).getPathWithNamespace();
+                            sourceRepoURL = req.getSourceProject(getDesc().getGitlab()).getSshUrl();
+                        } catch (IOException ex) {
+                            LOGGER.log(Level.WARNING, "Could not fetch source project''s data from Gitlab. '('{0}':' {1}')'", new String[]{ex.toString(), ex.getMessage()});
+                        }
+                    }
+
+                    values.put("gitlabSourceRepoName", new StringParameterValue("gitlabSourceRepoName", sourceRepoName));
+                    values.put("gitlabSourceRepoURL", new StringParameterValue("gitlabSourceRepoURL", sourceRepoURL));
 
                     List<ParameterValue> listValues = new ArrayList<ParameterValue>(values.values());
 
@@ -296,6 +305,10 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 	                } else {
 	                    LOGGER.log(Level.INFO, "GitLab Merge Request detected in {0}. Job is already in the queue.", job.getName());
 	                }
+
+                    if(addCiMessage) {
+                        req.createCommitStatus(getDescriptor().getGitlab().instance(), "pending", getDescriptor().gitlabHostUrl);
+                    }
                 }
 
                 private GitLabMergeCause createGitLabMergeCause(GitLabMergeRequest req) {
@@ -379,12 +392,23 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         }
     }
 
-    public void onCompleted(Run build){
-        Cause mCause= build.getCause(GitLabMergeCause.class);
+    public void onCompleted(Run run){
+        Cause mCause= run.getCause(GitLabMergeCause.class);
         if (mCause != null && mCause instanceof GitLabMergeCause) {
-            onCompleteMergeRequest(build,(GitLabMergeCause) mCause);
+            onCompleteMergeRequest(run, (GitLabMergeCause) mCause);
         }
 
+        Cause pCause= run.getCause(GitLabPushCause.class);
+        if (pCause != null && pCause instanceof GitLabPushCause) {
+            onCompletedPushRequest(run, (GitLabPushCause) pCause);
+        }
+
+    }
+
+    private void onCompletedPushRequest(Run run, GitLabPushCause cause) {
+        if(addCiMessage) {
+            cause.getPushRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), run.getResult()==Result.SUCCESS?"success":"failure", this.getDescriptor().gitlabHostUrl);
+        }
     }
 
     private void onCompleteMergeRequest(Run run,GitLabMergeCause cause){
@@ -423,10 +447,35 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
             }
         }
 
+        if(addCiMessage) {
+            cause.getMergeRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), run.getResult()==Result.SUCCESS?"success":"failure", this.getDescriptor().gitlabHostUrl);
+        }
     }
 
     public void onStarted(Run run) {
         setBuildCauseInJob(run);
+
+        Cause mCause= run.getCause(GitLabMergeCause.class);
+        if (mCause != null && mCause instanceof GitLabMergeCause) {
+            onStartedMergeRequest(run, (GitLabMergeCause) mCause);
+        }
+
+        Cause pCause= run.getCause(GitLabPushCause.class);
+        if (pCause != null && pCause instanceof GitLabPushCause) {
+            onStartedPushRequest(run, (GitLabPushCause) pCause);
+        }
+    }
+
+    private void onStartedPushRequest(Run run, GitLabPushCause cause) {
+        if(addCiMessage) {
+            cause.getPushRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), "running", this.getDescriptor().gitlabHostUrl);
+        }
+    }
+
+    private void onStartedMergeRequest(Run run, GitLabMergeCause cause) {
+        if(addCiMessage) {
+            cause.getMergeRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), "running", this.getDescriptor().gitlabHostUrl);
+        }
     }
 
     private String getSourceBranch(GitLabRequest req) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -133,6 +133,10 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         return allowAllBranches;
     }
 
+    public boolean getAddCiMessage() {
+        return addCiMessage;
+    }
+
     public boolean getCiSkip() {
         return ciSkip;
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabRequest.java
@@ -14,8 +14,10 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
+import org.gitlab.api.GitlabAPI;
+import org.gitlab.api.models.GitlabCommitStatus;
 
-public class GitLabRequest {
+public abstract class GitLabRequest {
 	protected enum Builder {
 		INSTANCE;
 		private final Gson gson;
@@ -50,5 +52,7 @@ public class GitLabRequest {
 					+ Arrays.toString(DATE_FORMATS));
 		}
 	}
+
+    public abstract GitlabCommitStatus createCommitStatus(GitlabAPI api, String status, String targetUrl);
 
 }

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -18,7 +18,7 @@
     <f:entry title="Add note with build status on merge requests" field="addNoteOnMergeRequest">
       <f:checkbox default="true" />
     </f:entry>
-    <f:entry title="Use GitLab CI features (GitLab 8.1 required!)" field="addCiMessage">
+    <f:entry title="Use GitLab CI features (GitLab 8.1 required!)" field="addCiMessage" help="/plugin/gitlab-plugin/help/help-gitlab8.1CI.html">
       <f:checkbox default="false"/>
     </f:entry>
      <f:entry title="Vote added to note with build status on merge requests" field="addVoteOnMergeRequest">

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -18,6 +18,9 @@
     <f:entry title="Add note with build status on merge requests" field="addNoteOnMergeRequest">
       <f:checkbox default="true" />
     </f:entry>
+    <f:entry title="Use GitLab CI features (GitLab 8.1 required!)" field="addCiMessage">
+      <f:checkbox default="false"/>
+    </f:entry>
      <f:entry title="Vote added to note with build status on merge requests" field="addVoteOnMergeRequest">
       <f:checkbox default="true" />
     </f:entry>

--- a/src/main/webapp/help/help-gitlab8.1CI.html
+++ b/src/main/webapp/help/help-gitlab8.1CI.html
@@ -1,0 +1,3 @@
+<div>
+    Enable GitLab 8.1 Continuous Integration feature. <b>DO NOT ENABLE IF YOU'RE USING A VERSION BEFORE GITLAB 8.1</b>.
+</div>


### PR DESCRIPTION
Fixes #111 & fixes #122
This adds support for the GitLab 8.1 commit API.
Added an extra option so it can be enabled (disabled by default)

Will add result to all pushrequests & mergerequests using the gitlab api.

Please note: it uses the java-gitlab-api v1.1.10-SNAPSHOT which isn't available (yet) through the official maven repository. See issue: timols/java-gitlab-api#80
