### PR TITLE
#126 handle npe on push requests

### DIFF
--- a/src/test/java/com/dabsquared/gitlabjenkins/AbstractGitLabPushTriggerGitlabServerTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/AbstractGitLabPushTriggerGitlabServerTest.java
@@ -1,0 +1,125 @@
+package com.dabsquared.gitlabjenkins;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import com.dabsquared.gitlabjenkins.testhelpers.GitLabPushRequestSamples;
+
+import hudson.model.Job;
+import hudson.plugins.git.RevisionParameterAction;
+
+public abstract class AbstractGitLabPushTriggerGitlabServerTest {
+
+	protected GitLabPushTrigger pushTrigger;
+	protected GitLabPushRequestSamples gitLabPushRequestSamples;
+	protected Job<?, ?> job = null;
+
+	@Test
+	public void createRevisionParameterAction_pushBrandNewMasterBranchRequest() throws Exception {
+		// given
+		GitLabPushRequest pushRequest = gitLabPushRequestSamples.pushBrandNewMasterBranchRequest();
+
+		// when
+		RevisionParameterAction revisionParameterAction = pushTrigger.createPushRequestRevisionParameter(job,
+				pushRequest);
+
+		// then
+		assertThat(revisionParameterAction, is(notNullValue()));
+		assertThat(revisionParameterAction.commit, is(pushRequest.getAfter()));
+	}
+
+	@Test
+	public void createRevisionParameterAction_mergeRequestMergePushRequest() throws Exception {
+		// given
+		GitLabPushRequest pushRequest = gitLabPushRequestSamples.mergePushRequest();
+
+		// when
+		RevisionParameterAction revisionParameterAction = pushTrigger.createPushRequestRevisionParameter(job,
+				pushRequest);
+
+		// then
+		assertThat(revisionParameterAction, is(notNullValue()));
+		assertThat(revisionParameterAction.commit, is(pushRequest.getAfter()));
+	}
+
+	@Test
+	public void createRevisionParameterAction_pushCommitRequest() throws Exception {
+		// given
+		GitLabPushRequest pushRequest = gitLabPushRequestSamples.pushCommitRequest();
+
+		// when
+		RevisionParameterAction revisionParameterAction = pushTrigger.createPushRequestRevisionParameter(job,
+				pushRequest);
+
+		// then
+		assertThat(revisionParameterAction, is(notNullValue()));
+		assertThat(revisionParameterAction.commit, is(pushRequest.getAfter()));
+	}
+
+	@Test
+	public void createRevisionParameterAction_pushNewBranchRequest() throws Exception {
+		// given
+		GitLabPushRequest pushRequest = gitLabPushRequestSamples.pushNewBranchRequest();
+
+		// when
+		RevisionParameterAction revisionParameterAction = pushTrigger.createPushRequestRevisionParameter(job,
+				pushRequest);
+
+		// then
+		assertThat(revisionParameterAction, is(notNullValue()));
+		assertThat(revisionParameterAction.commit, is(pushRequest.getAfter()));
+	}
+
+	@Test
+	public void createRevisionParameterAction_pushNewTagRequest() throws Exception {
+		// given
+		GitLabPushRequest pushRequest = gitLabPushRequestSamples.pushNewTagRequest();
+
+		// when
+		RevisionParameterAction revisionParameterAction = pushTrigger.createPushRequestRevisionParameter(job,
+				pushRequest);
+
+		// then
+		assertThat(revisionParameterAction, is(notNullValue()));
+		assertThat(revisionParameterAction.commit, is(pushRequest.getAfter()));
+	}
+
+	@Test
+	public void doNotCreateRevisionParameterAction_deleteBranchRequest() throws Exception {
+		// given
+		GitLabPushRequest pushRequest = gitLabPushRequestSamples.deleteBranchRequest();
+
+		// when
+		RevisionParameterAction revisionParameterAction = pushTrigger.createPushRequestRevisionParameter(job,
+				pushRequest);
+
+		// then
+		assertThat(revisionParameterAction, is(nullValue()));
+	}
+
+	protected GitLabPushTrigger setUpWithPushTrigger() {
+		boolean triggerOnPush = true;
+		boolean triggerOnMergeRequest = true;
+		String triggerOpenMergeRequestOnPush = "both";
+		boolean ciSkip = false;
+		boolean setBuildDescription = true;
+		boolean addNoteOnMergeRequest = true;
+		boolean addCiMessage = true;
+		boolean addVoteOnMergeRequest = true;
+		boolean acceptMergeRequestOnSuccess = false;
+		boolean allowAllBranches = true;
+		String includeBranchesSpec = null;
+		String excludeBranchesSpec = null;
+		GitLabPushTrigger gitLabPushTrigger = new GitLabPushTrigger(triggerOnPush, triggerOnMergeRequest,
+				triggerOpenMergeRequestOnPush, ciSkip, setBuildDescription, addNoteOnMergeRequest, addCiMessage,
+				addVoteOnMergeRequest, acceptMergeRequestOnSuccess, allowAllBranches, includeBranchesSpec,
+				excludeBranchesSpec);
+
+		return gitLabPushTrigger;
+	}
+
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/GitLabPushTriggerGitlabServer_7_10_5_489b413_Test.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/GitLabPushTriggerGitlabServer_7_10_5_489b413_Test.java
@@ -1,0 +1,15 @@
+package com.dabsquared.gitlabjenkins;
+
+import org.junit.Before;
+
+import com.dabsquared.gitlabjenkins.testhelpers.GitLabPushRequestSamples_7_10_5_489b413;
+
+public class GitLabPushTriggerGitlabServer_7_10_5_489b413_Test extends AbstractGitLabPushTriggerGitlabServerTest {
+
+	@Before
+	public void setUp() {
+		pushTrigger = setUpWithPushTrigger();
+		gitLabPushRequestSamples = new GitLabPushRequestSamples_7_10_5_489b413();
+	}
+
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/GitLabPushTriggerGitlabServer_7_5_1_36679b5_Test.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/GitLabPushTriggerGitlabServer_7_5_1_36679b5_Test.java
@@ -1,0 +1,15 @@
+package com.dabsquared.gitlabjenkins;
+
+import org.junit.Before;
+
+import com.dabsquared.gitlabjenkins.testhelpers.GitLabPushRequestSamples_7_5_1_36679b5;
+
+public class GitLabPushTriggerGitlabServer_7_5_1_36679b5_Test extends AbstractGitLabPushTriggerGitlabServerTest {
+
+	@Before
+	public void setUp() {
+		pushTrigger = setUpWithPushTrigger();
+		gitLabPushRequestSamples = new GitLabPushRequestSamples_7_5_1_36679b5();
+	}
+
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/GitLabPushTriggerGitlabServer_8_1_2_8c8af7b_Test.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/GitLabPushTriggerGitlabServer_8_1_2_8c8af7b_Test.java
@@ -1,0 +1,15 @@
+package com.dabsquared.gitlabjenkins;
+
+import org.junit.Before;
+
+import com.dabsquared.gitlabjenkins.testhelpers.GitLabPushRequestSamples_8_1_2_8c8af7b;
+
+public class GitLabPushTriggerGitlabServer_8_1_2_8c8af7b_Test extends AbstractGitLabPushTriggerGitlabServerTest {
+
+	@Before
+	public void setUp() {
+		pushTrigger = setUpWithPushTrigger();
+		gitLabPushRequestSamples = new GitLabPushRequestSamples_8_1_2_8c8af7b();
+	}
+
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/CommitBuilder.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/CommitBuilder.java
@@ -1,0 +1,31 @@
+package com.dabsquared.gitlabjenkins.testhelpers;
+
+import com.dabsquared.gitlabjenkins.GitLabPushRequest;
+
+public class CommitBuilder {
+
+	public static GitLabPushRequest.Commit buildWithDefaults() {
+		return new CommitBuilder().withCommitSha("4bf0fcd937085dc2f69dcbe31f2ef960ec9ca7eb").build();
+	}
+
+	private GitLabPushRequest.Commit commit;
+
+	public CommitBuilder() {
+		commit = new GitLabPushRequest.Commit();
+		commit.setAuthor(new GitLabPushRequest.User());
+		commit.getAuthor().setName("author name");
+		commit.getAuthor().setEmail("author@example.com");
+		commit.setTimestamp("2015-11-12T07:49:09+11:00");
+	}
+
+	public CommitBuilder withCommitSha(String commitSha) {
+		commit.setId(commitSha);
+		commit.setUrl("http://gitlabserver.example.com/test-group/test-repo/commit/" + commitSha);
+		return this;
+	}
+
+	public GitLabPushRequest.Commit build() {
+		return commit;
+	}
+
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestBuilder.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestBuilder.java
@@ -1,0 +1,65 @@
+package com.dabsquared.gitlabjenkins.testhelpers;
+
+import java.util.ArrayList;
+
+import com.dabsquared.gitlabjenkins.GitLabPushRequest;
+
+public class GitLabPushRequestBuilder {
+
+	public static final String ZERO_SHA = "0000000000000000000000000000000000000000";
+
+	public static GitLabPushRequest buildWithDefaults() {
+		return new GitLabPushRequestBuilder().withBasicValues().build();
+	}
+
+	private GitLabPushRequest pushRequest;
+
+	public GitLabPushRequestBuilder() {
+		pushRequest = new GitLabPushRequest();
+		pushRequest.setUser_id(123);
+		pushRequest.setUser_name("admin@example");
+		pushRequest.setProject_id(345);
+		pushRequest.setRepository(RepositoryBuilder.buildWithDefaults());
+		pushRequest.setCommits(new ArrayList<GitLabPushRequest.Commit>());
+	}
+
+	public GitLabPushRequestBuilder withBasicValues() {
+		withBefore("2bf4170829aedd706d7485d40091a01637b9abf4");
+		withAfter("c04c8822d1df397fb7e6dd3dd133018a0af567a8");
+		withCheckoutSha("c04c8822d1df397fb7e6dd3dd133018a0af567a8");
+		withRef("refs/heads/master");
+		addCommit("c04c8822d1df397fb7e6dd3dd133018a0af567a8");
+		return this;
+	}
+
+	public GitLabPushRequestBuilder withBefore(String beforeSha) {
+		pushRequest.setBefore(beforeSha);
+		return this;
+	}
+
+	public GitLabPushRequestBuilder withAfter(String afterSha) {
+		pushRequest.setAfter(afterSha);
+		return this;
+	}
+
+	public GitLabPushRequestBuilder withCheckoutSha(String checkoutSha) {
+		pushRequest.setCheckout_sha(checkoutSha);
+		return this;
+	}
+
+	public GitLabPushRequestBuilder withRef(String ref) {
+		pushRequest.setRef(ref);
+		return this;
+	}
+
+	public GitLabPushRequestBuilder addCommit(String commitSha) {
+		pushRequest.getCommits().add(new CommitBuilder().withCommitSha(commitSha).build());
+		return this;
+	}
+
+	public GitLabPushRequest build() {
+		pushRequest.setTotal_commits_count(pushRequest.getCommits().size());
+		return pushRequest;
+	}
+
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples.java
@@ -1,0 +1,17 @@
+package com.dabsquared.gitlabjenkins.testhelpers;
+
+import com.dabsquared.gitlabjenkins.GitLabPushRequest;
+
+public interface GitLabPushRequestSamples {
+	GitLabPushRequest pushBrandNewMasterBranchRequest();
+
+	GitLabPushRequest pushNewBranchRequest();
+
+	GitLabPushRequest pushCommitRequest();
+
+	GitLabPushRequest mergePushRequest();
+
+	GitLabPushRequest pushNewTagRequest();
+
+	GitLabPushRequest deleteBranchRequest();
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples_7_10_5_489b413.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples_7_10_5_489b413.java
@@ -1,0 +1,56 @@
+package com.dabsquared.gitlabjenkins.testhelpers;
+
+import static com.dabsquared.gitlabjenkins.testhelpers.GitLabPushRequestBuilder.ZERO_SHA;
+
+import com.dabsquared.gitlabjenkins.GitLabPushRequest;
+
+public class GitLabPushRequestSamples_7_10_5_489b413 implements GitLabPushRequestSamples {
+
+	private static final String COMMIT_7A = "7a5db3baf5d42b4218a2a501c88f745559b1d24c";
+	private static final String COMMIT_21 = "21d67fe28097b49a1a6fb5c82cbfe03d389e8685";
+	private static final String COMMIT_9d = "9dbdd7a128a2789d0f436222ce116f1d8229e083";
+
+	public GitLabPushRequest pushBrandNewMasterBranchRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/master").withBefore(ZERO_SHA)
+				.withAfter(COMMIT_7A).withCheckoutSha(COMMIT_7A)
+				// no commit on new branches
+				.build();
+		return pushRequest;
+	}
+
+	public GitLabPushRequest pushNewBranchRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/test-new-branch1")
+				.withBefore(ZERO_SHA).withAfter(COMMIT_7A).withCheckoutSha(COMMIT_7A)
+				// no commit on new branches
+				.build();
+		return pushRequest;
+	}
+
+	public GitLabPushRequest pushCommitRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/test-new-branch1")
+				.withBefore(COMMIT_7A).withAfter(COMMIT_21).withCheckoutSha(COMMIT_21).addCommit(COMMIT_21).build();
+		return pushRequest;
+	}
+
+	public GitLabPushRequest mergePushRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/master")
+				.withBefore("ca84f96a846b0e241808ea7b75dfa3bf4cd3b98b").withAfter(COMMIT_9d).withCheckoutSha(COMMIT_9d)
+				.addCommit(COMMIT_21).addCommit("c04c8822d1df397fb7e6dd3dd133018a0af567a8").addCommit(COMMIT_9d)
+				.build();
+		return pushRequest;
+	}
+
+	public GitLabPushRequest pushNewTagRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/tags/test-tag-1")
+				.withBefore(ZERO_SHA).withAfter(COMMIT_21).withCheckoutSha(COMMIT_21).addCommit(COMMIT_21).build();
+		return pushRequest;
+	}
+
+	public GitLabPushRequest deleteBranchRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/test-branch-3-delete")
+				.withBefore("c34984ff6ed9935b3d843237947adbaaa85fc5f9").withAfter(ZERO_SHA).withCheckoutSha(ZERO_SHA)
+				.build();
+		return pushRequest;
+	}
+
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples_7_5_1_36679b5.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples_7_5_1_36679b5.java
@@ -1,0 +1,62 @@
+package com.dabsquared.gitlabjenkins.testhelpers;
+
+import static com.dabsquared.gitlabjenkins.testhelpers.GitLabPushRequestBuilder.ZERO_SHA;
+
+import com.dabsquared.gitlabjenkins.GitLabPushRequest;
+
+public class GitLabPushRequestSamples_7_5_1_36679b5 implements GitLabPushRequestSamples {
+
+	public GitLabPushRequest pushBrandNewMasterBranchRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/master").withBefore(ZERO_SHA)
+				.withAfter("d91a0f248625f6dc808fb7cda75c4ee01516b609")
+				// no checkout_sha and no commit on new branches
+				.build();
+		return pushRequest;
+	}
+
+	public GitLabPushRequest pushNewBranchRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/test-new-branch1")
+				.withBefore(ZERO_SHA).withAfter("2bf4170829aedd706d7485d40091a01637b9abf4")
+				// no checkout_sha and no commit on new branches
+				.build();
+		return pushRequest;
+	}
+
+	public GitLabPushRequest pushCommitRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/test-new-branch1")
+				.withBefore("2bf4170829aedd706d7485d40091a01637b9abf4")
+				.withAfter("4bf0fcd937085dc2f69dcbe31f2ef960ec9ca7eb")
+				// no checkout_sha
+				.addCommit("4bf0fcd937085dc2f69dcbe31f2ef960ec9ca7eb").build();
+		return pushRequest;
+	}
+
+	public GitLabPushRequest mergePushRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/master")
+				.withBefore("27548e742f40971f75c715aaa7920404eeff6616")
+				.withAfter("3ebb6927ad4afbe8a11830938b3584cdaf4d657b")
+				// no checkout_sha
+				.addCommit("4bf0fcd937085dc2f69dcbe31f2ef960ec9ca7eb")
+				.addCommit("be473fcc670b920cc9795581a5cd8f00fa7afddd")
+				.addCommit("3ebb6927ad4afbe8a11830938b3584cdaf4d657b").build();
+		return pushRequest;
+		// and afterwards the "delete branch" request comes in
+	}
+
+	public GitLabPushRequest pushNewTagRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/tags/test-tag-2")
+				.withBefore(ZERO_SHA).withAfter("f10d9d7b648e5a3e55fe8fe865aba5aa7404df7c")
+				// no checkout_sha and no commit on new branches
+				.build();
+		return pushRequest;
+	}
+
+	public GitLabPushRequest deleteBranchRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/test-branch-delete-1")
+				.withBefore("3ebb6927ad4afbe8a11830938b3584cdaf4d657b").withAfter(ZERO_SHA)
+				// no checkout_sha and no commit on new branches
+				.build();
+		return pushRequest;
+	}
+
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples_8_1_2_8c8af7b.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples_8_1_2_8c8af7b.java
@@ -1,0 +1,61 @@
+package com.dabsquared.gitlabjenkins.testhelpers;
+
+import static com.dabsquared.gitlabjenkins.testhelpers.GitLabPushRequestBuilder.ZERO_SHA;
+
+import com.dabsquared.gitlabjenkins.GitLabPushRequest;
+
+public class GitLabPushRequestSamples_8_1_2_8c8af7b implements GitLabPushRequestSamples {
+
+	private static final String COMMIT_25 = "258d6f6e21e6dda343f6e9f8e78c38f12bb81c87";
+	private static final String COMMIT_63 = "63b30060be89f0338123f2d8975588e7d40a1874";
+	private static final String COMMIT_64 = "64ed77c360ee7ac900c68292775bee2184c1e593";
+	private static final String COMMIT_74 = "742d8d0b4b16792c38c6798b28ba1fa754da165e";
+	private static final String COMMIT_E5 = "e5a46665b80965724b45fe921788105258b3ec5c";
+
+	public GitLabPushRequest pushBrandNewMasterBranchRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/master").withBefore(ZERO_SHA)
+				.withAfter(COMMIT_63).withCheckoutSha(COMMIT_63)
+				// no commit on new branches
+				.build();
+		return pushRequest;
+	}
+
+	public GitLabPushRequest pushNewBranchRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/test-new-branch1")
+				.withBefore(ZERO_SHA).withAfter(COMMIT_25).withCheckoutSha(COMMIT_25)
+				// no commit on new branches
+				.build();
+		return pushRequest;
+	}
+
+	public GitLabPushRequest pushCommitRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/test-new-branch1")
+				.withBefore(COMMIT_25).withAfter(COMMIT_74).withCheckoutSha(COMMIT_74).addCommit(COMMIT_74).build();
+
+		return pushRequest;
+	}
+
+	public GitLabPushRequest mergePushRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/master")
+				.withBefore("e8b9327c9704e308949f9d31dd0fae6abfac3798").withAfter(COMMIT_E5).withCheckoutSha(COMMIT_E5)
+				.addCommit(COMMIT_74).addCommit("ab569fa9c51fa80d6509b277a6b587faf8e7cb72").addCommit(COMMIT_E5)
+				.build();
+		return pushRequest;
+
+		// and afterwards the "delete branch" request comes in
+	}
+
+	public GitLabPushRequest pushNewTagRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/tags/test-tag-2")
+				.withBefore(ZERO_SHA).withAfter(COMMIT_64).withCheckoutSha(COMMIT_64).addCommit(COMMIT_64).build();
+		return pushRequest;
+	}
+
+	public GitLabPushRequest deleteBranchRequest() {
+		GitLabPushRequest pushRequest = new GitLabPushRequestBuilder().withRef("refs/heads/test-branch-delete-1")
+				.withBefore("784c5ca7814aa7ea1913ae8e64187c31322946f0").withAfter(ZERO_SHA).withCheckoutSha(null)
+				.build();
+		return pushRequest;
+	}
+
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/RepositoryBuilder.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/RepositoryBuilder.java
@@ -1,0 +1,29 @@
+package com.dabsquared.gitlabjenkins.testhelpers;
+
+import com.dabsquared.gitlabjenkins.GitLabPushRequest;
+
+public class RepositoryBuilder {
+
+	public static GitLabPushRequest.Repository buildWithDefaults() {
+		return new RepositoryBuilder().withBasicValues().build();
+	}
+
+	private GitLabPushRequest.Repository repository;
+
+	public RepositoryBuilder() {
+		repository = new GitLabPushRequest.Repository();
+	}
+
+	public RepositoryBuilder withBasicValues() {
+		repository.setName("test-repo");
+		repository.setUrl("git@gitlabserver.example.com:test-group/test-repo.git");
+		repository.setHomepage("http://gitlabserver.example.com/test-group/test-repo");
+		repository.setDescription("");
+		return this;
+	}
+
+	public GitLabPushRequest.Repository build() {
+		return repository;
+	}
+
+}


### PR DESCRIPTION
Fixes #126 the null pointer exception on gitlab 7.5 by falling back to the "after" commit sha
Also added some test cases for that particular code.
