### PR TITLE
Added missing documentation 8.1 CI features

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ If you plan to use forked repositories, you will need to enable the GitLab CI in
         * Add a Web Hook for *Merge Request Events* and *Push Events* to ``http://JENKINS_URL/project/PROJECT_NAME`` <br/>
         **Note:** You do not need to select any "Trigger Events" as the Web Hook for Merge Request Events will alert Jenkins.
 
-## GitLab Configuration (≥ 8.1)
+### GitLab Configuration (≥ 8.1)
 GitLab 8.1 uses the same configuration as GitLab 8.0
 * GitLab 8.1 has implemented a commit status api. To enable this check the ``Use GitLab CI features`` under the project settings.
+* Configure access to GitLab as described above in "Configure access to GitLab"
 
 ### GitLab Configuration (< 8.0)
 * In GitLab go to you primary repository's project *Settings*


### PR DESCRIPTION
Added the requirement of gitlab access to 8.1 ci features.
Users are required to setup the comminication from Jenkins to GitLab for the 8.1 ci features, as Jenkins uses the GitLab API to communicate. Without the configuration, no data can and will be send.
