### PR TITLE
New feature: Add support for regex based filtering and more

### DIFF
--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -1,47 +1,62 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <f:entry title="Build on Merge Request Events" field="triggerOnMergeRequest">
-      <f:checkbox default="true" />
+        <f:checkbox default="true"/>
     </f:entry>
     <f:entry title="Build on Push Events" field="triggerOnPush">
-      <f:checkbox default="true" />
+        <f:checkbox default="true"/>
     </f:entry>
     <f:entry title="Rebuild open Merge Requests" field="triggerOpenMergeRequestOnPush">
-      <f:select/>
+        <f:select/>
     </f:entry>
     <f:entry title="Enable [ci-skip]" field="ciSkip">
-      <f:checkbox default="true" />
+        <f:checkbox default="true"/>
     </f:entry>
     <f:entry title="Set build description to build cause (eg. Merge request or Git Push )" field="setBuildDescription">
-      <f:checkbox default="true" />
+        <f:checkbox default="true"/>
     </f:entry>
     <f:entry title="Add note with build status on merge requests" field="addNoteOnMergeRequest">
-      <f:checkbox default="true" />
+        <f:checkbox default="true"/>
     </f:entry>
-    <f:entry title="Use GitLab CI features (GitLab 8.1 required!)" field="addCiMessage" help="/plugin/gitlab-plugin/help/help-gitlab8.1CI.html">
-      <f:checkbox default="false"/>
+    <f:entry title="Use GitLab CI features (GitLab 8.1 required!)" field="addCiMessage"
+             help="/plugin/gitlab-plugin/help/help-gitlab8.1CI.html">
+        <f:checkbox default="false"/>
     </f:entry>
-     <f:entry title="Vote added to note with build status on merge requests" field="addVoteOnMergeRequest">
-      <f:checkbox default="true" />
+    <f:entry title="Vote added to note with build status on merge requests" field="addVoteOnMergeRequest">
+        <f:checkbox default="true"/>
     </f:entry>
-     <f:entry title="Accept merge request on success" field="acceptMergeRequestOnSuccess">
-       <f:checkbox default="false" />
-     </f:entry>
-        <f:entry title="All allow all branches (Ignoring Filtered Branches)" field="allowAllBranches">
-      <f:checkbox default="false" />
+    <f:entry title="Accept merge request on success" field="acceptMergeRequestOnSuccess">
+        <f:checkbox default="false"/>
     </f:entry>
 
     <f:block>
-      <table style="margin-left:10px">
-	<f:optionalBlock title="Filter branches" help="/plugin/gitlab-plugin/help/help-allowedBranches.html"  inline="true" checked="${not (empty(instance.includeBranchesSpec) and empty(instance.excludeBranchesSpec))}">
-          <f:entry title="Include">
-            <f:textbox field="includeBranchesSpec" autocompleteDelimChar="," />
-          </f:entry>
-          <f:entry title="Exclude">
-            <f:textbox field="excludeBranchesSpec" autocompleteDelimChar="," />
-          </f:entry>
-	</f:optionalBlock>
-      </table>
+        <table style="margin-left:10px">
+            <!--<f:section title="">-->
+            <f:radioBlock name="branchFilterName" value="" title="Allow all branches to trigger this job"
+                          checked="${instance.branchFilterName == ''}"
+                          inline="true" help="/plugin/gitlab-plugin/help/help-noBranchFiltering.html"/>
+            <f:radioBlock name="branchFilterName" value="NameBasedFilter" title="Filter branches by name"
+                          checked="${instance.branchFilterName == 'NameBasedFilter'}" inline="true"
+                          help="/plugin/gitlab-plugin/help/help-allowedBranches.html">
+                <f:entry title="Include">
+                    <f:textbox field="includeBranchesSpec" autocompleteDelimChar=","/>
+                </f:entry>
+                <f:entry title="Exclude">
+                    <f:textbox field="excludeBranchesSpec" autocompleteDelimChar=","/>
+                </f:entry>
+            </f:radioBlock>
+
+            <f:radioBlock name="branchFilterName" value="RegexBasedFilter" title="Filter branches by regex"
+                          checked="${instance.branchFilterName == 'RegexBasedFilter'}" inline="true"
+                          help="/plugin/gitlab-plugin/help/help-filterBranchesByRegex.html">
+                <f:entry title="Target Branch Regex">
+                    <f:textbox field="targetBranchRegex"/>
+                </f:entry>
+            </f:radioBlock>
+            <!--</f:section> -->
+        </table>
     </f:block>
+
 
 </j:jelly>

--- a/src/main/webapp/help/help-allowedBranches.html
+++ b/src/main/webapp/help/help-allowedBranches.html
@@ -1,3 +1,4 @@
-<div>
-    Comma-separated list of source branches allowed to trigger a build from a <b>Push event</b>.
+<p>Comma-separated list of source branches allowed to trigger a build from a <b>Push event</b> or a <b>Merge Request event</b>.
+    If both fields are left empty, all branches are allowed to trigger this job.
+    For <b>Merge Request events</b> only the target branch name is filtered out by the include and exclude lists.
 </div>

--- a/src/main/webapp/help/help-filterBranchesByRegex.html
+++ b/src/main/webapp/help/help-filterBranchesByRegex.html
@@ -1,0 +1,9 @@
+<div>
+    <div>
+        <p>The target branch regex allows to limit the execution of this job to certain branches. Any branch matching the specified pattern triggers the
+            job. No filtering is performed if the field is left empty.</p>
+        <p>Examples:</p>
+        <pre># Allow execution for debug and release branches: (.*debug.*|.*release.*) </pre>
+        <pre># Ignore any branch with `Release` or `release` as subword: ^(?:(?![R|r]elease).)*$ </pre>
+    </div>
+</div>

--- a/src/main/webapp/help/help-noBranchFiltering.html
+++ b/src/main/webapp/help/help-noBranchFiltering.html
@@ -1,0 +1,3 @@
+<div>
+    <p>All branches are allowed to trigger this job.</p>
+</div>

--- a/src/test/java/com/dabsquared/gitlabjenkins/AbstractGitLabPushTriggerGitlabServerTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/AbstractGitLabPushTriggerGitlabServerTest.java
@@ -111,13 +111,14 @@ public abstract class AbstractGitLabPushTriggerGitlabServerTest {
 		boolean addCiMessage = true;
 		boolean addVoteOnMergeRequest = true;
 		boolean acceptMergeRequestOnSuccess = false;
-		boolean allowAllBranches = true;
+		String branchFilter = null;
 		String includeBranchesSpec = null;
 		String excludeBranchesSpec = null;
+		String targetBranchRegex = null;
 		GitLabPushTrigger gitLabPushTrigger = new GitLabPushTrigger(triggerOnPush, triggerOnMergeRequest,
 				triggerOpenMergeRequestOnPush, ciSkip, setBuildDescription, addNoteOnMergeRequest, addCiMessage,
-				addVoteOnMergeRequest, acceptMergeRequestOnSuccess, allowAllBranches, includeBranchesSpec,
-				excludeBranchesSpec);
+				addVoteOnMergeRequest, acceptMergeRequestOnSuccess, branchFilter, includeBranchesSpec,
+				excludeBranchesSpec, targetBranchRegex);
 
 		return gitLabPushTrigger;
 	}


### PR DESCRIPTION
Two new features were introduced:

(1) Allow branch filtering through regular expressions
(2) Use branch filtering also for Merge Request events

By making use of <b>radioBlocks</b> tags, the user is forced to choose
between allowing all branches to trigger the respective job and 
filtering the branches by one out of two possible approaches:
- filtering by name
- filtering by regular expression
