### PR TITLE
Merge requests should also set gitlabBranch

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -362,6 +362,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
                     Map<String, ParameterValue> values = getDefaultParameters();
                     values.put("gitlabSourceBranch", new StringParameterValue("gitlabSourceBranch", getSourceBranch(req)));
                     values.put("gitlabTargetBranch", new StringParameterValue("gitlabTargetBranch", req.getObjectAttribute().getTargetBranch()));
+                    values.put("gitlabBranch", new StringParameterValue("gitlabBranch", getSourceBranch(req)));
                     values.put("gitlabActionType", new StringParameterValue("gitlabActionType", "MERGE"));
                     if (req.getObjectAttribute().getAuthor() != null) {
                         values.put("gitlabUserName", new StringParameterValue("gitlabUserName", req.getObjectAttribute().getAuthor().getName()));


### PR DESCRIPTION
Not sure I understand why 'gitlabBranch' is there, when I could also use one of the other parameters fine in Jenkins.
So we should either deprecate it or also set it on merge requests. Like this.

(this is untested)
