### PR TITLE
Push requests should also build against the target branch

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -234,7 +234,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 
                     Map<String, ParameterValue> values = getDefaultParameters();
                     values.put("gitlabSourceBranch", new StringParameterValue("gitlabSourceBranch", branch));
-                    values.put("gitlabTargetBranch", new StringParameterValue("gitlabTargetBranch", branch));
+                    values.put("gitlabTargetBranch", new StringParameterValue("gitlabTargetBranch", req.getObjectAttribute().getTargetBranch()));
                     values.put("gitlabBranch", new StringParameterValue("gitlabBranch", branch));
 
                     values.put("gitlabActionType", new StringParameterValue("gitlabActionType", "PUSH"));


### PR DESCRIPTION
Before this jenkins will try to merge our source branch with a branch of the same name on our upstream git server. Which mostly means it will fail due to that branch not existing. We should use the branch name the gitlab push request send us.
Also see: #164

(untested so far, but the jenkins build triggered by this PR might help)
