### PR TITLE
fix null pointer access in buildOpenMergeRequests

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -419,8 +419,8 @@ public class GitLabWebHook implements UnprotectedRootAction {
 									+ mr.getSourceBranch() + "\n target: "
 									+ mr.getTargetBranch() + "\n state: "
 									+ mr.getState() + "\n assign: "
-									+ mr.getAssignee().getName() + "\n author: "
-									+ mr.getAuthor().getName() + "\n id: "
+									+ (mr.getAssignee() != null ? mr.getAssignee().getName() : "") + "\n author: "
+									+ (mr.getAuthor() != null ? mr.getAuthor().getName() : "") + "\n id: "
 									+ mr.getId() + "\n iid: "
                                     + mr.getIid() + "\n last commit: "
                                     + lastCommit.getId() + "\n\n");


### PR DESCRIPTION
assignee is not a mandatory field for a merge request, we need to test it before accessing its members

Signed-off-by: runsisi runsisi@hust.edu.cn
