### PR TITLE
fix "FATAL: Null value not allowed as an environment variable: gitlabUserEmail"

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -429,7 +429,7 @@ public class GitLabWebHook implements UnprotectedRootAction {
 					newReq.setObjectAttribute(new GitLabMergeRequest.ObjectAttributes());
 					if (mr.getAssignee() != null)
 						newReq.getObjectAttribute().setAssignee(mr.getAssignee());
-					if (mr.getAuthor() != null)
+					if (mr.getAuthor() != null && mr.getAuthor().getName() != null && mr.getAuthor().getEmail() != null)
                         newReq.getObjectAttribute().setAuthor(mr.getAuthor());
 					newReq.getObjectAttribute().setDescription(mr.getDescription());
 					newReq.getObjectAttribute().setId(mr.getId());


### PR DESCRIPTION
as in gitlab-ce-8.3.0-ce, when we try to get info of opened MRs, gitlab will not return us the email address of the author:

```
curl http://hust/api/v3/projects/1/merge_requests?state=opened\&private_token=CiQcZ9TLJ3qZD6sy-Ftv

[{"id":6,"iid":6,"project_id":1,"title":"mr3.1","description":"mr3.1",
...
"author":{
"name":"luo.runbing",
"username":"luo.runbing",
"id":2,
"state":"active",
"avatar_url":"http://www.gravatar.com/avatar/3c0c2978976bf9b11c965017aec497a9?s=80\u0026d=identicon",
"web_url":"http://hust/u/luo.runbing"},
...}]
```

which results error like this:

```
FATAL: Null value not allowed as an environment variable: gitlabUserEmail
```

Signed-off-by: runsisi runsisi@hust.edu.cn
