### PR TITLE
fix error "failed to communicate with gitlab server ..." when try to rebuild open MRs

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -398,19 +398,24 @@ public class GitLabWebHook implements UnprotectedRootAction {
 			GitLab api = new GitLab();
 			List<GitlabMergeRequest> mergeRequests = api.instance().getOpenMergeRequests(projectId);
 
-			for (org.gitlab.api.models.GitlabMergeRequest mr : mergeRequests) {
-				if (projectRef.endsWith(mr.getSourceBranch()) || 
-                                        (trigger.getTriggerOpenMergeRequestOnPush().equals("both") && projectRef.endsWith(mr.getTargetBranch()))) {
-                                    
-                                        if (trigger.getCiSkip() && mr.getDescription().contains("[ci-skip]")) {
-                                            LOGGER.log(Level.INFO, "Skipping MR " + mr.getTitle() + " due to ci-skip.");
-                                            continue;
-                                        }
-					GitlabBranch branch = api.instance().getBranch(api.instance().getProject(projectId), mr.getSourceBranch());
+            for (org.gitlab.api.models.GitlabMergeRequest mr : mergeRequests) {
+                if (projectRef.endsWith(mr.getSourceBranch()) ||
+                        (trigger.getTriggerOpenMergeRequestOnPush().equals("both") && projectRef.endsWith(mr.getTargetBranch()))) {
+                    if (trigger.getCiSkip() && mr.getDescription().contains("[ci-skip]")) {
+                        LOGGER.log(Level.INFO, "Skipping MR " + mr.getTitle() + " due to ci-skip.");
+                        continue;
+                    }
+
+                    Integer srcProjectId = projectId;
+                    if (!projectRef.endsWith(mr.getSourceBranch())) {
+                        srcProjectId = mr.getSourceProjectId();
+                    }
+
+                    GitlabBranch branch = api.instance().getBranch(api.instance().getProject(srcProjectId), mr.getSourceBranch());
                     LastCommit lastCommit = new LastCommit();
                     lastCommit.setId(branch.getCommit().getId());
                     lastCommit.setMessage(branch.getCommit().getMessage());
-                    lastCommit.setUrl(GitlabProject.URL + "/" + projectId + "/repository" + GitlabCommit.URL + "/"
+                    lastCommit.setUrl(GitlabProject.URL + "/" + srcProjectId + "/repository" + GitlabCommit.URL + "/"
                             + branch.getCommit().getId());
 
 					LOGGER.log(Level.FINE,


### PR DESCRIPTION
as stated in [comment](https://github.com/jenkinsci/gitlab-plugin/issues/144#issuecomment-167432522) of #144,  when we try to rebuild opened MRs, we should try to get the source branch by the id of source project, or else we will meet this:

```
failed to communicate with gitlab server to determine is this is an update for a merge request: http://hust/api/v3/projects/4/repository/branches/mr4?private_token=UmK47w8rxu7PfA3Fuu6-
```

Signed-off-by: runsisi runsisi@hust.edu.cn
