### PR TITLE
Status to canceled instead of failed if Jenkins build is aborted

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -451,7 +451,15 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 
     private void onCompletedPushRequest(Run run, GitLabPushCause cause) {
         if(addCiMessage) {
-            cause.getPushRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), run.getResult()==Result.SUCCESS?"success":"failed", Jenkins.getInstance().getRootUrl() + run.getUrl());
+            String status;
+            if (run.getResult() == Result.ABORTED) {
+                status = "canceled";
+            }else if (run.getResult() == Result.SUCCESS) {
+                status = "success";
+            }else {
+                status = "failed";
+            }
+            cause.getPushRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), status, Jenkins.getInstance().getRootUrl() + run.getUrl());
         }
     }
 
@@ -492,7 +500,15 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         }
 
         if(addCiMessage) {
-            cause.getMergeRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), run.getResult()==Result.SUCCESS?"success":"failed", Jenkins.getInstance().getRootUrl() + run.getUrl());
+            String status;
+            if (run.getResult() == Result.ABORTED) {
+                status = "canceled";
+            }else if (run.getResult() == Result.SUCCESS) {
+                status = "success";
+            }else {
+                status = "failed";
+            }
+            cause.getMergeRequest().createCommitStatus(this.getDescriptor().getGitlab().instance(), status, Jenkins.getInstance().getRootUrl() + run.getUrl());
         }
     }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -243,6 +243,8 @@ public class GitLabWebHook implements UnprotectedRootAction {
         //TODO: add status of pending when we figure it out.
         if(mainBuild.isBuilding()) {
             object.put("status", "running");
+        }else if(res == Result.ABORTED) {
+            object.put("status", "canceled");
         }else if(res == Result.SUCCESS) {
             object.put("status", "success");
         }else {


### PR DESCRIPTION
Hi, I was encountering a problem when someone aborted a running build in Jenkins (clicking the [x] icon), the build state in GitLab was "failed" and should be "canceled" in my opinion. This pull request solves this.

Something that still missing is if someone aborts a build in the queue, the build state in GitLab is "pending" forever.
