### PR TITLE
Fix NPE if there is no assignee of the MR

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -419,8 +419,8 @@ public class GitLabWebHook implements UnprotectedRootAction {
 									+ mr.getSourceBranch() + "\n target: "
 									+ mr.getTargetBranch() + "\n state: "
 									+ mr.getState() + "\n assign: "
-									+ mr.getAssignee().getName() + "\n author: "
-									+ mr.getAuthor().getName() + "\n id: "
+									+ (mr.getAssignee() != null ? mr.getAssignee().getName() : "") + "\n author: "
+									+ (mr.getAuthor() != null ? mr.getAuthor().getName() : "") + "\n id: "
 									+ mr.getId() + "\n iid: "
                                     + mr.getIid() + "\n last commit: "
                                     + lastCommit.getId() + "\n\n");


### PR DESCRIPTION
Related to https://github.com/jenkinsci/gitlab-plugin/pull/170
#170 fixes the main problem, but we also access these variables in a logging above, where we should also guard against nulls.
