### PR TITLE
Customize notes for merge requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,16 @@ In order to build when a new tag is pushed:
     * select ``Advance...`` and add  ``+refs/tags/*:refs/remotes/origin/tags/*`` as ``Refspec``
     * you can also use ``Branch Specifier`` to specify which tag need to be built (exampple ``refs/tags/${TAGNAME}``)
 
+# Send message on complete of a build
+
+1. In the *Post build steps* section:
+    1. Click *Add post build step*
+    2. Click *Add note with build status on merge requests* and save build settings (You enabled autoumatically sending default message on result of a build)
+
+2. If you want make custom message on result of a build:
+    1. In *Add note with build status on merge requests* section click to *Custom message on success/failure/abort*
+    2. Write text of message, you can use Environment variables
+
 # Parameterized builds
 
 You can trigger a job a manually by clicking ``This build is parameterized`` and adding the any of the relevant build parameters.

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -6,6 +6,7 @@ import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.MergeRequestHook;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.PushHook;
 import com.dabsquared.gitlabjenkins.publisher.GitLabCommitStatusPublisher;
+import com.dabsquared.gitlabjenkins.publisher.GitLabMessagePublisher;
 import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
 import com.dabsquared.gitlabjenkins.trigger.branch.ProjectBranchesProvider;
 import com.dabsquared.gitlabjenkins.trigger.filter.BranchFilter;
@@ -114,6 +115,9 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
                 if (trigger != null) {
                     if (trigger.addCiMessage) {
                         project.getPublishersList().add(new GitLabCommitStatusPublisher());
+                    }
+                    if (trigger.addNoteOnMergeRequest) {
+                        project.getPublishersList().add(new GitLabMessagePublisher(false, false, false, null, null, null));
                     }
                     if (trigger.branchFilterType == null) {
                         trigger.branchFilterType = trigger.branchFilterName;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabApi.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabApi.java
@@ -1,9 +1,6 @@
 package com.dabsquared.gitlabjenkins.gitlab.api;
 
-import com.dabsquared.gitlabjenkins.gitlab.api.model.Branch;
-import com.dabsquared.gitlabjenkins.gitlab.api.model.BuildState;
-import com.dabsquared.gitlabjenkins.gitlab.api.model.Project;
-import com.dabsquared.gitlabjenkins.gitlab.api.model.User;
+import com.dabsquared.gitlabjenkins.gitlab.api.model.*;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
 
 import javax.ws.rs.DELETE;
@@ -102,6 +99,12 @@ public interface GitLabApi {
                               @QueryParam("state") State state,
                               @QueryParam("page") int page,
                               @QueryParam("per_page") int perPage);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/projects/{projectId}/merge_requests/{mergeRequestId}")
+    MergeRequest getMergeRequest(@PathParam("projectId") String projectId,
+                                 @PathParam("mergeRequestId") Integer mergeRequestId);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/com/dabsquared/gitlabjenkins/listener/GitLabMergeRequestRunListener.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/listener/GitLabMergeRequestRunListener.java
@@ -10,38 +10,28 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
-import jenkins.model.Jenkins;
 
 import javax.annotation.Nonnull;
 import javax.ws.rs.WebApplicationException;
-import java.text.MessageFormat;
 
 /**
  * @author Robin Müller
  */
 @Extension
 public class GitLabMergeRequestRunListener extends RunListener<Run<?, ?>> {
-
     @Override
     public void onCompleted(Run<?, ?> build, @Nonnull TaskListener listener) {
         GitLabPushTrigger trigger = GitLabPushTrigger.getFromJob(build.getParent());
         GitLabWebHookCause cause = build.getCause(GitLabWebHookCause.class);
 
         if (trigger != null && cause != null && cause.getData().getActionType() == CauseData.ActionType.MERGE) {
-            String buildUrl = getBuildUrl(build);
             Result buildResult = build.getResult();
             Integer projectId = cause.getData().getProjectId();
             Integer mergeRequestId = cause.getData().getMergeRequestId();
             if (buildResult == Result.SUCCESS) {
                 acceptMergeRequestIfNecessary(build, trigger, listener, projectId.toString(), mergeRequestId);
             }
-            addNoteOnMergeRequestIfNecessary(build, trigger, listener, projectId.toString(), mergeRequestId, build.getParent().getDisplayName(), build.getNumber(),
-                    buildUrl, getResultIcon(trigger, buildResult), buildResult.color.getDescription());
         }
-    }
-
-    private String getBuildUrl(Run<?, ?> build) {
-        return Jenkins.getInstance().getRootUrl() + build.getUrl();
     }
 
     private void acceptMergeRequestIfNecessary(Run<?, ?> build, GitLabPushTrigger trigger, TaskListener listener, String projectId, Integer mergeRequestId) {
@@ -59,32 +49,6 @@ public class GitLabMergeRequestRunListener extends RunListener<Run<?, ?>> {
         }
     }
 
-    private void addNoteOnMergeRequestIfNecessary(Run<?, ?> build, GitLabPushTrigger trigger, TaskListener listener, String projectId, Integer mergeRequestId,
-                                                  String projectName, int buildNumber, String buildUrl, String resultIcon, String statusDescription) {
-        if (trigger.getAddNoteOnMergeRequest()) {
-            String message = MessageFormat.format("{0} Jenkins Build {1}\n\nResults available at: [Jenkins [{2} #{3}]]({4})", resultIcon,
-                    statusDescription, projectName, buildNumber, buildUrl);
-            try {
-                GitLabApi client = getClient(build);
-                if (client == null) {
-                    listener.getLogger().println("No GitLab connection configured");
-                } else {
-                    client.createMergeRequestNote(projectId, mergeRequestId, message);
-                }
-            } catch (WebApplicationException e) {
-                listener.getLogger().println("Failed to add message to merge request.");
-            }
-        }
-    }
-
-    private String getResultIcon(GitLabPushTrigger trigger, Result result) {
-        if (result == Result.SUCCESS) {
-            return trigger.getAddVoteOnMergeRequest() ? ":+1:" : ":white_check_mark:";
-        } else {
-            return trigger.getAddVoteOnMergeRequest() ? ":-1:" : ":anguished:";
-        }
-    }
-
     private GitLabApi getClient(Run<?, ?> run) {
         GitLabConnectionProperty connectionProperty = run.getParent().getProperty(GitLabConnectionProperty.class);
         if (connectionProperty != null) {
@@ -92,5 +56,4 @@ public class GitLabMergeRequestRunListener extends RunListener<Run<?, ?>> {
         }
         return null;
     }
-
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisher.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisher.java
@@ -1,0 +1,204 @@
+package com.dabsquared.gitlabjenkins.publisher;
+
+import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
+import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
+import com.dabsquared.gitlabjenkins.gitlab.api.GitLabApi;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.*;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Notifier;
+import hudson.tasks.Publisher;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.WebApplicationException;
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Nikolay Ustinov
+ */
+public class GitLabMessagePublisher extends Notifier {
+    private static final Logger LOGGER = Logger.getLogger(GitLabMessagePublisher.class.getName());
+    private boolean replaceSuccessNote = false;
+    private boolean replaceFailureNote = false;
+    private boolean replaceAbortNote = false;
+    private String successNoteText;
+    private String failureNoteText;
+    private String abortNoteText;
+
+    @DataBoundConstructor
+    public GitLabMessagePublisher(boolean replaceSuccessNote, boolean replaceFailureNote, boolean replaceAbortNote,
+                                  String successNoteText, String failureNoteText, String abortNoteText) {
+        this.replaceSuccessNote = replaceSuccessNote;
+        this.replaceFailureNote = replaceFailureNote;
+        this.replaceAbortNote = replaceAbortNote;
+        this.successNoteText = successNoteText;
+        this.failureNoteText = failureNoteText;
+        this.abortNoteText = abortNoteText;
+    }
+
+    public boolean getReplaceSuccessNote() {
+        return replaceSuccessNote;
+    }
+
+    public boolean getReplaceFailureNote() {
+        return replaceFailureNote;
+    }
+
+    public boolean getReplaceAbortNote() {
+        return replaceAbortNote;
+    }
+
+    public String getSuccessNoteText() {
+        return this.successNoteText == null ? "" : this.successNoteText;
+    }
+
+    public String getFailureNoteText() {
+        return this.failureNoteText == null ? "" : this.failureNoteText;
+    }
+
+    public String getAbortNoteText() {
+        return this.abortNoteText == null ? "" : this.abortNoteText;
+    }
+
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.BUILD;
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        addNoteOnMergeRequest(build, listener);
+        return true;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.GitLabMessagePublisher_DisplayName();
+        }
+
+        @Override
+        public String getHelpFile() {
+            return "/plugin/gitlab-plugin/help/help-messagesOnResult.html";
+        }
+    }
+
+    private void addNoteOnMergeRequest(Run<?, ?> build, TaskListener listener) {
+        String projectId = getProjectId(build);
+        Integer mergeRequestId = getMergeRequestId(build);
+        if (projectId != null && mergeRequestId != null) {
+            try {
+                GitLabApi client = getClient(build);
+                if (client == null) {
+                    LOGGER.log(Level.WARNING, "No GitLab connection configured");
+                } else if (existsMergeRequest(client, projectId, mergeRequestId)) {
+                    client.createMergeRequestNote(projectId, mergeRequestId, getNote(build, listener));
+                }
+            } catch (WebApplicationException e) {
+                LOGGER.log(Level.SEVERE, String.format("Failed to update Gitlab commit status for project '%s'", projectId), e);
+            }
+        }
+    }
+
+    private static boolean existsMergeRequest(GitLabApi client, String projectId, Integer mergeRequestId) {
+        try {
+            client.getMergeRequest(projectId, mergeRequestId);
+            return true;
+        } catch (NotFoundException e) {
+            LOGGER.log(Level.FINE, String.format("Project (%s) and merge request (%s) combination not found", projectId, mergeRequestId));
+            return false;
+        }
+    }
+
+    public String getProjectId(Run<?, ?> build) {
+        GitLabWebHookCause cause = build.getCause(GitLabWebHookCause.class);
+        return cause == null ? null : cause.getData().getProjectId().toString();
+    }
+
+    public Integer getMergeRequestId(Run<?, ?> build) {
+        GitLabWebHookCause cause = build.getCause(GitLabWebHookCause.class);
+        return cause == null ? null : cause.getData().getMergeRequestId();
+    }
+
+    private String getResultIcon(Result result) {
+        if (result == Result.SUCCESS) {
+            return ":+1:";
+        } else if (result == Result.ABORTED) {
+            return ":point_up:";
+        } else {
+            return ":-1:";
+        }
+    }
+
+    private static GitLabApi getClient(Run<?, ?> build) {
+        GitLabConnectionProperty connectionProperty = build.getParent().getProperty(GitLabConnectionProperty.class);
+        if (connectionProperty != null) {
+            return connectionProperty.getClient();
+        }
+        return null;
+    }
+
+    public static String replaceMacros(Run<?, ?> build, TaskListener listener, String inputString) {
+        String returnString = inputString;
+        if (build != null && inputString != null) {
+            try {
+                Map<String, String> messageEnvVars = getEnvVars(build, listener);
+                returnString = Util.replaceMacro(inputString, messageEnvVars);
+
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Couldn't replace macros in message: ", e);
+            }
+        }
+        return returnString;
+    }
+
+    public static Map<String, String> getEnvVars(Run<?, ?> build, TaskListener listener) {
+        Map<String, String> messageEnvVars = new HashMap<String, String>();
+        if (build != null) {
+            messageEnvVars.putAll(build.getCharacteristicEnvVars());
+            try {
+                messageEnvVars.putAll(build.getEnvironment(listener));
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Couldn't get Env Variables: ", e);
+            }
+        }
+        return messageEnvVars;
+    }
+
+    public String getNote(Run<?, ?> build, TaskListener listener) {
+        String message_part;
+        StringBuilder msg = new StringBuilder();
+        String icon = getResultIcon(build.getResult());
+        String buildUrl = Jenkins.getInstance().getRootUrl() + build.getUrl();
+        String defaultNote = MessageFormat.format("{0} Jenkins Build {1}\n\nResults available at: [Jenkins [{2} #{3}]]({4})",
+            icon, build.getResult().toString(), build.getParent().getDisplayName(), build.getNumber(), buildUrl);
+
+        if (this.getReplaceSuccessNote() && build.getResult() == Result.SUCCESS) {
+            message_part = replaceMacros(build, listener, this.getSuccessNoteText());
+        } else if (this.getReplaceAbortNote() && build.getResult() == Result.ABORTED) {
+            message_part = replaceMacros(build, listener, this.getAbortNoteText());
+        } else if (this.getReplaceFailureNote() && build.getResult() == Result.FAILURE) {
+            message_part = replaceMacros(build, listener, this.getFailureNoteText());
+        } else {
+            message_part = defaultNote;
+        }
+        msg.append(message_part);
+        return msg.toString();
+    }
+}

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -17,9 +17,6 @@
   <f:entry title="Set build description to build cause (eg. Merge request or Git Push )" field="setBuildDescription">
     <f:checkbox default="true"/>
   </f:entry>
-  <f:entry title="Add note with build status on merge requests" field="addNoteOnMergeRequest">
-    <f:checkbox default="true"/>
-  </f:entry>
   <f:entry title="Vote added to note with build status on merge requests" field="addVoteOnMergeRequest">
     <f:checkbox default="true"/>
   </f:entry>

--- a/src/main/resources/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisher/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisher/config.jelly
@@ -1,0 +1,21 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
+  <f:block>
+    <f:optionalBlock name="replaceSuccessNote" checked="${instance.replaceSuccessNote}" title="Custom message on success" inline="true">
+      <f:entry>
+        <f:textarea name="successNoteText" field="successNoteText"/>
+      </f:entry>
+    </f:optionalBlock>
+    <f:optionalBlock name="replaceFailureNote" checked="${instance.replaceFailureNote}" title="Custom message on failure" inline="true">
+      <f:entry>
+        <f:textarea name="failureNoteText" field="failureNoteText"/>
+      </f:entry>
+    </f:optionalBlock>
+    <f:optionalBlock name="replaceAbortNote" checked="${instance.replaceAbortNote}" title="Custom message on abort" inline="true">
+      <f:entry>
+        <f:textarea name="abortNoteText" field="abortNoteText"/>
+      </f:entry>
+    </f:optionalBlock>
+  </f:block>
+</j:jelly>

--- a/src/main/resources/com/dabsquared/gitlabjenkins/publisher/Messages.properties
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/publisher/Messages.properties
@@ -1,1 +1,2 @@
 GitLabCommitStatusPublisher.DisplayName=Publish build status to GitLab commit (GitLab 8.1+ required)
+GitLabMessagePublisher.DisplayName=Add note with build status on merge requests

--- a/src/main/webapp/help/help-messagesOnResult.html
+++ b/src/main/webapp/help/help-messagesOnResult.html
@@ -1,0 +1,4 @@
+<div>
+  <p>Enable sending message to GitLab Merge Request.</p>
+  <p>You can change default message on success, failure and abort. (with support environment variables)</p>
+</div>

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisherTest.java
@@ -1,0 +1,267 @@
+package com.dabsquared.gitlabjenkins.publisher;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.dabsquared.gitlabjenkins.connection.GitLabConnection;
+import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
+import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
+import hudson.EnvVars;
+import hudson.model.*;
+import hudson.plugins.git.util.BuildData;
+import hudson.util.Secret;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.mockserver.client.server.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.HttpRequest;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+/**
+ * @author Nikolay Ustinov
+ */
+public class GitLabMessagePublisherTest {
+
+    private static final String GIT_LAB_CONNECTION = "GitLab";
+    private static final String API_TOKEN = "secret";
+
+    @Rule
+    public MockServerRule mockServer = new MockServerRule(this);
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    private MockServerClient mockServerClient;
+    private BuildListener listener;
+
+    @Before
+    public void setup() throws IOException {
+        listener = new StreamBuildListener(jenkins.createTaskListener().getLogger(), Charset.defaultCharset());
+        GitLabConnectionConfig connectionConfig = jenkins.get(GitLabConnectionConfig.class);
+        String apiTokenId = "apiTokenId";
+        for (CredentialsStore credentialsStore : CredentialsProvider.lookupStores(Jenkins.getInstance())) {
+            if (credentialsStore instanceof SystemCredentialsProvider.StoreImpl) {
+                List<Domain> domains = credentialsStore.getDomains();
+                credentialsStore.addCredentials(domains.get(0),
+                    new StringCredentialsImpl(CredentialsScope.SYSTEM, apiTokenId, "GitLab API Token", Secret.fromString(API_TOKEN)));
+            }
+        }
+        connectionConfig.addConnection(new GitLabConnection(GIT_LAB_CONNECTION, "http://localhost:" + mockServer.getPort() + "/gitlab", apiTokenId, false));
+    }
+
+    @After
+    public void cleanup() {
+        mockServerClient.reset();
+    }
+
+    @Test
+    public void canceled() throws IOException, InterruptedException {
+        Integer buildNumber = 1;
+        String projectId = "3";
+        Integer mergeRequestId = 1;
+        AbstractBuild build = mockBuild("/build/123", GIT_LAB_CONNECTION, Result.ABORTED, buildNumber, projectId);
+        String buildUrl = Jenkins.getInstance().getRootUrl() + build.getUrl();
+        String defaultNote = MessageFormat.format(":point_up: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})",
+            Result.ABORTED, build.getParent().getDisplayName(), buildNumber, buildUrl);
+
+        HttpRequest[] requests = new HttpRequest[] {
+            prepareExistMergeRequestWithSuccessResponse(projectId, mergeRequestId.toString()),
+            prepareSendMessageWithSuccessResponse(projectId, mergeRequestId.toString(), defaultNote)
+        };
+
+        GitLabMessagePublisher publisher = spy(new GitLabMessagePublisher(false, false, false, null, null, null));
+        doReturn(projectId).when(publisher).getProjectId(build);
+        doReturn(mergeRequestId).when(publisher).getMergeRequestId(build);
+        publisher.perform(build, null, listener);
+
+        mockServerClient.verify(requests);
+    }
+
+    @Test
+    public void success() throws IOException, InterruptedException {
+        Integer buildNumber = 1;
+        String projectId = "3";
+        Integer mergeRequestId = 1;
+        AbstractBuild build = mockBuild("/build/123", GIT_LAB_CONNECTION, Result.SUCCESS, buildNumber, projectId);
+        String buildUrl = Jenkins.getInstance().getRootUrl() + build.getUrl();
+        String defaultNote = MessageFormat.format(":+1: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})",
+            Result.SUCCESS, build.getParent().getDisplayName(), buildNumber, buildUrl);
+
+        HttpRequest[] requests = new HttpRequest[] {
+            prepareExistMergeRequestWithSuccessResponse(projectId, mergeRequestId.toString()),
+            prepareSendMessageWithSuccessResponse(projectId, mergeRequestId.toString(), defaultNote)
+        };
+
+        GitLabMessagePublisher publisher = spy(new GitLabMessagePublisher(false, false, false, null, null, null));
+        doReturn(projectId).when(publisher).getProjectId(build);
+        doReturn(mergeRequestId).when(publisher).getMergeRequestId(build);
+        publisher.perform(build, null, listener);
+
+        mockServerClient.verify(requests);
+    }
+
+    @Test
+    public void failed() throws IOException, InterruptedException {
+        Integer buildNumber = 1;
+        String projectId = "3";
+        Integer mergeRequestId = 1;
+        AbstractBuild build = mockBuild("/build/123", GIT_LAB_CONNECTION, Result.FAILURE, buildNumber, projectId);
+        String buildUrl = Jenkins.getInstance().getRootUrl() + build.getUrl();
+        String defaultNote = MessageFormat.format(":-1: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})",
+            Result.FAILURE, build.getParent().getDisplayName(), buildNumber, buildUrl);
+
+        HttpRequest[] requests = new HttpRequest[] {
+            prepareExistMergeRequestWithSuccessResponse(projectId, mergeRequestId.toString()),
+            prepareSendMessageWithSuccessResponse(projectId, mergeRequestId.toString(), defaultNote)
+        };
+
+        GitLabMessagePublisher publisher = spy(new GitLabMessagePublisher(false, false, false, null, null, null));
+        doReturn(projectId).when(publisher).getProjectId(build);
+        doReturn(mergeRequestId).when(publisher).getMergeRequestId(build);
+        publisher.perform(build, null, listener);
+
+        mockServerClient.verify(requests);
+    }
+
+    @Test
+    public void canceledWithCustomNote() throws IOException, InterruptedException {
+        Integer buildNumber = 1;
+        String projectId = "3";
+        Integer mergeRequestId = 1;
+        AbstractBuild build = mockBuild("/build/123", GIT_LAB_CONNECTION, Result.ABORTED, buildNumber, projectId);
+        String defaultNote = "abort";
+
+        HttpRequest[] requests = new HttpRequest[] {
+            prepareExistMergeRequestWithSuccessResponse(projectId, mergeRequestId.toString()),
+            prepareSendMessageWithSuccessResponse(projectId, mergeRequestId.toString(), defaultNote)
+        };
+
+        GitLabMessagePublisher publisher = spy(new GitLabMessagePublisher(false, false, true, null, null, defaultNote));
+        doReturn(projectId).when(publisher).getProjectId(build);
+        doReturn(mergeRequestId).when(publisher).getMergeRequestId(build);
+        publisher.perform(build, null, listener);
+
+        mockServerClient.verify(requests);
+    }
+
+    @Test
+    public void successWithCustomNote() throws IOException, InterruptedException {
+        Integer buildNumber = 1;
+        String projectId = "3";
+        Integer mergeRequestId = 1;
+        AbstractBuild build = mockBuild("/build/123", GIT_LAB_CONNECTION, Result.SUCCESS, buildNumber, projectId);
+        String defaultNote = "success";
+
+        HttpRequest[] requests = new HttpRequest[] {
+            prepareExistMergeRequestWithSuccessResponse(projectId, mergeRequestId.toString()),
+            prepareSendMessageWithSuccessResponse(projectId, mergeRequestId.toString(), defaultNote)
+        };
+
+        GitLabMessagePublisher publisher = spy(new GitLabMessagePublisher(true, false, false, defaultNote, null, null));
+        doReturn(projectId).when(publisher).getProjectId(build);
+        doReturn(mergeRequestId).when(publisher).getMergeRequestId(build);
+        publisher.perform(build, null, listener);
+
+        mockServerClient.verify(requests);
+    }
+
+    @Test
+    public void failedWithCustomNote() throws IOException, InterruptedException {
+        Integer buildNumber = 1;
+        String projectId = "3";
+        Integer mergeRequestId = 1;
+        AbstractBuild build = mockBuild("/build/123", GIT_LAB_CONNECTION, Result.FAILURE, buildNumber, projectId);
+        String defaultNote = "failure";
+
+        HttpRequest[] requests = new HttpRequest[] {
+            prepareExistMergeRequestWithSuccessResponse(projectId, mergeRequestId.toString()),
+            prepareSendMessageWithSuccessResponse(projectId, mergeRequestId.toString(), defaultNote)
+        };
+
+        GitLabMessagePublisher publisher = spy(new GitLabMessagePublisher(false, true, false, null, defaultNote, null));
+        doReturn(projectId).when(publisher).getProjectId(build);
+        doReturn(mergeRequestId).when(publisher).getMergeRequestId(build);
+        publisher.perform(build, null, listener);
+
+        mockServerClient.verify(requests);
+    }
+
+    private HttpRequest prepareSendMessageWithSuccessResponse(String projectId, String mergeRequestId, String body) throws UnsupportedEncodingException {
+        HttpRequest updateCommitStatus = prepareSendMessageStatus(projectId, mergeRequestId, body);
+        mockServerClient.when(updateCommitStatus).respond(response().withStatusCode(200));
+        return updateCommitStatus;
+    }
+
+    private HttpRequest prepareSendMessageStatus(String projectId, String mergeRequestId, String body) throws UnsupportedEncodingException {
+        return request()
+                .withPath("/gitlab/api/v3/projects/" + URLEncoder.encode(projectId, "UTF-8") + "/merge_requests/" + URLEncoder.encode(mergeRequestId, "UTF-8") + "/notes")
+                .withMethod("POST")
+                .withHeader("PRIVATE-TOKEN", "secret")
+                .withQueryStringParameter("body", body);
+    }
+
+    private HttpRequest prepareExistMergeRequestWithSuccessResponse(String projectId, String mergeRequestId) throws UnsupportedEncodingException {
+        HttpRequest existsMergeRequest = prepareExistsMergeRequest(projectId, mergeRequestId);
+        mockServerClient.when(existsMergeRequest).respond(response().withStatusCode(200));
+        return existsMergeRequest;
+    }
+
+    private HttpRequest prepareExistsMergeRequest(String projectId, String mergeRequestId) throws UnsupportedEncodingException {
+        return request()
+            .withPath("/gitlab/api/v3/projects/" + URLEncoder.encode(projectId, "UTF-8") + "/merge_requests/" + mergeRequestId)
+            .withMethod("GET")
+            .withHeader("PRIVATE-TOKEN", "secret");
+    }
+
+    private AbstractBuild mockBuild(String buildUrl, String gitLabConnection, Result result, Integer buildNumber, String... remoteUrls) {
+        AbstractBuild build = mock(AbstractBuild.class);
+        BuildData buildData = mock(BuildData.class);
+        when(buildData.getRemoteUrls()).thenReturn(new HashSet<>(Arrays.asList(remoteUrls)));
+        when(build.getAction(BuildData.class)).thenReturn(buildData);
+        when(build.getResult()).thenReturn(result);
+        when(build.getUrl()).thenReturn(buildUrl);
+        when(build.getResult()).thenReturn(result);
+        when(build.getUrl()).thenReturn(buildUrl);
+        when(build.getNumber()).thenReturn(buildNumber);
+
+        AbstractProject<?, ?> project = mock(AbstractProject.class);
+        when(project.getProperty(GitLabConnectionProperty.class)).thenReturn(new GitLabConnectionProperty(gitLabConnection));
+        when(build.getProject()).thenReturn(project);
+        EnvVars environment = mock(EnvVars.class);
+        when(environment.expand(anyString())).thenAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                return (String) invocation.getArguments()[0];
+            }
+        });
+        try {
+            when(build.getEnvironment(any(TaskListener.class))).thenReturn(environment);
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return build;
+    }
+}


### PR DESCRIPTION
1. Sending message on result of a build as Post-build action.
2. You can set custom notes for success, failure and/or abort.
3. Jenkins environment variables interpolation is working in custom notes.
