### PR TITLE
Allow build to be triggered when pushing to an Open MR

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -182,7 +182,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
     private boolean isBranchAllowed(final String branchName) {
 
         final String branchFilterName = this.getBranchFilterName();
-        if (branchFilterName.isEmpty()) {
+        if (StringUtils.isEmpty(branchFilterName)) {
             // no filter is applied, allow all branches
             return true;
         }

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -461,10 +461,6 @@ public class GitLabWebHook implements UnprotectedRootAction {
             LOGGER.log(Level.INFO, "Accepted Merge Request, no build started");
             return;
         }
-        if("update".equals(request.getObjectAttribute().getAction())) {
-            LOGGER.log(Level.INFO, "Existing Merge Request, build will be trigged by buildOpenMergeRequests instead");
-            return;
-        }
         if(request.getObjectAttribute().getLastCommit()!=null) {
             Run mergeBuild = getBuildBySHA1(project, request.getObjectAttribute().getLastCommit().getId(), true);
             if (mergeBuild != null) {


### PR DESCRIPTION
The function generateMergeRequestBuild return when it should not be if the state
equals to "update". I removed the check to allow the build to be triggered.

I also used StringUtils.isEmpty to perform a check in GitLabWebHook to avoid a NPE.
