### PR TITLE
Add description to parameters actions

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -282,6 +282,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         values.put("gitlabUserEmail", new StringParameterValue("gitlabUserEmail", req.getCommits().get(0).getAuthor().getEmail()));
         values.put("gitlabMergeRequestTitle", new StringParameterValue("gitlabMergeRequestTitle", ""));
         values.put("gitlabMergeRequestId", new StringParameterValue("gitlabMergeRequestId", ""));
+        values.put("gitlabMergeRequestDescription", new StringParameterValue("gitlabMergeRequestDescription", ""));
         values.put("gitlabMergeRequestAssignee", new StringParameterValue("gitlabMergeRequestAssignee", ""));
 
         LOGGER.log(Level.INFO, "Trying to get name and URL for job: {0}", job.getFullName());
@@ -408,6 +409,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         }
         values.put("gitlabMergeRequestTitle", new StringParameterValue("gitlabMergeRequestTitle",  req.getObjectAttribute().getTitle()));
         values.put("gitlabMergeRequestId", new StringParameterValue("gitlabMergeRequestId", req.getObjectAttribute().getIid().toString()));
+        values.put("gitlabMergeRequestDescription", new StringParameterValue("gitlabMergeRequestDescription", req.getObjectAttribute().getDescription()));
         if (req.getObjectAttribute().getAssignee() != null) {
             values.put("gitlabMergeRequestAssignee", new StringParameterValue("gitlabMergeRequestAssignee", req.getObjectAttribute().getAssignee().getName()));
         }


### PR DESCRIPTION
With #211 some values were added but the description of the merge request is missing.

The description is present in the datamodel, just add it to parameters actions.
