### PR TITLE
mention required permissions for commit status API

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If you plan to use forked repositories, you will need to enable the GitLab CI in
 ### GitLab Configuration (>= 8.1)
 GitLab 8.1 uses the same configuration as GitLab 8.0
 * GitLab 8.1 has implemented a commit status api. To enable this check the ``Use GitLab CI features`` under the project settings.
-* Configure access to GitLab as described above in "Configure access to GitLab"
+* Configure access to GitLab as described above in "Configure access to GitLab" (the account needs at least developer permissions to post commit statuses)
 
 ### Forked repositories
 If you plan to use forked repositories, you will need to enable the GitLab CI integration on **each fork**.


### PR DESCRIPTION
Since gitlab 8.5 the reporter permissions are no longer sufficient to post commit statuses.
https://gitlab.com/gitlab-org/gitlab-ce/commit/055afab5c7d33d061d339c270bd258ed847450f3#2d52ce552f2d21beb86ec07b784cb47791f894cc_161_172
