### PR TITLE
When branches are not allowed in a MR build, log it.

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -383,14 +383,11 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 	        }
 
 	        scheduledJob.scheduleBuild2(projectbuildDelay, action, new CauseAction(cause));
-    	} else {
-            
-            if (triggerOnMergeRequest ) {
-	            LOGGER.log(Level.INFO, "trigger on merge request not set");
-            } else if ( this.isBranchAllowed(req.getObjectAttribute().getTargetBranch())) {
-                LOGGER.log(Level.INFO, "branch {0} is not allowed", req.getObjectAttribute().getTargetBranch());
-            }
 
+        } else if ( ! triggerOnMergeRequest ) {
+	        LOGGER.log(Level.INFO, "trigger on merge request not set");
+        } else {
+            LOGGER.log(Level.INFO, "branch {0} is not allowed", req.getObjectAttribute().getTargetBranch());
 	    }
     }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -384,7 +384,13 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 
 	        scheduledJob.scheduleBuild2(projectbuildDelay, action, new CauseAction(cause));
     	} else {
-	        LOGGER.log(Level.INFO, "trigger on merge request not set");
+            
+            if (triggerOnMergeRequest ) {
+	            LOGGER.log(Level.INFO, "trigger on merge request not set");
+            } else if ( this.isBranchAllowed(req.getObjectAttribute().getTargetBranch())) {
+                LOGGER.log(Level.INFO, "branch {0} is not allowed", req.getObjectAttribute().getTargetBranch());
+            }
+
 	    }
     }
 


### PR DESCRIPTION
The message "trigger on merge request not set" was not entirely accurate for times when triggerOnMergeRequest WAS set, but the branch was not allowed. Now we have two separate log messages, one for either case.
