### PR TITLE
Add setters for all parameters of the Gitlab system config to the trigger descriptor

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -938,12 +938,24 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
             return gitlabApiToken;
         }
 
+        public void setGitlabApiToken(String gitlabApiToken) {
+            this.gitlabApiToken = gitlabApiToken;
+        }
+
         public String getGitlabHostUrl() {
             return gitlabHostUrl;
         }
 
+        public void setGitlabHostUrl(String gitlabHostUrl) {
+            this.gitlabHostUrl = gitlabHostUrl;
+        }
+
         public boolean getIgnoreCertificateErrors() {
         	return ignoreCertificateErrors;
+        }
+
+        public void setIgnoreCertificateErrors(boolean ignoreCertificateErrors) {
+            this.ignoreCertificateErrors = ignoreCertificateErrors;
         }
 
         public static DescriptorImpl get() {


### PR DESCRIPTION
This makes it possible to change the Gitlab system config (host url, api token and ignore ssl errors) via a Groovy-script, e.g.:

init.groovy:

```
import jenkins.model.*

def jenkins = Jenkins.getInstance()
...

def gitlab = jenkins.getDescriptor("com.dabsquared.gitlabjenkins.GitLabPushTrigger")
gitlab.setGitlabHostUrl("https://url-to-gitlab")
gitlab.setGitlabApiToken("some-gitlab-token")
gitlab.setIgnoreCertificateErrors(true)
gitlab.save()
```
