### PR TITLE
Plugin modes for better MR handling.

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeRequest.java
@@ -35,10 +35,14 @@ public class GitLabMergeRequest extends GitLabRequest {
     private GitlabProject sourceProject = null;
     
     public GitlabProject getSourceProject (GitLab api) throws IOException {
-    	if (sourceProject == null) {
-    		sourceProject = api.instance().getProject(objectAttributes.getSourceProjectId());
-    	}
-    	return sourceProject;
+        return getSourceProject(api.instance());
+    }
+    
+    private GitlabProject getSourceProject(GitlabAPI api) throws IOException {
+        if (sourceProject == null) {
+            sourceProject = api.getProject(objectAttributes.getSourceProjectId());
+        }
+        return sourceProject;
     }
 
     public String getObject_kind() {
@@ -66,7 +70,7 @@ public class GitLabMergeRequest extends GitLabRequest {
     public GitlabCommitStatus createCommitStatus(GitlabAPI api, String status, String targetUrl) {
         try {
             if (objectAttributes.getLastCommit() != null) {
-                return api.createCommitStatus(sourceProject, objectAttributes.getLastCommit().getId(), status, objectAttributes.getSourceBranch(), "Jenkins", targetUrl, null);
+                return api.createCommitStatus(getSourceProject(api), objectAttributes.getLastCommit().getId(), status, objectAttributes.getSourceBranch(), "Jenkins", targetUrl, null);
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPluginMode.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPluginMode.java
@@ -1,0 +1,34 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.dabsquared.gitlabjenkins;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ *
+ * @author Pablo Bendersky
+ */
+public enum GitLabPluginMode {
+    LEGACY(GitLabPluginStrategyLegacy.class),
+    MODERN(GitLabPluginStrategyModern.class);
+    
+    private final Class<? extends GitLabPluginStrategy> pushTriggerStrategyClass;
+    
+    GitLabPluginMode(Class<? extends GitLabPluginStrategy> pushTriggerStrategyClass) {
+        this.pushTriggerStrategyClass = pushTriggerStrategyClass;
+    }
+    
+    public GitLabPluginStrategy getGitLabPluginStrategy() {
+        try {
+            return this.pushTriggerStrategyClass.newInstance();
+        } catch (InstantiationException | IllegalAccessException ex) {
+            Logger.getLogger(GitLabPluginMode.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        
+        return null;
+    }
+}

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPluginStrategy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPluginStrategy.java
@@ -1,0 +1,68 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.dabsquared.gitlabjenkins;
+
+import hudson.model.Action;
+import hudson.model.Job;
+import hudson.model.Run;
+
+/**
+ *
+ * @author Pablo Bendersky
+ */
+public interface GitLabPluginStrategy {
+    
+    /**
+     * Creates the Actions for the Push Request trigger.
+     * @param pushTrigger The GitLabPushTrigger instance that is using this strategy.
+     * @param req The Push Request, as received from GitLab
+     * @param job The Jenkins Job
+     * @return An Array of Actions to be used in the Jenkins Job.
+     */
+    Action[] createActions(GitLabPushTrigger pushTrigger, GitLabPushRequest req, Job job);
+
+    /**
+     * Creates the Action for the Merge Request trigger
+     * @param pushTrigger The GitLabPushTrigger instance that is using this strategy.
+     * @param req The Merge Request, as received from GitLab
+     * @param job The Jenkins Job
+     * @return A single action, to be used in Jenkins Job.
+     */
+    Action createAction(GitLabPushTrigger pushTrigger, GitLabMergeRequest req, Job job);
+    
+    /**
+     * Runs after the web hook for push events has completed. Different strategies may either
+     * ignore this method, or look up old builds to merge.
+     * @param webHook Originating Web Hook
+     * @param trigger Push Trigger instance
+     * @param projectId The Project ID
+     * @param projectRef The Project Ref
+     */
+    void buildOpenMergeRequestTriggeredByPush(GitLabWebHook webHook, GitLabPushTrigger trigger, Integer projectId, String projectRef);
+
+    /**
+     * Returns true if, in the current strategy, we need to skip a build for a Merge Request with a given state.
+     * @param trigger Trigger instance, in case the strategy needs to inspect its settings.
+     * @param state GitLab state of the Merge Request hook
+     * @return true if we need to trigger a build for this state.
+     */
+    boolean shouldSkipMergeRequestBuild(GitLabPushTrigger trigger, String state);
+
+    /**
+     * Returns true if the found Merge Build has already been built. Depending on the strategy, this can be implemented in different ways.
+     * @param request GitLabMergeRequest instance that triggered this build.
+     * @param mergeBuild Found Merge Build for the commit.
+     * @return true if the mergeBuild passed as parameter has already been built.
+     */
+    boolean isMergeBuildAlreadyBuilt(GitLabMergeRequest request, Run mergeBuild);
+
+    /**
+     * Returns true if this strategy skips existing builds through matching by SHA1.
+     * @return true if this strategy skips existing builds through matching by SHA1, false otherwise.
+     */
+    boolean skipsExistingPushBuildsMatchingBySHA1();
+    
+}

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPluginStrategyLegacy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPluginStrategyLegacy.java
@@ -1,0 +1,243 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.dabsquared.gitlabjenkins;
+
+import static com.dabsquared.gitlabjenkins.GitLabPushTrigger.getDesc;
+import com.dabsquared.gitlabjenkins.data.LastCommit;
+import com.dabsquared.gitlabjenkins.data.ObjectAttributes;
+import hudson.model.Action;
+import hudson.model.CauseAction;
+import hudson.model.Job;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Run;
+import hudson.model.StringParameterValue;
+import hudson.plugins.git.RevisionParameterAction;
+import hudson.security.ACL;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.acegisecurity.Authentication;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.gitlab.api.models.GitlabBranch;
+import org.gitlab.api.models.GitlabCommit;
+import org.gitlab.api.models.GitlabMergeRequest;
+import org.gitlab.api.models.GitlabProject;
+
+/**
+ *
+ * @author Pablo Bendersky
+ */
+public class GitLabPluginStrategyLegacy implements GitLabPluginStrategy {
+
+    private static final Logger LOGGER = Logger.getLogger(GitLabPluginStrategyLegacy.class.getName());
+
+    @Override
+    public Action[] createActions(GitLabPushTrigger pushTrigger, GitLabPushRequest req, Job job) {
+        ArrayList<Action> actions = new ArrayList<Action>();
+        actions.add(new CauseAction(pushTrigger.createGitLabPushCause(req)));
+
+        String branch = pushTrigger.getSourceBranch(req);
+
+        LOGGER.log(Level.INFO, "GitLab Push Request from branch {0}.", branch);
+
+        Map<String, ParameterValue> values = pushTrigger.getDefaultParameters();
+        values.put("gitlabSourceBranch", new StringParameterValue("gitlabSourceBranch", branch));
+        values.put("gitlabTargetBranch", new StringParameterValue("gitlabTargetBranch", branch));
+        values.put("gitlabBranch", new StringParameterValue("gitlabBranch", branch));
+
+        values.put("gitlabActionType", new StringParameterValue("gitlabActionType", "PUSH"));
+        values.put("gitlabUserName", new StringParameterValue("gitlabUserName", req.getCommits().get(0).getAuthor().getName()));
+        values.put("gitlabUserEmail", new StringParameterValue("gitlabUserEmail", req.getCommits().get(0).getAuthor().getEmail()));
+        values.put("gitlabMergeRequestTitle", new StringParameterValue("gitlabMergeRequestTitle", ""));
+        values.put("gitlabMergeRequestId", new StringParameterValue("gitlabMergeRequestId", ""));
+        values.put("gitlabMergeRequestDescription", new StringParameterValue("gitlabMergeRequestDescription", ""));
+        values.put("gitlabMergeRequestAssignee", new StringParameterValue("gitlabMergeRequestAssignee", ""));
+
+        LOGGER.log(Level.INFO, "Trying to get name and URL for job: {0}", job.getFullName());
+        String sourceRepoName = getDesc().getSourceRepoNameDefault(job);
+        String sourceRepoURL = getDesc().getSourceRepoURLDefault(job).toString();
+
+        if (!pushTrigger.getDescriptor().getGitlabHostUrl().isEmpty()) {
+            // Get source repository if communication to Gitlab is possible
+            try {
+                sourceRepoName = req.getSourceProject(getDesc().getGitlab()).getPathWithNamespace();
+                sourceRepoURL = req.getSourceProject(getDesc().getGitlab()).getSshUrl();
+            } catch (IOException ex) {
+                LOGGER.log(Level.WARNING, "Could not fetch source project''s data from Gitlab. '('{0}':' {1}')'", new String[]{ex.toString(), ex.getMessage()});
+            }
+        }
+
+        values.put("gitlabSourceRepoName", new StringParameterValue("gitlabSourceRepoName", sourceRepoName));
+        values.put("gitlabSourceRepoURL", new StringParameterValue("gitlabSourceRepoURL", sourceRepoURL));
+
+        List<ParameterValue> listValues = new ArrayList<ParameterValue>(values.values());
+
+        ParametersAction parametersAction = new ParametersAction(listValues);
+        actions.add(parametersAction);
+        RevisionParameterAction revision;
+
+        revision = pushTrigger.createPushRequestRevisionParameter(job, req);
+        if (revision == null) {
+            return null;
+        }
+
+        actions.add(revision);
+        Action[] actionsArray = actions.toArray(new Action[0]);
+
+        return actionsArray;
+    }
+
+    @Override
+    public Action createAction(GitLabPushTrigger pushTrigger, GitLabMergeRequest req, Job job) {
+        Map<String, ParameterValue> values = pushTrigger.getDefaultParameters();
+        values.put("gitlabSourceBranch", new StringParameterValue("gitlabSourceBranch", pushTrigger.getSourceBranch(req)));
+        values.put("gitlabTargetBranch", new StringParameterValue("gitlabTargetBranch", req.getObjectAttribute().getTargetBranch()));
+        values.put("gitlabActionType", new StringParameterValue("gitlabActionType", "MERGE"));
+        if (req.getObjectAttribute().getAuthor() != null) {
+            values.put("gitlabUserName", new StringParameterValue("gitlabUserName", req.getObjectAttribute().getAuthor().getName()));
+
+            String email = req.getObjectAttribute().getAuthor().getEmail();
+            if (email != null) {
+                values.put("gitlabUserEmail", new StringParameterValue("gitlabUserEmail", email));
+            }
+        }
+        values.put("gitlabMergeRequestTitle", new StringParameterValue("gitlabMergeRequestTitle", req.getObjectAttribute().getTitle()));
+        values.put("gitlabMergeRequestId", new StringParameterValue("gitlabMergeRequestId", req.getObjectAttribute().getIid().toString()));
+        values.put("gitlabMergeRequestDescription", new StringParameterValue("gitlabMergeRequestDescription", req.getObjectAttribute().getDescription()));
+        if (req.getObjectAttribute().getAssignee() != null) {
+            values.put("gitlabMergeRequestAssignee", new StringParameterValue("gitlabMergeRequestAssignee", req.getObjectAttribute().getAssignee().getName()));
+        }
+
+        LOGGER.log(Level.INFO, "Trying to get name and URL for job: {0}", job.getFullName());
+        String sourceRepoName = getDesc().getSourceRepoNameDefault(job);
+        String sourceRepoURL = getDesc().getSourceRepoURLDefault(job).toString();
+
+        if (!pushTrigger.getDescriptor().getGitlabHostUrl().isEmpty()) {
+            // Get source repository if communication to Gitlab is possible
+            try {
+                sourceRepoName = req.getSourceProject(getDesc().getGitlab()).getPathWithNamespace();
+                sourceRepoURL = req.getSourceProject(getDesc().getGitlab()).getSshUrl();
+            } catch (IOException ex) {
+                LOGGER.log(Level.WARNING, "Could not fetch source project''s data from Gitlab. '('{0}':' {1}')'", new String[]{ex.toString(), ex.getMessage()});
+            }
+        }
+
+        values.put("gitlabSourceRepoName", new StringParameterValue("gitlabSourceRepoName", sourceRepoName));
+        values.put("gitlabSourceRepoURL", new StringParameterValue("gitlabSourceRepoURL", sourceRepoURL));
+
+        List<ParameterValue> listValues = new ArrayList<ParameterValue>(values.values());
+
+        return new ParametersAction(listValues);
+    }
+
+    @Override
+    public void buildOpenMergeRequestTriggeredByPush(GitLabWebHook webHook, GitLabPushTrigger trigger, Integer projectId, String projectRef) {
+        try {
+            GitLab api = new GitLab();
+            List<GitlabMergeRequest> mergeRequests = api.instance().getOpenMergeRequests(projectId);
+
+            for (org.gitlab.api.models.GitlabMergeRequest mr : mergeRequests) {
+                if (projectRef.endsWith(mr.getSourceBranch())
+                        || (trigger.getTriggerOpenMergeRequestOnPush().equals("both") && projectRef.endsWith(mr.getTargetBranch()))) {
+
+                    if (trigger.getCiSkip() && mr.getDescription().contains("[ci-skip]")) {
+                        LOGGER.log(Level.INFO, "Skipping MR " + mr.getTitle() + " due to ci-skip.");
+                        continue;
+                    }
+
+                    Integer srcProjectId = projectId;
+                    if (!projectRef.endsWith(mr.getSourceBranch())) {
+                        srcProjectId = mr.getSourceProjectId();
+                    }
+
+                    GitlabBranch branch = api.instance().getBranch(api.instance().getProject(srcProjectId), mr.getSourceBranch());
+                    LastCommit lastCommit = new LastCommit();
+                    lastCommit.setId(branch.getCommit().getId());
+                    lastCommit.setMessage(branch.getCommit().getMessage());
+                    lastCommit.setUrl(GitlabProject.URL + "/" + srcProjectId + "/repository" + GitlabCommit.URL + "/"
+                            + branch.getCommit().getId());
+
+                    LOGGER.log(Level.FINE,
+                            "Generating new merge trigger from "
+                            + mr.toString() + "\n source: "
+                            + mr.getSourceBranch() + "\n target: "
+                            + mr.getTargetBranch() + "\n state: "
+                            + mr.getState() + "\n assign: "
+                            + (mr.getAssignee() != null ? mr.getAssignee().getName() : "") + "\n author: "
+                            + (mr.getAuthor() != null ? mr.getAuthor().getName() : "") + "\n id: "
+                            + mr.getId() + "\n iid: "
+                            + mr.getIid() + "\n last commit: "
+                            + lastCommit.getId() + "\n\n");
+                    GitLabMergeRequest newReq = new GitLabMergeRequest();
+                    newReq.setObject_kind("merge_request");
+                    newReq.setObjectAttribute(new ObjectAttributes());
+                    if (mr.getAssignee() != null) {
+                        newReq.getObjectAttribute().setAssignee(mr.getAssignee());
+                    }
+                    if (mr.getAuthor() != null) {
+                        newReq.getObjectAttribute().setAuthor(mr.getAuthor());
+                    }
+                    newReq.getObjectAttribute().setDescription(mr.getDescription());
+                    newReq.getObjectAttribute().setId(mr.getId());
+                    newReq.getObjectAttribute().setIid(mr.getIid());
+                    newReq.getObjectAttribute().setMergeStatus(mr.getState());
+                    newReq.getObjectAttribute().setSourceBranch(mr.getSourceBranch());
+                    newReq.getObjectAttribute().setSourceProjectId(mr.getSourceProjectId());
+                    newReq.getObjectAttribute().setTargetBranch(mr.getTargetBranch());
+                    newReq.getObjectAttribute().setTargetProjectId(projectId);
+                    newReq.getObjectAttribute().setTitle(mr.getTitle());
+                    newReq.getObjectAttribute().setLastCommit(lastCommit);
+
+                    Authentication old = SecurityContextHolder.getContext().getAuthentication();
+                    SecurityContextHolder.getContext().setAuthentication(ACL.SYSTEM);
+                    try {
+                        trigger.onPost(newReq);
+                    } finally {
+                        SecurityContextHolder.getContext().setAuthentication(old);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warning("failed to communicate with gitlab server to determine is this is an update for a merge request: "
+                    + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public boolean shouldSkipMergeRequestBuild(GitLabPushTrigger trigger, String state) {
+        String[] skipStates = {"closed", "merged", "update", "opened" };
+
+        return ArrayUtils.contains(skipStates, state);
+    }
+
+    @Override
+    public boolean isMergeBuildAlreadyBuilt(GitLabMergeRequest request, Run mergeBuild) {
+        StringParameterValue mergeBuildTargetBranch = (StringParameterValue) mergeBuild.getAction(ParametersAction.class).getParameter("gitlabTargetBranch");
+        boolean targetBranchesEqual = StringUtils.equals(mergeBuildTargetBranch.value, request.getObjectAttribute().getTargetBranch());
+        LOGGER.fine("Previous build's target-branch: " + mergeBuildTargetBranch.value
+                + ", current build's target-branch: "
+                + request.getObjectAttribute().getTargetBranch() + ", equals: "
+                + targetBranchesEqual);
+
+        if (targetBranchesEqual) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean skipsExistingPushBuildsMatchingBySHA1() {
+        return false;
+    }
+
+}

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPluginStrategyModern.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPluginStrategyModern.java
@@ -1,0 +1,90 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.dabsquared.gitlabjenkins;
+
+import static com.dabsquared.gitlabjenkins.GitLabPushTrigger.getDesc;
+import hudson.model.Action;
+import hudson.model.CauseAction;
+import hudson.model.Job;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Run;
+import hudson.model.StringParameterValue;
+import hudson.plugins.git.RevisionParameterAction;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.lang.ArrayUtils;
+
+/**
+ *
+ * @author Pablo Bendersky
+ */
+public class GitLabPluginStrategyModern implements GitLabPluginStrategy {
+    private static final Logger LOGGER = Logger.getLogger(GitLabPluginStrategyModern.class.getName());
+
+    @Override
+    public Action[] createActions(GitLabPushTrigger pushTrigger, GitLabPushRequest req, Job job) {
+        ArrayList<Action> actions = new ArrayList<Action>();
+	    actions.add(new CauseAction(pushTrigger.createGitLabPushCause(req)));
+
+        String branch = pushTrigger.getSourceBranch(req);
+
+        LOGGER.log(Level.INFO, "GitLab Push Request from branch {0}.", branch);
+        
+        RevisionParameterAction revision;
+        revision = pushTrigger.createPushRequestRevisionParameter(job, req);
+        if (revision == null) {
+            return null;
+        }
+
+        actions.add(revision);
+        Action[] actionsArray = actions.toArray(new Action[0]);
+
+        return actionsArray;    
+    }
+
+    @Override
+    public Action createAction(GitLabPushTrigger pushTrigger, GitLabMergeRequest req, Job job) {
+        RevisionParameterAction action;
+        action = new RevisionParameterAction(String.format("refs/remotes/origin/merge-requests/%s", req.getObjectAttribute().getIid()), getDesc().getSourceRepoURLDefault(job));
+        
+        return action;
+    }
+
+    @Override
+    public void buildOpenMergeRequestTriggeredByPush(GitLabWebHook webHook, GitLabPushTrigger trigger, Integer projectId, String projectRef) {
+        // Intentionally blank. In this strategy, merge requests are not handled _at all_ when the build was triggered by a push.
+    }
+
+    @Override
+    public boolean shouldSkipMergeRequestBuild(GitLabPushTrigger trigger, String state) {
+        String[] skipStates = { "closed", "merged" };
+        String[] openStates = { "opened", "update" };
+        
+        if (ArrayUtils.contains(skipStates, state)) {
+            return true;
+        } else if (ArrayUtils.contains(openStates, state) && "never".equals(trigger.getTriggerOpenMergeRequestOnPush())) {
+            return true;
+        }
+        
+        return false;
+    }
+
+    @Override
+    public boolean isMergeBuildAlreadyBuilt(GitLabMergeRequest request, Run mergeBuild) {
+        return true;
+    }
+
+    @Override
+    public boolean skipsExistingPushBuildsMatchingBySHA1() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushRequest.java
@@ -32,8 +32,12 @@ public class GitLabPushRequest extends GitLabRequest {
     private GitlabProject sourceProject = null;
 
     public GitlabProject getSourceProject (GitLab api) throws IOException {
+        return getSourceProject(api.instance());
+    }
+    
+    private GitlabProject getSourceProject (GitlabAPI api) throws IOException {
         if (sourceProject == null) {
-            sourceProject = api.instance().getProject(project_id);
+            sourceProject = api.getProject(project_id);
         }
         return sourceProject;
     }
@@ -41,7 +45,7 @@ public class GitLabPushRequest extends GitLabRequest {
     public GitlabCommitStatus createCommitStatus(GitlabAPI api, String status, String targetUrl) {
         try {
             if(getLastCommit()!=null) {
-                return api.createCommitStatus(sourceProject, checkout_sha, status, checkout_sha, "Jenkins", targetUrl, null);
+                return api.createCommitStatus(getSourceProject(api), checkout_sha, status, checkout_sha, "Jenkins", targetUrl, null);
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -1,13 +1,12 @@
 package com.dabsquared.gitlabjenkins;
 
-import com.dabsquared.gitlabjenkins.data.LastCommit;
-import com.dabsquared.gitlabjenkins.data.ObjectAttributes;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import hudson.Extension;
 import hudson.model.*;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.Revision;
 import hudson.plugins.git.util.Build;
 import hudson.plugins.git.util.BuildData;
 import hudson.plugins.git.util.MergeRecord;
@@ -25,12 +24,7 @@ import net.sf.json.JSONObject;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.lib.ObjectId;
-import org.gitlab.api.models.GitlabBranch;
-import org.gitlab.api.models.GitlabCommit;
-import org.gitlab.api.models.GitlabMergeRequest;
-import org.gitlab.api.models.GitlabProject;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -53,7 +47,6 @@ import java.util.logging.Logger;
  *
  * @author Daniel Brooks
  */
-
 @Extension
 public class GitLabWebHook implements UnprotectedRootAction {
 
@@ -76,7 +69,7 @@ public class GitLabWebHook implements UnprotectedRootAction {
     public void getDynamic(final String projectName, final StaplerRequest req, StaplerResponse res) {
         LOGGER.log(Level.INFO, "WebHook called with url: {0}", req.getRestOfPath());
         final Iterator<String> restOfPathParts = Splitter.on('/').omitEmptyStrings().split(req.getRestOfPath()).iterator();
-        final Job<?, ?>[] projectHolder = new Job<?, ?>[] { null };
+        final Job<?, ?>[] projectHolder = new Job<?, ?>[]{null};
         ACL.impersonate(ACL.SYSTEM, new Runnable() {
 
             public void run() {
@@ -112,11 +105,13 @@ public class GitLabWebHook implements UnprotectedRootAction {
         String sourceBranch = null;
         if (!paths.isEmpty() && paths.get(0).equals("refs")) {
             int index = paths.lastIndexOf("commits");
-            if (index == -1)
+            if (index == -1) {
                 index = paths.lastIndexOf("builds");
-            if (index == -1)
+            }
+            if (index == -1) {
                 index = paths.lastIndexOf("!builds");
-            
+            }
+
             if (index > 1) {
                 sourceBranch = Joiner.on('/').join(paths.subList(1, index)); // extract branch
                 paths.subList(0, index).clear(); // remove 'refs/<branchName>'
@@ -126,7 +121,6 @@ public class GitLabWebHook implements UnprotectedRootAction {
         String token = req.getParameter("token");
 
         //TODO: Check token authentication with project id. For now we are not using this.
-
         StringWriter writer = new StringWriter();
         try {
             IOUtils.copy(req.getInputStream(), writer, "UTF-8");
@@ -136,41 +130,41 @@ public class GitLabWebHook implements UnprotectedRootAction {
 
         String theString = writer.toString();
 
-        if(paths.size() == 0) {
-        	if (req.getParameter("ref") != null){
-        		// support /project/PROJECT_NAME?ref=BRANCH_NAME
-        		// link on project activity page - build status
-        		Run build = this.getBuildByBranch(project, req.getParameter("ref"));
-        		redirectToBuildPage(res, build);
-        	} else {
-        		this.generateBuild(theString, project, req, res);           
-        	}
-        	throw HttpResponses.ok();
+        if (paths.size() == 0) {
+            if (req.getParameter("ref") != null) {
+                // support /project/PROJECT_NAME?ref=BRANCH_NAME
+                // link on project activity page - build status
+                Run build = this.getBuildByBranch(project, req.getParameter("ref"));
+                redirectToBuildPage(res, build);
+            } else {
+                this.generateBuild(theString, project, req, res);
+            }
+            throw HttpResponses.ok();
         }
 
-        String lastPath = paths.get(paths.size()-1);
+        String lastPath = paths.get(paths.size() - 1);
         String firstPath = paths.get(0);
-        if(lastPath.equals("status.json") && !firstPath.equals("!builds")) {
+        if (lastPath.equals("status.json") && !firstPath.equals("!builds")) {
             String commitSHA1 = paths.get(1);
             this.generateStatusJSON(commitSHA1, project, req, res);
-        } else if(lastPath.equals("build") || (lastPath.equals("status.json") && firstPath.equals("!builds"))) {
+        } else if (lastPath.equals("build") || (lastPath.equals("status.json") && firstPath.equals("!builds"))) {
             this.generateBuild(theString, project, req, res);
-        } else if(lastPath.equals("status.png")) {
+        } else if (lastPath.equals("status.png")) {
             String branch = req.getParameter("ref");
             String commitSHA1 = req.getParameter("sha1");
             try {
                 this.generateStatusPNG(branch, commitSHA1, project, req, res);
             } catch (ServletException e) {
                 e.printStackTrace();
-                throw HttpResponses.error(500,"Could not generate an image.");
+                throw HttpResponses.error(500, "Could not generate an image.");
             } catch (IOException e) {
                 e.printStackTrace();
-                throw HttpResponses.error(500,"Could not generate an image.");
+                throw HttpResponses.error(500, "Could not generate an image.");
             }
-        } else if((firstPath.equals("commits") || firstPath.equals("builds")) && !lastPath.equals("status.json")) {
-            Run build = this.getBuildBySHA1(project, lastPath, true);
+        } else if ((firstPath.equals("commits") || firstPath.equals("builds")) && !lastPath.equals("status.json")) {
+            Run build = this.getBuildBySHA1(project, lastPath);
             redirectToBuildPage(res, build);
-        } else{
+        } else {
             LOGGER.warning("Dynamic request mot met: First path: '" + firstPath + "' late path: '" + lastPath + "'");
         }
 
@@ -178,24 +172,24 @@ public class GitLabWebHook implements UnprotectedRootAction {
 
     }
 
-	private void redirectToBuildPage(StaplerResponse res, Run build) {
-		if(build != null) {
-		    try {
-		        res.sendRedirect2(Jenkins.getInstance().getRootUrl() + build.getUrl());
-		    } catch (IOException e) {
-		        try {
-		            res.sendRedirect2(Jenkins.getInstance().getRootUrl() + build.getBuildStatusUrl());
-		        } catch (IOException e1) {
-		            e1.printStackTrace();
-		        }
-		    }
-		}
-	}
+    private void redirectToBuildPage(StaplerResponse res, Run build) {
+        if (build != null) {
+            try {
+                res.sendRedirect2(Jenkins.getInstance().getRootUrl() + build.getUrl());
+            } catch (IOException e) {
+                try {
+                    res.sendRedirect2(Jenkins.getInstance().getRootUrl() + build.getBuildStatusUrl());
+                } catch (IOException e1) {
+                    e1.printStackTrace();
+                }
+            }
+        }
+    }
 
     private GitSCM getGitSCM(SCMTriggerItem item) {
-        if(item != null) {
-            for(SCM scm : item.getSCMs()) {
-                if(scm instanceof GitSCM) {
+        if (item != null) {
+            for (SCM scm : item.getSCMs()) {
+                if (scm instanceof GitSCM) {
                     return (GitSCM) scm;
                 }
             }
@@ -207,123 +201,112 @@ public class GitLabWebHook implements UnprotectedRootAction {
         SCMTriggerItem item = SCMTriggerItems.asSCMTriggerItem(project);
         GitSCM gitSCM = getGitSCM(item);
 
-        if(gitSCM == null) {
+        if (gitSCM == null) {
             throw new IllegalArgumentException("This repo does not use git.");
         }
 
-        Run mainBuild = this.getBuildBySHA1(project, commitSHA1, true);
+        Run mainBuild = this.getBuildBySHA1(project, commitSHA1);
 
         JSONObject object = new JSONObject();
         object.put("sha", commitSHA1);
 
-        if(mainBuild == null) {
+        if (mainBuild == null) {
             try {
                 object.put("status", "pending");
                 this.writeJSON(rsp, object);
                 return;
             } catch (IOException e) {
-                throw HttpResponses.error(500,"Could not generate response.");
+                throw HttpResponses.error(500, "Could not generate response.");
             }
         }
-
 
         object.put("id", mainBuild.getNumber());
 
         Result res = mainBuild.getResult();
 
         //TODO: add status of pending when we figure it out.
-        if(mainBuild.isBuilding()) {
+        if (mainBuild.isBuilding()) {
             object.put("status", "running");
-        }else if(res == Result.ABORTED) {
+        } else if (res == Result.ABORTED) {
             object.put("status", "canceled");
-        }else if(res == Result.SUCCESS) {
+        } else if (res == Result.SUCCESS) {
             object.put("status", "success");
-        }else {
+        } else {
             object.put("status", "failed");
         }
-        
+
         try {
             this.writeJSON(rsp, object);
         } catch (IOException e) {
-            throw HttpResponses.error(500,"Could not generate response.");
+            throw HttpResponses.error(500, "Could not generate response.");
         }
     }
-
 
     private void generateStatusPNG(String branch, String commitSHA1, Job project, final StaplerRequest req, final StaplerResponse rsp) throws ServletException, IOException {
         SCMTriggerItem item = SCMTriggerItems.asSCMTriggerItem(project);
         GitSCM gitSCM = getGitSCM(item);
 
-        if(gitSCM == null) {
+        if (gitSCM == null) {
             throw new IllegalArgumentException("This repo does not use git.");
         }
 
         Run mainBuild = null;
 
-        if(branch != null) {
+        if (branch != null) {
             mainBuild = this.getBuildByBranch(project, branch);
-        } else if(commitSHA1 != null) {
-            mainBuild = this.getBuildBySHA1(project, commitSHA1, false);
+        } else if (commitSHA1 != null) {
+            mainBuild = this.getBuildBySHA1(project, commitSHA1);
         }
 
         String baseUrl = Jenkins.getInstance().getRootUrl();
         // Remove trailing slash
         if (baseUrl.endsWith("/")) {
-           baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
         }
         String imageUrl = "images/unknown.png";
-        if(null != mainBuild) {
+        if (null != mainBuild) {
             Result res = mainBuild.getResult();
-            if(mainBuild.isBuilding()) {
-            	imageUrl = "images/running.png";
-            }else if(res == Result.SUCCESS) {
-            	imageUrl = "images/success.png";
-            }else if(res == Result.FAILURE) {
-            	imageUrl = "images/failed.png";
-            }else if(res == Result.UNSTABLE) {
-            	imageUrl = "images/unstable.png";
-            }else {
-            	imageUrl = "images/unknown.png"; 
+            if (mainBuild.isBuilding()) {
+                imageUrl = "images/running.png";
+            } else if (res == Result.SUCCESS) {
+                imageUrl = "images/success.png";
+            } else if (res == Result.FAILURE) {
+                imageUrl = "images/failed.png";
+            } else if (res == Result.UNSTABLE) {
+                imageUrl = "images/unstable.png";
+            } else {
+                imageUrl = "images/unknown.png";
             }
-        }       
+        }
         Authentication old = SecurityContextHolder.getContext().getAuthentication();
         SecurityContextHolder.getContext().setAuthentication(ACL.SYSTEM);
         try {
             URL resourceUrl = new URL(Jenkins.getInstance().getPlugin("gitlab-plugin").getWrapper().baseResourceURL + imageUrl);
-            LOGGER.info("serving image "+resourceUrl.toExternalForm());
-            rsp.setHeader("Expires","Fri, 01 Jan 1984 00:00:00 GMT");
+            LOGGER.info("serving image " + resourceUrl.toExternalForm());
+            rsp.setHeader("Expires", "Fri, 01 Jan 1984 00:00:00 GMT");
             rsp.setHeader("Cache-Control", "no-cache, private");
             rsp.setHeader("Content-Type", "image/png");
             hudson.util.IOUtils.copy(new File(resourceUrl.toURI()), rsp.getOutputStream());
             rsp.flushBuffer();
         } catch (Exception e) {
-			throw HttpResponses.error(500,"Could not generate response.");
-		} finally {
+            throw HttpResponses.error(500, "Could not generate response.");
+        } finally {
             SecurityContextHolder.getContext().setAuthentication(old);
         }
 
     }
 
-
     /**
-     * Take the GitLab Data and parse through it.
-     * {
-     #     "before": "95790bf891e76fee5e1747ab589903a6a1f80f22",
-     #     "after": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
-     #     "ref": "refs/heads/master",
-     #     "commits": [
-     #       {
-     #         "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
-     #         "message": "Update Catalan translation to e38cb41.",
-     #         "timestamp": "2011-12-12T14:27:31+02:00",
-     #         "url": "http://localhost/diaspora/commits/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
-     #         "author": {
-     #           "name": "Jordi Mallach",
-     #           "email": "jordi@softcatala.org",
-     #         }
-     #       }, .... more commits
-     #     ]
-     #   }
+     * Take the GitLab Data and parse through it. { # "before":
+     * "95790bf891e76fee5e1747ab589903a6a1f80f22", # "after":
+     * "da1560886d4f094c3e6c9ef40349f7d38b5d27d7", # "ref": "refs/heads/master",
+     * # "commits": [ # { # "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327", #
+     * "message": "Update Catalan translation to e38cb41.", # "timestamp":
+     * "2011-12-12T14:27:31+02:00", # "url":
+     * "http://localhost/diaspora/commits/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+     * # "author": { # "name": "Jordi Mallach", # "email":
+     * "jordi@softcatala.org", # } # }, .... more commits # ] # }
+     *
      * @param data
      */
     private void generateBuild(String data, Job project, StaplerRequest req, StaplerResponse rsp) {
@@ -332,13 +315,12 @@ public class GitLabWebHook implements UnprotectedRootAction {
 
         String objectType = json.optString("object_kind");
 
-        if(objectType != null && objectType.equals("merge_request")) {
+        if (objectType != null && objectType.equals("merge_request")) {
             this.generateMergeRequestBuild(data, project, req, rsp);
         } else {
             this.generatePushBuild(data, project, req, rsp);
         }
     }
-
 
     public void generatePushBuild(String json, Job project, StaplerRequest req, StaplerResponse rsp) {
         GitLabPushRequest request = GitLabPushRequest.create(json);
@@ -354,22 +336,24 @@ public class GitLabWebHook implements UnprotectedRootAction {
         try {
 
             GitLabPushTrigger trigger = null;
-            if (project instanceof ParameterizedJobMixIn.ParameterizedJob) {
-                ParameterizedJobMixIn.ParameterizedJob p = (ParameterizedJobMixIn.ParameterizedJob) project;
-                for (Trigger t : p.getTriggers().values()) {
-
-                    if (t instanceof GitLabPushTrigger) {
-                        trigger = (GitLabPushTrigger) t;
-                    }
-                }
-            }
+            trigger = findTriggerForProject(project, trigger);
 
             if (trigger == null) {
                 return;
             }
+            
+            if (trigger.getGitLabPluginStrategyStrategy().skipsExistingPushBuildsMatchingBySHA1()) {
+                if (request.getLastCommit() != null) {
+                    Run previousBuild = getBuildBySHA1(project, request.getLastCommit().getId());
+                    if (previousBuild != null) {
+                        LOGGER.log(Level.INFO, "Last commit in Push has already been built in build #" + previousBuild.getId());
+                        return;
+                    }
+                }
+            }
 
-            if(trigger.getCiSkip() && request.getLastCommit() != null) {
-                if(request.getLastCommit().getMessage().contains("[ci-skip]")) {
+            if (trigger.getCiSkip() && request.getLastCommit() != null) {
+                if (request.getLastCommit().getMessage().contains("[ci-skip]")) {
                     LOGGER.log(Level.INFO, "Skipping due to ci-skip.");
                     return;
                 }
@@ -378,133 +362,42 @@ public class GitLabWebHook implements UnprotectedRootAction {
             trigger.onPost(request);
 
             if (!trigger.getTriggerOpenMergeRequestOnPush().equals("never")) {
-            	// Fetch and build open merge requests with the same source branch
-            	buildOpenMergeRequests(trigger, request.getProject_id(), request.getRef());
+                // Call the strategy, to see if we need to do something about Merg Requests when triggered by a push.
+                trigger.getGitLabPluginStrategyStrategy().buildOpenMergeRequestTriggeredByPush(this, trigger, request.getProject_id(), request.getRef());
             }
         } finally {
             SecurityContextHolder.getContext().setAuthentication(old);
         }
     }
 
-	protected void buildOpenMergeRequests(GitLabPushTrigger trigger, Integer projectId, String projectRef) {
-		try {
-			GitLab api = new GitLab();
-			List<GitlabMergeRequest> mergeRequests = api.instance().getOpenMergeRequests(projectId);
-
-			for (org.gitlab.api.models.GitlabMergeRequest mr : mergeRequests) {
-				if (projectRef.endsWith(mr.getSourceBranch()) || 
-                                        (trigger.getTriggerOpenMergeRequestOnPush().equals("both") && projectRef.endsWith(mr.getTargetBranch()))) {
-                                    
-                                        if (trigger.getCiSkip() && mr.getDescription().contains("[ci-skip]")) {
-                                            LOGGER.log(Level.INFO, "Skipping MR " + mr.getTitle() + " due to ci-skip.");
-                                            continue;
-                                        }
-
-					Integer srcProjectId = projectId;
-					if (!projectRef.endsWith(mr.getSourceBranch())) {
-						srcProjectId = mr.getSourceProjectId();
-					}
-
-					GitlabBranch branch = api.instance().getBranch(api.instance().getProject(srcProjectId), mr.getSourceBranch());
-                    LastCommit lastCommit = new LastCommit();
-                    lastCommit.setId(branch.getCommit().getId());
-                    lastCommit.setMessage(branch.getCommit().getMessage());
-                    lastCommit.setUrl(GitlabProject.URL + "/" + srcProjectId + "/repository" + GitlabCommit.URL + "/"
-                            + branch.getCommit().getId());
-
-					LOGGER.log(Level.FINE,
-							"Generating new merge trigger from "
-									+ mr.toString() + "\n source: "
-									+ mr.getSourceBranch() + "\n target: "
-									+ mr.getTargetBranch() + "\n state: "
-									+ mr.getState() + "\n assign: "
-									+ (mr.getAssignee() != null ? mr.getAssignee().getName() : "") + "\n author: "
-									+ (mr.getAuthor() != null ? mr.getAuthor().getName() : "") + "\n id: "
-									+ mr.getId() + "\n iid: "
-                                    + mr.getIid() + "\n last commit: "
-                                    + lastCommit.getId() + "\n\n");
-					GitLabMergeRequest newReq = new GitLabMergeRequest();
-					newReq.setObject_kind("merge_request");
-					newReq.setObjectAttribute(new ObjectAttributes());
-					if (mr.getAssignee() != null)
-						newReq.getObjectAttribute().setAssignee(mr.getAssignee());
-					if (mr.getAuthor() != null)
-                        newReq.getObjectAttribute().setAuthor(mr.getAuthor());
-					newReq.getObjectAttribute().setDescription(mr.getDescription());
-					newReq.getObjectAttribute().setId(mr.getId());
-					newReq.getObjectAttribute().setIid(mr.getIid());
-					newReq.getObjectAttribute().setMergeStatus(mr.getState());
-					newReq.getObjectAttribute().setSourceBranch(mr.getSourceBranch());
-					newReq.getObjectAttribute().setSourceProjectId(mr.getSourceProjectId());
-					newReq.getObjectAttribute().setTargetBranch(mr.getTargetBranch());
-					newReq.getObjectAttribute().setTargetProjectId(projectId);
-					newReq.getObjectAttribute().setTitle(mr.getTitle());
-                    newReq.getObjectAttribute().setLastCommit(lastCommit);
-
-					Authentication old = SecurityContextHolder.getContext().getAuthentication();
-					SecurityContextHolder.getContext().setAuthentication(ACL.SYSTEM);
-					try {
-						trigger.onPost(newReq);
-					} finally {
-						SecurityContextHolder.getContext().setAuthentication(old);
-					}
-				}
-			}
-		} catch (Exception e) {
-			LOGGER.warning("failed to communicate with gitlab server to determine is this is an update for a merge request: "
-					+ e.getMessage());
-			e.printStackTrace();
-		}
-	}
-
     public void generateMergeRequestBuild(String json, Job project, StaplerRequest req, StaplerResponse rsp) {
         GitLabMergeRequest request = GitLabMergeRequest.create(json);
-        if("closed".equals(request.getObjectAttribute().getState())) {
-            LOGGER.log(Level.INFO, "Closed Merge Request, no build started");
-            return;
-        }
-        if("merged".equals(request.getObjectAttribute().getState())) {
-            LOGGER.log(Level.INFO, "Accepted Merge Request, no build started");
-            return;
-        }
-        if("update".equals(request.getObjectAttribute().getAction())) {
-            LOGGER.log(Level.INFO, "Existing Merge Request, build will be trigged by buildOpenMergeRequests instead");
-            return;
-        }
-        if(request.getObjectAttribute().getLastCommit()!=null) {
-            Run mergeBuild = getBuildBySHA1(project, request.getObjectAttribute().getLastCommit().getId(), true);
-            if (mergeBuild != null) {
-                StringParameterValue mergeBuildTargetBranch = (StringParameterValue) mergeBuild.getAction(ParametersAction.class).getParameter("gitlabTargetBranch");
-                boolean targetBranchesEqual = StringUtils.equals(mergeBuildTargetBranch.value, request.getObjectAttribute().getTargetBranch());
-                LOGGER.fine("Previous build's target-branch: " + mergeBuildTargetBranch.value
-                        + ", current build's target-branch: "
-                        + request.getObjectAttribute().getTargetBranch() + ", equals: "
-                        + targetBranchesEqual);
-
-                if (targetBranchesEqual) {
-                    LOGGER.log(Level.INFO, "Last commit in Merge Request has already been built in build #" + mergeBuild.getId());
-                    return;
-                }
-            }
-        }
 
         Authentication old = SecurityContextHolder.getContext().getAuthentication();
         SecurityContextHolder.getContext().setAuthentication(ACL.SYSTEM);
         try {
             GitLabPushTrigger trigger = null;
-            if (project instanceof ParameterizedJobMixIn.ParameterizedJob) {
-                ParameterizedJobMixIn.ParameterizedJob p = (ParameterizedJobMixIn.ParameterizedJob) project;
-                for (Trigger t : p.getTriggers().values()) {
-                    if (t instanceof GitLabPushTrigger) {
-                        trigger = (GitLabPushTrigger) t;
-                    }
-                }
-            }
+            trigger = findTriggerForProject(project, trigger);
             if (trigger == null) {
                 return;
             }
+            
+            if (trigger.getGitLabPluginStrategyStrategy().shouldSkipMergeRequestBuild(trigger, request.getObjectAttribute().getState())) {
+                LOGGER.log(Level.INFO, String.format("Merge Request with state %s, no build started", request.getObjectAttribute().getState()));
+                return;
+            }
 
-            if(trigger.getCiSkip() && request.getObjectAttribute().getDescription().contains("[ci-skip]")) {
+            if (request.getObjectAttribute().getLastCommit() != null) {
+                Run mergeBuild = getBuildBySHA1(project, request.getObjectAttribute().getLastCommit().getId());
+                if (mergeBuild != null) {
+                    if (trigger.getGitLabPluginStrategyStrategy().isMergeBuildAlreadyBuilt(request, mergeBuild)) {
+                        LOGGER.log(Level.INFO, "Last commit in Merge Request has already been built in build #" + mergeBuild.getId());
+                        return;
+                    }
+                }
+            }
+
+            if (trigger.getCiSkip() && request.getObjectAttribute().getDescription().contains("[ci-skip]")) {
                 LOGGER.log(Level.INFO, "Skipping MR " + request.getObjectAttribute().getTitle() + " due to ci-skip.");
                 return;
             }
@@ -515,14 +408,41 @@ public class GitLabWebHook implements UnprotectedRootAction {
         }
     }
 
+    private GitLabPushTrigger findTriggerForProject(Job project, GitLabPushTrigger trigger) {
+        if (project instanceof ParameterizedJobMixIn.ParameterizedJob) {
+            ParameterizedJobMixIn.ParameterizedJob p = (ParameterizedJobMixIn.ParameterizedJob) project;
+            for (Trigger t : p.getTriggers().values()) {
+                if (t instanceof GitLabPushTrigger) {
+                    trigger = (GitLabPushTrigger) t;
+                }
+            }
+        }
+        return trigger;
+    }
 
-
-    /**************************************************
+    /**
+     * ************************************************
      *
      * Helper methods
      *
-     **************************************************/
+     *************************************************
+     */
+    private Run getBuildBySHA1(Job project, String commitSHA1) {
+        List<Run> builds = project.getBuilds();
+        for (Run build : builds) {
+            BuildData data = build.getAction(BuildData.class);
 
+            if (data != null) {
+                Revision revision = data.getLastBuiltRevision();
+
+                if (revision != null && revision.getSha1String().contains(commitSHA1)) {
+                    return build;
+                }
+            }
+        }
+
+        return null;
+    }
 
     /**
      *
@@ -530,87 +450,90 @@ public class GitLabWebHook implements UnprotectedRootAction {
      * @param commitSHA1
      * @return
      */
-    private Run getBuildBySHA1(Job project, String commitSHA1, boolean triggeredByMergeRequest) {
+    private Run _getBuildBySHA1(Job project, String commitSHA1, boolean triggeredByMergeRequest) {
         List<Run> builds = project.getBuilds();
-        for(Run build : builds) {
+        for (Run build : builds) {
             BuildData data = build.getAction(BuildData.class);
             MergeRecord mergeRecord = build.getAction(MergeRecord.class);
             if (mergeRecord == null) {
                 //Determine if build was triggered by a Merge Request event
                 ParametersAction params = build.getAction(ParametersAction.class);
 
-                if (params == null) continue;
+                if (params == null) {
+                    continue;
+                }
 
                 StringParameterValue sourceBranch = (StringParameterValue) params.getParameter("gitlabSourceBranch");
                 StringParameterValue targetBranch = (StringParameterValue) params.getParameter("gitlabTargetBranch");
                 boolean isMergeRequestBuild = (sourceBranch != null && !sourceBranch.value.equals(targetBranch.value));
 
                 if (!triggeredByMergeRequest) {
-    				if (isMergeRequestBuild)
-    					// skip Merge Request builds
-    					continue;
+                    if (isMergeRequestBuild) // skip Merge Request builds
+                    {
+                        continue;
+                    }
 
                     if (data.getLastBuiltRevision().getSha1String().contains(commitSHA1)) {
                         return build;
                     }
-                } else {
-    				if (hasBeenBuilt(data, ObjectId.fromString(commitSHA1), build)) {
-    					return build;
-    				}
+                } else if (hasBeenBuilt(data, ObjectId.fromString(commitSHA1), build)) {
+                    return build;
                 }
 
             } else {
-            	Build b =  data.lastBuild;
-            	boolean isMergeBuild = mergeRecord!=null && !mergeRecord.getSha1().equals(b.getMarked().getSha1String());
-            	if(b!=null && b.getMarked()!=null && b.getMarked().getSha1String().equals(commitSHA1)){
-            		if(triggeredByMergeRequest == isMergeBuild){
-            			LOGGER.log(Level.FINE, build.getNumber()+" Build found matching "+commitSHA1+" "+(isMergeBuild? "merge":"normal")+" build");
-            			return build;
-            		}
-            	}
+                Build b = data.lastBuild;
+                boolean isMergeBuild = mergeRecord != null && !mergeRecord.getSha1().equals(b.getMarked().getSha1String());
+                if (b != null && b.getMarked() != null && b.getMarked().getSha1String().equals(commitSHA1)) {
+                    if (triggeredByMergeRequest == isMergeBuild) {
+                        LOGGER.log(Level.FINE, build.getNumber() + " Build found matching " + commitSHA1 + " " + (isMergeBuild ? "merge" : "normal") + " build");
+                        return build;
+                    }
+                }
             }
         }
         return null;
     }
 
     private boolean hasBeenBuilt(BuildData data, ObjectId sha1, Run build) {
-		try {
-			for (Build b : data.getBuildsByBranchName().values()) {
-				if (b.getBuildNumber() == build.number
-						&& b.marked.getSha1().equals(sha1))
-					return true;
-			}
-			return false;
-		} catch (Exception ex) {
-			return false;
-		}
-	}
-    
+        try {
+            for (Build b : data.getBuildsByBranchName().values()) {
+                if (b.getBuildNumber() == build.number
+                        && b.marked.getSha1().equals(sha1)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
     /**
      *
      * @param project
      * @param branch
-     * @return latest build of the branch specified that is not part of a merge request
+     * @return latest build of the branch specified that is not part of a merge
+     * request
      */
     @SuppressWarnings("rawtypes")
-	private Run getBuildByBranch(Job project, String branch) {
+    private Run getBuildByBranch(Job project, String branch) {
         RunList<?> builds = project.getBuilds();
-        for(Run build : builds) {
+        for (Run build : builds) {
             BuildData data = build.getAction(BuildData.class);
-            if(data!=null && data.lastBuild!=null) {
+            if (data != null && data.lastBuild != null) {
                 MergeRecord merge = build.getAction(MergeRecord.class);
                 boolean isMergeBuild = merge != null && !merge.getSha1().equals(data.lastBuild.getMarked().getSha1String());
                 if (data.lastBuild.getRevision() != null && !isMergeBuild) {
                     for (Branch b : data.lastBuild.getRevision().getBranches()) {
-                        if (b.getName().endsWith("/" + branch))
+                        if (b.getName().endsWith("/" + branch)) {
                             return build;
+                        }
                     }
                 }
             }
         }
         return null;
     }
-
 
     /**
      *
@@ -621,7 +544,7 @@ public class GitLabWebHook implements UnprotectedRootAction {
         rsp.setContentType("application/json");
         PrintWriter w = rsp.getWriter();
 
-        if(jsonObject == null) {
+        if (jsonObject == null) {
             w.write("null");
         } else {
             w.write(jsonObject.toString());

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -2,6 +2,9 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
+    <f:entry title="GitLab Plugin Mode" field="pluginMode">
+        <f:select/>
+    </f:entry>
     <f:entry title="Build on Merge Request Events" field="triggerOnMergeRequest">
         <f:checkbox default="true"/>
     </f:entry>

--- a/src/main/resources/com/dabsquared/gitlabjenkins/Messages.properties
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/Messages.properties
@@ -7,3 +7,4 @@ GitLabPushTrigger.BranchesMatched=Matching {0} branch{0,choice,1#|2#s}.
 GitLabPushTrigger.CannotCheckBranches=Cannot connect to GitLab to check whether selected branches exist.
 GitLabPushTrigger.CannotConnectToGitLab=Cannot connect to GitLab: {0}
 GitLabPushTrigger.NoSourceRepository=Repository url must be saved first.
+GitLabPushTriggerStrategyModern.refs_remotes_origin_merge_requests_s=refs/remotes/origin/merge-requests/%s

--- a/src/test/java/com/dabsquared/gitlabjenkins/AbstractGitLabPushTriggerGitlabServerTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/AbstractGitLabPushTriggerGitlabServerTest.java
@@ -129,7 +129,7 @@ public abstract class AbstractGitLabPushTriggerGitlabServerTest {
 		String includeBranchesSpec = null;
 		String excludeBranchesSpec = null;
 		String targetBranchRegex = null;
-		GitLabPushTrigger gitLabPushTrigger = new GitLabPushTrigger(triggerOnPush, triggerOnMergeRequest,
+		GitLabPushTrigger gitLabPushTrigger = new GitLabPushTrigger(GitLabPluginMode.LEGACY.toString(), triggerOnPush, triggerOnMergeRequest,
 				triggerOpenMergeRequestOnPush, ciSkip, setBuildDescription, addNoteOnMergeRequest, addCiMessage,
 				addVoteOnMergeRequest, acceptMergeRequestOnSuccess, branchFilter, includeBranchesSpec,
 				excludeBranchesSpec, targetBranchRegex);


### PR DESCRIPTION
This PR enhances gitlab-plugin by adding two operation modes: Modern and Legacy.
**Legacy** is what we currently have, that works with older versions of GitLab.

**Modern** works with GitLab 8.1 or better, and provides an easier configuration of projects in Jenkins (a single Git repository is enough) and much better handling of Merge Requests (MR are fetched from `origin` and matched by SHA1 instead of comparing branch names).

This PR fixes the two issues I reported: #239 and #155.
Also, a quick review of the current issues indicates that it should fix (assuming they can use the Modern mode):
- #250, #238 and #210 (seem related to MR handling)
- #249, #194 (since builds are matched by SHA1, duplicates are prevented easily)
- #232 (since it won't use the title to construct the git URL)
- #136, #98 

This has been implemented with a strategy pattern. The points where the strategy is used are ad-hoc based on where the Legacy and Modern strategies differ (a few but important points).
