### PR TITLE
Added gitlabBefore and gitlabAfter

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -273,6 +273,8 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         LOGGER.log(Level.INFO, "GitLab Push Request from branch {0}.", branch);
 
         Map<String, ParameterValue> values = getDefaultParameters();
+        values.put("gitlabBefore", new StringParameterValue("gitlabBefore", req.getBefore()));
+        values.put("gitlabAfter", new StringParameterValue("gitlabAfter", req.getAfter()));
         values.put("gitlabSourceBranch", new StringParameterValue("gitlabSourceBranch", branch));
         values.put("gitlabTargetBranch", new StringParameterValue("gitlabTargetBranch", branch));
         values.put("gitlabBranch", new StringParameterValue("gitlabBranch", branch));
@@ -403,6 +405,8 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 
     private Action createAction(GitLabMergeRequest req, Job job) {
         Map<String, ParameterValue> values = getDefaultParameters();
+        values.put("gitlabBefore", new StringParameterValue("gitlabBefore", ""));
+        values.put("gitlabAfter", new StringParameterValue("gitlabAfter", ""));
         values.put("gitlabSourceBranch", new StringParameterValue("gitlabSourceBranch", getSourceBranch(req)));
         values.put("gitlabTargetBranch", new StringParameterValue("gitlabTargetBranch", req.getObjectAttribute().getTargetBranch()));
         values.put("gitlabActionType", new StringParameterValue("gitlabActionType", "MERGE"));


### PR DESCRIPTION
In the case of a Push Event the gitlabBefore and gitlabAfter parameters will be populated with the gitlab Push Event document's "before" and "after" attributes.  In the case of a merge request an empty string is added as it seems that is the project's default for StringParameterValue's that are absent
