### PR TITLE
Swap equals check around to prevent NPE

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/ActionResolver.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/ActionResolver.java
@@ -90,9 +90,9 @@ public class ActionResolver {
     private WebHookAction onPost(Job<?, ?> project, StaplerRequest request) {
         String requestBody = getRequestBody(request);
         String eventHeader = request.getHeader("X-Gitlab-Event");
-        if (eventHeader.equals("Merge Request Hook")) {
+        if ("Merge Request Hook".equals(eventHeader)) {
             return new MergeRequestBuildAction(project, requestBody);
-        } else if (eventHeader.equals("Push Hook")) {
+        } else if ("Push Hook".equals(eventHeader)) {
             return new PushBuildAction(project, requestBody);
         }
         LOGGER.log(Level.FINE, "Unsupported event header: {0}", eventHeader);

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/ActionResolver.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/ActionResolver.java
@@ -17,6 +17,7 @@ import hudson.security.ACL;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -90,9 +91,9 @@ public class ActionResolver {
     private WebHookAction onPost(Job<?, ?> project, StaplerRequest request) {
         String requestBody = getRequestBody(request);
         String eventHeader = request.getHeader("X-Gitlab-Event");
-        if ("Merge Request Hook".equals(eventHeader)) {
+        if (StringUtils.equals(eventHeader, "Merge Request Hook") ) {
             return new MergeRequestBuildAction(project, requestBody);
-        } else if ("Push Hook".equals(eventHeader)) {
+        } else if ( StringUtils.equals(eventHeader,"Push Hook")) {
             return new PushBuildAction(project, requestBody);
         }
         LOGGER.log(Level.FINE, "Unsupported event header: {0}", eventHeader);


### PR DESCRIPTION
Swapped equals check on strings around to prevent NPE and let the code handle the missing header condition as intended.
