### PR TITLE
Utilizing SpringUtils to safely perform string comparison.

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/ActionResolver.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/ActionResolver.java
@@ -17,6 +17,7 @@ import hudson.security.ACL;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -90,9 +91,9 @@ public class ActionResolver {
     private WebHookAction onPost(Job<?, ?> project, StaplerRequest request) {
         String requestBody = getRequestBody(request);
         String eventHeader = request.getHeader("X-Gitlab-Event");
-        if (eventHeader.equals("Merge Request Hook")) {
+        if (StringUtils.equals(eventHeader, "Merge Request Hook") ) {
             return new MergeRequestBuildAction(project, requestBody);
-        } else if (eventHeader.equals("Push Hook")) {
+        } else if ( StringUtils.equals(eventHeader,"Push Hook")) {
             return new PushBuildAction(project, requestBody);
         }
         LOGGER.log(Level.FINE, "Unsupported event header: {0}", eventHeader);


### PR DESCRIPTION
When the X-Gitlab-Event header is not present (pre-7.14 versions of GitLab), a NPE was raised here, hereby bypassing intended error handling.
