### PR TITLE
Git push hook namespace compatibility for Gitlab pre ~v8.5

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/BuildWebHookAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/BuildWebHookAction.java
@@ -1,0 +1,17 @@
+package com.dabsquared.gitlabjenkins.webhook.build;
+
+import com.dabsquared.gitlabjenkins.webhook.WebHookAction;
+import org.kohsuke.stapler.StaplerResponse;
+
+/**
+ * @author Xinran Xiao
+ */
+abstract class BuildWebHookAction implements WebHookAction {
+    abstract void processForCompatibility();
+    abstract void execute();
+
+    public final void execute(StaplerResponse response) {
+        processForCompatibility();
+        execute();
+    }
+}

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildAction.java
@@ -17,7 +17,7 @@ import static com.dabsquared.gitlabjenkins.util.JsonUtil.toPrettyPrint;
 /**
  * @author Robin Müller
  */
-public class MergeRequestBuildAction implements WebHookAction {
+public class MergeRequestBuildAction extends BuildWebHookAction {
 
     private final static Logger LOGGER = Logger.getLogger(MergeRequestBuildAction.class.getName());
     private Job<?, ?> project;
@@ -29,7 +29,12 @@ public class MergeRequestBuildAction implements WebHookAction {
         this.mergeRequestHook = JsonUtil.read(json, MergeRequestHook.class);
     }
 
-    public void execute(StaplerResponse response) {
+    /**
+    * Noop for merge request hooks.
+    */
+    void processForCompatibility() {}
+
+    public void execute() {
         ACL.impersonate(ACL.SYSTEM, new Runnable() {
             public void run() {
                 GitLabPushTrigger trigger = GitLabPushTrigger.getFromJob(project);


### PR DESCRIPTION
Gitlab hooks pre ~v8.5 do not send the "project" field with the POST json. If we want to support using this plugin for versions of gitlab before ~8.5, we need try populating the project field with values that can be inferred from fields that _do_ exist in the json.

This patch simply fills in the namespace field in the project field for `PushBuildAction`'s pushHook if it does not get parsed in from the POST json. We need this because `pushHook.getProject().getNamespace()` is used later in the plugin code, and it will throw a null pointer exception if we do not have the project filled out.
