### PR TITLE
Allign to GitLab API

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -4,19 +4,21 @@ import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabApi;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.BuildState;
-import hudson.EnvVars;
-import hudson.model.Run;
-import hudson.model.TaskListener;
-import hudson.plugins.git.util.BuildData;
-import jenkins.model.Jenkins;
 
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.WebApplicationException;
+
+import hudson.EnvVars;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.util.BuildData;
+import jenkins.model.Jenkins;
 
 /**
  * @author Robin Müller
@@ -98,7 +100,7 @@ public class CommitStatusUpdater {
         List<String> result = new ArrayList<>();
         for (String remoteUrl : build.getAction(BuildData.class).getRemoteUrls()) {
             try {
-                result.add(ProjectIdUtil.retrieveProjectId(environment.expand(remoteUrl)));
+                result.add(getClient(build).getProject(ProjectIdUtil.retrieveProjectId(environment.expand(remoteUrl))).getId().toString());
             } catch (ProjectIdUtil.ProjectIdResolutionException e) {
                 // nothing to do
             }


### PR DESCRIPTION
This PR fix 2 issues:
https://github.com/jenkinsci/gitlab-plugin/issues/295
https://github.com/jenkinsci/gitlab-plugin/issues/284

According to GitLab Commit API - http://docs.gitlab.com/ee/api/commits.html
all operations performed on commit objects are requires to provides ProjectId as integer instead of String used in com.dabsquared.gitlabjenkins.util.CommitStatusUpdater#retrieveGitlabProjectIds

To be alligned with GitLab API
com.dabsquared.gitlabjenkins.util.CommitStatusUpdater#retrieveGitlabProjectIds was updated to send get-single-project(http://docs.gitlab.com/ee/api/projects.html#get-single-project) request and use real ProjectId(Int) provided by GitLab in response

Tested with
GitLab 8.6.1
Jenkins 1.637
