### PR TITLE
 CI build status for merge requests remains skipped since updating to 1.2.x

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -34,7 +34,7 @@ public class CommitStatusUpdater {
                     GitLabApi client = getClient(build);
                     if (client == null) {
                         println(listener, "No GitLab connection configured");
-                    } else if (existsCommit(client, gitlabProjectId, commitHash)) {
+                    } else {
                         client.changeBuildStatus(gitlabProjectId, commitHash, state, getBuildBranch(build), "jenkins", buildUrl, null);
                     }
                 } catch (WebApplicationException e) {
@@ -65,16 +65,6 @@ public class CommitStatusUpdater {
 
     private static String getBuildRevision(Run<?, ?> build) {
         return build.getAction(BuildData.class).getLastBuiltRevision().getSha1String();
-    }
-
-    private static boolean existsCommit(GitLabApi client, String gitlabProjectId, String commitHash) {
-        try {
-            client.getCommit(gitlabProjectId, commitHash);
-            return true;
-        } catch (NotFoundException e) {
-            LOGGER.log(Level.FINE, String.format("Project (%s) and commit (%s) combination not found", gitlabProjectId, commitHash));
-            return false;
-        }
     }
 
     private static String getBuildBranch(Run<?, ?> build) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -64,7 +64,7 @@ public class CommitStatusUpdater {
     }
 
     private static String getBuildRevision(Run<?, ?> build) {
-        return build.getAction(BuildData.class).getLastBuiltRevision().getSha1String();
+        return build.getAction(BuildData.class).lastBuild.marked.getSha1String();
     }
 
     private static String getBuildBranch(Run<?, ?> build) {

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
@@ -17,6 +17,7 @@ import hudson.model.Result;
 import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
 import hudson.plugins.git.Revision;
+import hudson.plugins.git.util.Build;
 import hudson.plugins.git.util.BuildData;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
@@ -193,6 +194,7 @@ public class GitLabCommitStatusPublisherTest {
         BuildData buildData = mock(BuildData.class);
         Revision revision = mock(Revision.class);
         when(revision.getSha1String()).thenReturn(sha);
+        buildData.lastBuild = new Build(revision, 123, result);
         when(buildData.getLastBuiltRevision()).thenReturn(revision);
         when(buildData.getRemoteUrls()).thenReturn(new HashSet<>(Arrays.asList(remoteUrls)));
         when(build.getAction(BuildData.class)).thenReturn(buildData);

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
@@ -92,7 +92,6 @@ public class GitLabCommitStatusPublisherTest {
     @Test
     public void running() throws UnsupportedEncodingException {
         HttpRequest[] requests = new HttpRequest[] {
-                prepareExistsCommitWithSuccessResponse("test/project", "123abc"),
                 prepareUpdateCommitStatusWithSuccessResponse("test/project", "123abc", jenkins.getInstance().getRootUrl() + "/build/123", BuildState.running)
         };
         AbstractBuild build = mockBuild("123abc", "/build/123", GIT_LAB_CONNECTION, null, "test/project");
@@ -106,7 +105,6 @@ public class GitLabCommitStatusPublisherTest {
     @Test
     public void canceled() throws IOException, InterruptedException {
         HttpRequest[] requests = new HttpRequest[] {
-                prepareExistsCommitWithSuccessResponse("test/project", "123abc"),
                 prepareUpdateCommitStatusWithSuccessResponse("test/project", "123abc", jenkins.getInstance().getRootUrl() + "/build/123", BuildState.canceled)
         };
         AbstractBuild build = mockBuild("123abc", "/build/123", GIT_LAB_CONNECTION, Result.ABORTED, "test/project");
@@ -120,7 +118,6 @@ public class GitLabCommitStatusPublisherTest {
     @Test
     public void success() throws IOException, InterruptedException {
         HttpRequest[] requests = new HttpRequest[] {
-                prepareExistsCommitWithSuccessResponse("test/project", "123abc"),
                 prepareUpdateCommitStatusWithSuccessResponse("test/project", "123abc", jenkins.getInstance().getRootUrl() + "/build/123", BuildState.success)
         };
         AbstractBuild build = mockBuild("123abc", "/build/123", GIT_LAB_CONNECTION, Result.SUCCESS, "test/project");
@@ -134,7 +131,6 @@ public class GitLabCommitStatusPublisherTest {
     @Test
     public void failed() throws IOException, InterruptedException {
         HttpRequest[] requests = new HttpRequest[] {
-                prepareExistsCommitWithSuccessResponse("test/project", "123abc"),
                 prepareUpdateCommitStatusWithSuccessResponse("test/project", "123abc", jenkins.getInstance().getRootUrl() + "/build/123", BuildState.failed)
         };
         AbstractBuild build = mockBuild("123abc", "/build/123", GIT_LAB_CONNECTION, Result.FAILURE, "test/project");
@@ -148,9 +144,7 @@ public class GitLabCommitStatusPublisherTest {
     @Test
     public void running_multipleRepos() throws UnsupportedEncodingException {
         HttpRequest[] requests = new HttpRequest[] {
-                prepareExistsCommitWithSuccessResponse("test/project-1", "123abc"),
                 prepareUpdateCommitStatusWithSuccessResponse("test/project-1", "123abc", jenkins.getInstance().getRootUrl() + "/build/123", BuildState.running),
-                prepareExistsCommitWithSuccessResponse("test/project-2", "123abc"),
                 prepareUpdateCommitStatusWithSuccessResponse("test/project-2", "123abc", jenkins.getInstance().getRootUrl() + "/build/123", BuildState.running)
         };
         AbstractBuild build = mockBuild("123abc", "/build/123", GIT_LAB_CONNECTION, null, "test/project-1", "test/project-2");
@@ -162,21 +156,9 @@ public class GitLabCommitStatusPublisherTest {
     }
 
     @Test
-    public void running_commitNotExists() throws UnsupportedEncodingException {
-        HttpRequest updateCommitStatus = prepareUpdateCommitStatusWithSuccessResponse("test/project", "123abc", jenkins.getInstance().getRootUrl() + "/build/123", BuildState.running);
-        AbstractBuild build = mockBuild("123abc", "/build/123", GIT_LAB_CONNECTION, null, "test/project");
-
-        GitLabCommitStatusPublisher publisher = new GitLabCommitStatusPublisher();
-        publisher.prebuild(build, listener);
-
-        mockServerClient.verify(updateCommitStatus, VerificationTimes.exactly(0));
-    }
-
-    @Test
     public void running_failToUpdate() throws UnsupportedEncodingException {
-        prepareExistsCommitWithSuccessResponse("test/project", "123abc");
         HttpRequest updateCommitStatus = prepareUpdateCommitStatus("test/project", "123abc", jenkins.getInstance().getRootUrl() + "/build/123", BuildState.running);
-        mockServerClient.when(updateCommitStatus).respond(response().withStatusCode(403));
+        mockServerClient.when(updateCommitStatus).respond(response().withStatusCode(404));
         AbstractBuild build = mockBuild("123abc", "/build/123", GIT_LAB_CONNECTION, null, "test/project");
         BuildListener buildListener = mock(BuildListener.class);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -185,7 +167,7 @@ public class GitLabCommitStatusPublisherTest {
         GitLabCommitStatusPublisher publisher = new GitLabCommitStatusPublisher();
         publisher.prebuild(build, buildListener);
 
-        assertThat(outputStream.toString(), CoreMatchers.containsString("Failed to update Gitlab commit status for project 'test/project': HTTP 403 Forbidden"));
+        assertThat(outputStream.toString(), CoreMatchers.containsString("Failed to update Gitlab commit status for project 'test/project': HTTP 404 Not Found"));
         mockServerClient.verify(updateCommitStatus);
     }
 
@@ -204,19 +186,6 @@ public class GitLabCommitStatusPublisherTest {
                 .withQueryStringParameter("state", state.name())
                 .withQueryStringParameter("context", "jenkins")
                 .withQueryStringParameter("target_url", targetUrl);
-    }
-
-    private HttpRequest prepareExistsCommitWithSuccessResponse(String projectId, String sha) throws UnsupportedEncodingException {
-        HttpRequest existsCommit = prepareExistsCommit(projectId, sha);
-        mockServerClient.when(existsCommit).respond(response().withStatusCode(200));
-        return existsCommit;
-    }
-
-    private HttpRequest prepareExistsCommit(String projectId, String sha) throws UnsupportedEncodingException {
-        return request()
-                .withPath("/gitlab/api/v3/projects/" + URLEncoder.encode(projectId, "UTF-8") + "/repository/commits/" + sha)
-                .withMethod("GET")
-                .withHeader("PRIVATE-TOKEN", "secret");
     }
 
     private AbstractBuild mockBuild(String sha, String buildUrl, String gitLabConnection, Result result, String... remoteUrls) {


### PR DESCRIPTION
Something went wrong with the gitlab build status update. Since updating to version 1.2.x (from 1.1.x) builds in Gitlab 8.7.5 CE get marked as skipped.
I updated to a 1.2.3-SNAPSHOT build from master in order to get the fix for https://github.com/jenkinsci/gitlab-plugin/issues/284, and I had to manually add post-build hooks to report the status (b/c the gitlab config got lost during updating).
Still the status API is not working. Can I get more details logs somewhere to see whether the plugin actually called gitlab and what happened? The status calls seem to arrive at gitlab, but sth. in their content might be wrong (really sending skip as action?, commit hash after merge?).
