### PR TITLE
Fix to support NameSpace or ProjectName with dot in it

### DIFF
--- a/src/test/resources/com/dabsquared/gitlabjenkins/publisher/GetSingleProject.json
+++ b/src/test/resources/com/dabsquared/gitlabjenkins/publisher/GetSingleProject.json
@@ -1,0 +1,52 @@
+{
+  "id": "${projectId}",
+  "description": "",
+  "default_branch": "master",
+  "tag_list": [],
+  "public": false,
+  "archived": false,
+  "visibility_level": 10,
+  "ssh_url_to_repo": "git@localhost:${nameSpace}/${projectName}.git",
+  "http_url_to_repo": "https://localhost/${nameSpace}/${projectName}.git",
+  "web_url": "https://localhost/${nameSpace}/${projectName}",
+  "name": "${projectName}",
+  "name_with_namespace": "${nameSpace} / ${projectName}",
+  "path": "${projectName}",
+  "path_with_namespace": "${nameSpace}/${projectName}",
+  "issues_enabled": true,
+  "merge_requests_enabled": true,
+  "wiki_enabled": true,
+  "builds_enabled": true,
+  "snippets_enabled": false,
+  "created_at": "2016-04-08T13:20:40.951Z",
+  "last_activity_at": "2016-05-18T12:55:15.322Z",
+  "shared_runners_enabled": true,
+  "creator_id": 1,
+  "namespace": {
+    "id": 159,
+    "name": "${nameSpace}",
+    "path": "${nameSpace}",
+    "owner_id": null,
+    "created_at": "2016-04-08T13:18:08.233Z",
+    "updated_at": "2016-04-08T13:18:08.233Z",
+    "description": "",
+    "avatar": {
+      "url": null
+    },
+    "share_with_group_lock": false,
+    "visibility_level": 20
+  },
+  "avatar_url": null,
+  "star_count": 2,
+  "forks_count": 0,
+  "open_issues_count": 0,
+  "runners_token": "nR-uhvbge5MTFyBimJ7D",
+  "public_builds": true,
+  "permissions": {
+    "project_access": {
+      "access_level": 40,
+      "notification_level": 3
+    },
+    "group_access": null
+  }
+}


### PR DESCRIPTION
According to Rails documentation(http://guides.rubyonrails.org/v3.1.3/routing.html section 3.2 Dynamic Segments) Rail use a dot as separator for formatted routes.
In this case if we have dot in ProjectId constructed from(namespace + projectname) all request except getSingleProject(http://docs.gitlab.com/ce/api/projects.html#get-single-project) fail with message
"Failed to update Gitlab commit status for project Name.Test/Repo': HTTP 500 Internal Server Error"

To support This case we check if projectId have dot inside of it
if it has execute getSingleProject request and extract Integer projectId to operate with
if it hasn't use prepared projectId(Namespace + ProjectName)

Fix Issue https://github.com/jenkinsci/gitlab-plugin/issues/326
