### PR TITLE
add issue template, relates to #341

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+### Before submitting an issue to I have first:
+
+- [] read the documentation on the [homepage](https://github.com/jenkinsci/gitlab-plugin) 
+- [] searched for similar already existing issue
+
+*(if you have performed all the above, remove the paragraph and continue describing the issue with template below)*
+
+## Issue
+
+### Context
+- **Gitlab plugin version**: X.Y.Z
+- **Gitlab version**: X.Y.Z
+- **Jenkins version**: X.Y.Z
+
+### Logs & Traces
+
+_Please include any relevant log that could serve to better understand the source of your issue_
+For Jenkins Gitlab Plugin logs, follow instruction in [User Support section](https://github.com/jenkinsci/gitlab-plugin#user-support).
+For Gitlab logs, ask an administrator to provide you the relevant Gitlab logs.
+
+### Problem description
+
+_Describe your problem in a meaningful way_:
+- what were you doing (simple push, merge request, MR with fork, ...)
+- what was expected
+- what occured finally


### PR DESCRIPTION
As described in #341 guiding reporters is a good thing.
Find enclosed a first version of a possible issue template.

Example on other project:
- https://github.com/gitbucket/gitbucket/tree/master/.github

Github docs:
- https://help.github.com/articles/setting-guidelines-for-repository-contributors/
- https://help.github.com/articles/creating-an-issue-template-for-your-repository/
