### PR TITLE
Create pull request template #351

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+### Before submitting a pull request, please make sure you read the instructions in the ["Contribution to the Plugin"](https://github.com/jenkinsci/gitlab-plugin/tree/master#contributing-to-the-plugin) section in the README.
+
+*(if you read the above instructions, remove the paragraph and start describing the pull request)*


### PR DESCRIPTION
Most pull request submitters do not read the _Contribution to the Plugin_ 
section containing information aiming at improving the quality of the plugin 
and facilitating its maintenance. This template should point the submitters 
to that section when submitting a pull request.
