### PR TITLE
Updated readme with instructions to fetch MRs from origin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ To enable this functionality, a user should be set up on GitLab, with GitLab 'De
 
 ## Jenkins Job Configuration
 ### Git configuration for Freestyle jobs
+#### GitLab < 8.1
 1. In the *Source Code Management* section:
     1. Click *Git*
     2. Enter your *Repository URL* (e.g.: ``git@your.gitlab.server:group/repo_name.git``)
@@ -82,6 +83,22 @@ To enable this functionality, a user should be set up on GitLab, with GitLab 'De
     4. In *Branch Specifier* enter:
       * For single-repository setups: ``origin/${gitlabSourceBranch}``
       * For forked repository setups: ``${gitlabSourceRepoName}/${gitlabSourceBranch}``
+    5. In *Additional Behaviours*:
+        * Click the *Add* drop-down button.
+        * Select *Merge before build* from the drop-down.
+        * Set *Name of the repository" to ``origin`` 
+        * Set *Branch to merge* as ``${gitlabTargetBranch}``
+
+#### GitLab >= 8.1
+1. In the *Source Code Management* section:
+    1. Click *Git*
+    2. Enter your *Repository URL* (e.g.: ``git@your.gitlab.server:group/repo_name.git``)
+      * In the Advanced settings, set its *Name* to ``origin`` and its *refspec* to ``+refs/heads/*:refs/remotes/origin/* +refs/merge-requests/*/head:refs/remotes/origin/merge-requests/*``
+    3. To be able to merge from forked repositories:  <br/>**Note:** this requires [configuring communication to the GitLab server](#configuring-access-to-gitlab)
+      * Add a second repository with:
+        * *URL*: Your *Repository URL* as in the previous step (e.g.: ``git@your.gitlab.server:group/repo_name.git``)
+    4. In *Branch Specifier* enter:
+      * ``merge-requests/${gitlabMergeRequestIid}``
     5. In *Additional Behaviours*:
         * Click the *Add* drop-down button.
         * Select *Merge before build* from the drop-down.


### PR DESCRIPTION
In my pursue of wrapping up #285, I realised that it's possible to achieve the same effect (i.e. fetching Merge Requests from the `upstream` repository) just by means of adjusting the configuration a little bit.
This Readme changes reflect that, and doesn't carry the current limitations in #285 (re-build open MRs, etc.)
