### PR TITLE
Fix unit test failures

### DIFF
--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
@@ -15,6 +15,7 @@ import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -121,6 +122,10 @@ public class MergeRequestHookTriggerHandlerImplTest {
                                 .withHttpUrl("https://gitlab.org/test.git")
                                 .build())
                         .build())
+                .withProject(project()
+                    .withWebUrl("https://gitlab.org/test.git")
+                    .build()
+                )
                 .build(), true, BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)));
 
         buildTriggered.block(10000);

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
@@ -15,7 +15,6 @@ import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImplTest.java
@@ -140,6 +140,7 @@ public class NoteHookTriggerHandlerImplTest {
                         .withUrl("git@gitlab.org:test.git")
                         .withSshUrl("git@gitlab.org:test.git")
                         .withHttpUrl("https://gitlab.org/test.git")
+                        .withWebUrl("https://gitlab.org/test.git")
                         .build())
                     .build())
                 .build(), true, BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)));

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImplTest.java
@@ -105,6 +105,7 @@ public class PushHookTriggerHandlerImplTest {
                         .build())
                 .withProject(project()
                         .withNamespace("test-namespace")
+                        .withWebUrl("https://gitlab.org/test")
                         .build())
                 .withAfter(commit.name())
                 .withRef("refs/heads/" + git.nameRev().add(head).call().get(head))


### PR DESCRIPTION
The fix for #69 introduced three failing unit tests, due to a new required parameter in CauseData.

The PullRequest fixes these 3 unit tests by adding the required parameters.
