### PR TITLE
Increased concurrency of publisher

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisher.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisher.java
@@ -32,7 +32,7 @@ public class GitLabCommitStatusPublisher extends Notifier {
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     @Override


### PR DESCRIPTION
Dropped the publisher's locking requirements so that jobs complete instantly instead of waiting for all builds of the same job currently executing to finish.

Referencing issue: https://github.com/jenkinsci/gitlab-plugin/issues/396

Tested manually with GitLab version 8.8.2 and Jenkins version 1.650.

Would like feedback on this change, as I might have just been lucky with the testing :smile: 
