### PR TITLE
Fix gitlabBuilds step to actually use 'pending'

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabBuildsStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabBuildsStep.java
@@ -69,7 +69,7 @@ public class GitLabBuildsStep extends AbstractStepImpl {
                     @Override
                     public void onStart(StepContext context) {
                         for (String name : step.builds) {
-                            CommitStatusUpdater.updateCommitStatus(run, getTaskListener(context), BuildState.running, name);
+                            CommitStatusUpdater.updateCommitStatus(run, getTaskListener(context), BuildState.pending, name);
                         }
                         run.addAction(new PendingBuildsAction(new ArrayList<>(step.builds)));
                     }


### PR DESCRIPTION
Noticed that the gitlabBuilds step would set all the given builds to 'running' instead of 'pending', simple fix.
