### PR TITLE
Fallback to plugin for Git data if no data found in builds

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
@@ -105,6 +105,7 @@ public final class CauseData {
         variables.put("gitlabTargetRepoHttpUrl", targetRepoHttpUrl);
         variables.put("gitlabBefore", before);
         variables.put("gitlabAfter", after);
+        variables.put("gitlabLastCommitId", lastCommit);
         return variables;
     }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -123,7 +123,7 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
     private boolean isLastCommitNotYetBuild(Job<?, ?> project, MergeRequestHook hook) {
         MergeRequestObjectAttributes objectAttributes = hook.getObjectAttributes();
         if (objectAttributes != null && objectAttributes.getLastCommit() != null) {
-            Run<?, ?> mergeBuild = BuildUtil.getBuildBySHA1IncludingMergeBuilds(project, objectAttributes.getLastCommit().getId());
+            Run<?, ?> mergeBuild = BuildUtil.getBuildBySHA1(project, objectAttributes.getLastCommit().getId());
             if (mergeBuild != null && StringUtils.equals(getTargetBranchFromBuild(mergeBuild), objectAttributes.getTargetBranch())) {
                 LOGGER.log(Level.INFO, "Last commit in Merge Request has already been built in build #" + mergeBuild.getNumber());
                 return false;

--- a/src/main/java/com/dabsquared/gitlabjenkins/util/BuildUtil.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/BuildUtil.java
@@ -1,59 +1,119 @@
 package com.dabsquared.gitlabjenkins.util;
 
+import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.util.BuildData;
 import hudson.plugins.git.util.MergeRecord;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author Robin Müller
  */
 public class BuildUtil {
+    
     public static Run<?, ?> getBuildByBranch(Job<?, ?> project, String branchName) {
-        for (Run<?, ?> build : project.getBuilds()) {
-            BuildData data = build.getAction(BuildData.class);
-            MergeRecord merge = build.getAction(MergeRecord.class);
-            if (hasLastBuild(data) && isNoMergeBuild(data, merge)) {
-                for (Branch branch : data.lastBuild.getRevision().getBranches()) {
-                    if (branch.getName().endsWith("/" + branchName)) {
-                        return build;
-                    }
-                }
+        for (final Run<?, ?> build : project.getBuilds()) {
+            final BuildData data = build.getAction(BuildData.class);
+            final MergeRecord merge = build.getAction(MergeRecord.class);
+            final List<String> potentialBranchNames = new ArrayList<>();
+            if (hasLastBuildFromGitData(data) && isNoMergeBuild(data, merge)) {
+                getBranchNamesFromGitData(data, potentialBranchNames);
+            } else {
+                potentialBranchNames.addAll(getBranchNamesFromHook(build));
+            }
+
+            if (branchFound(branchName, potentialBranchNames)) {
+                return build;
             }
         }
         return null;
+    }
+
+    private static boolean branchFound(final String branchName, final List<String> branchNames) {
+        for (final String potentialBranchName : branchNames) {
+            if (potentialBranchName.endsWith("/" + branchName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void getBranchNamesFromGitData(final BuildData data, final List<String> branchNames) {
+        for (final Branch branch : data.lastBuild.getRevision().getBranches()) {
+            branchNames.add(branch.getName());
+        }
+    }
+
+    private static List<String> getBranchNamesFromHook(final Run<?, ?> build) {
+        final List<String> branchNames = new ArrayList<>();
+        final GitLabWebHookCause cause = build.getCause(GitLabWebHookCause.class);
+        if (cause != null) {
+            branchNames.add(cause.getData().getBranch());
+            branchNames.add(cause.getData().getSourceBranch());
+            branchNames.add(cause.getData().getTargetBranch());
+        }
+        return branchNames;
     }
 
     public static Run<?, ?> getBuildBySHA1WithoutMergeBuilds(Job<?, ?> project, String sha1) {
         for (Run<?, ?> build : project.getBuilds()) {
             BuildData data = build.getAction(BuildData.class);
             MergeRecord merge = build.getAction(MergeRecord.class);
-            if (hasLastBuild(data) && isNoMergeBuild(data, merge) && data.lastBuild.isFor(sha1)) {
+            if (isNoMergeBuild(data, merge) && revisionFound(sha1, build, data)) {
                 return build;
             }
         }
         return null;
     }
 
+    private static boolean revisionFound(final String sha1, final Run<?, ?> build, final BuildData data) {
+        return (hasLastBuildFromGitData(data) && data.lastBuild.isFor(sha1))|| revisionFoundFromHookData(sha1, build);
+    }
+
     public static Run<?, ?> getBuildBySHA1IncludingMergeBuilds(Job<?, ?> project, String sha1) {
         for (Run<?, ?> build : project.getBuilds()) {
-            BuildData data = build.getAction(BuildData.class);
-            if (data != null
-                && data.lastBuild != null
-                && data.lastBuild.getMarked() != null
-                && data.lastBuild.getMarked().getSha1String().equals(sha1)) {
+            if (revisionFoundFromGitData(sha1, build)) {
+                return build;
+            }
+
+            //also try to retrieve builds via the hook to allow for jobs to work without a Git setup
+            if (revisionFoundFromHookData(sha1, build)) {
                 return build;
             }
         }
         return null;
+    }
+
+    private static boolean revisionFoundFromHookData(final String sha1, final Run<?, ?> build) {
+        final GitLabWebHookCause cause = build.getCause(GitLabWebHookCause.class);
+        if (cause != null) {
+            final String lastCommit = cause.getData().getLastCommit();
+
+            if (lastCommit != null && lastCommit.equals(sha1)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean revisionFoundFromGitData(final String sha1, final Run<?, ?> build) {
+        //slight difference - this uses the marked revision, which according to Jenkins docs might differ slightly from revision used above (due to merges etc)
+        final BuildData data = build.getAction(BuildData.class);
+        return data != null
+            && data.lastBuild != null
+            && data.lastBuild.getMarked() != null
+            && data.lastBuild.getMarked().getSha1String().equals(sha1);
     }
 
     private static boolean isNoMergeBuild(BuildData data, MergeRecord merge) {
         return merge == null || merge.getSha1().equals(data.lastBuild.getMarked().getSha1String());
     }
-
-    private static boolean hasLastBuild(BuildData data) {
+    
+    private static boolean hasLastBuildFromGitData(BuildData data) {
         return data != null && data.lastBuild != null && data.lastBuild.getRevision() != null;
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/CommitBuildPageRedirectAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/CommitBuildPageRedirectAction.java
@@ -8,6 +8,6 @@ import hudson.model.Job;
  */
 public class CommitBuildPageRedirectAction extends BuildPageRedirectAction {
     public CommitBuildPageRedirectAction(Job<?, ?> project, String sha1) {
-        super(BuildUtil.getBuildBySHA1IncludingMergeBuilds(project, sha1));
+        super(BuildUtil.getBuildBySHA1(project, sha1));
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/CommitStatusPngAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/CommitStatusPngAction.java
@@ -8,6 +8,6 @@ import hudson.model.Job;
  */
 public class CommitStatusPngAction extends StatusPngAction {
     public CommitStatusPngAction(Job<?, ?> project, String sha1) {
-        super(project, BuildUtil.getBuildBySHA1WithoutMergeBuilds(project, sha1));
+        super(project, BuildUtil.getBuildBySHA1(project, sha1));
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/StatusJsonAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/StatusJsonAction.java
@@ -18,7 +18,7 @@ public class StatusJsonAction extends BuildStatusAction {
     private String sha1;
 
     public StatusJsonAction(Job<?, ?> project, String sha1) {
-        super(project, BuildUtil.getBuildBySHA1IncludingMergeBuilds(project, sha1));
+        super(project, BuildUtil.getBuildBySHA1(project, sha1));
         this.sha1 = sha1;
     }
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/BuildNotifier.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/BuildNotifier.java
@@ -1,0 +1,38 @@
+package com.dabsquared.gitlabjenkins.testhelpers;
+
+import com.dabsquared.gitlabjenkins.trigger.handler.merge.LockWrapper;
+import hudson.model.AbstractBuild;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class BuildNotifier {
+    private final LockWrapper lock;
+    private List<AbstractBuild> builds;
+
+    public BuildNotifier(final LockWrapper lock) {
+        this.lock = lock;
+        builds = new ArrayList<>();
+    }
+
+    public int getNumberOfBuildsTriggered() {
+        return builds.size();
+    }
+
+    public List<AbstractBuild> getBuildsTriggered() {
+        return Collections.unmodifiableList(builds);
+    }
+
+    public LockWrapper getLock() {
+        return lock;
+    }
+
+    public void addBuild(AbstractBuild<?, ?> build) {
+        builds.add(build);
+    }
+
+    public AbstractBuild getLastTriggeredBuild() {
+        return builds.isEmpty() ? null : builds.get(builds.size()-1);
+    }
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/HookTrigger.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/HookTrigger.java
@@ -1,0 +1,112 @@
+package com.dabsquared.gitlabjenkins.testhelpers;
+
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
+import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
+import com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterFactory;
+import com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterType;
+import com.dabsquared.gitlabjenkins.trigger.handler.merge.MergeRequestHookTriggerHandlerFactory;
+import com.google.common.base.Predicate;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.revwalk.RevCommit;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.CommitBuilder.commit;
+import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.MergeRequestHookBuilder.mergeRequestHook;
+import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.MergeRequestObjectAttributesBuilder.mergeRequestObjectAttributes;
+import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.ProjectBuilder.project;
+import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.UserBuilder.user;
+import static com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterConfig.BranchFilterConfigBuilder.branchFilterConfig;
+
+/**
+ * Intended to be the primary means to start off a merge request hook for testing purposes.
+ * Required if plugin logic needs to be tested - Jenkins-initiated scheduled builds will not
+ * have the necessary data for the plugin to function.
+ *
+ * @author benjie332
+ */
+public class HookTrigger {
+
+    public static void triggerHookSynchronously(ProjectSetupResult project,
+                                                Git git,
+                                                RevCommit lastCommit) throws InterruptedException, GitAPIException, IOException {
+
+        triggerHook(project, git, lastCommit, true);
+
+    }
+
+    public static void triggerHookWithoutWaitingForResult(ProjectSetupResult project,
+                                                          Git git,
+                                                          RevCommit lastCommit) throws InterruptedException, GitAPIException, IOException {
+        triggerHook(project, git, lastCommit, false);
+    }
+
+    private static void triggerHook(ProjectSetupResult project,
+                                   Git git,
+                                   RevCommit lastCommit,
+                                   boolean blocking) throws IOException, GitAPIException, InterruptedException {
+        ObjectId head = git.getRepository().resolve(Constants.HEAD);
+
+        MergeRequestHookTriggerHandlerFactory.newMergeRequestHookTriggerHandler(true, TriggerOpenMergeRequest.source, false).handle(project.getTestProject(), mergeRequestHook()
+            .withProject(project().withWebUrl("https://gitlab.org/test.git").build())
+            .withObjectAttributes(mergeRequestObjectAttributes()
+                .withTargetBranch("refs/heads/" + git.nameRev().add(head).call().get(head))
+                .withState(State.opened)
+                .withIid(1)
+                .withTitle("test")
+                .withTargetProjectId(1)
+                .withSourceProjectId(1)
+                .withSourceBranch("feature")
+                .withTargetBranch("master")
+                .withUrl("https://gitlab.org/test.git")
+                .withLastCommit(commit().withAuthor(user().withName("test").build()).withId(lastCommit.getName()).build())
+                .withSource(project()
+                    .withName("test")
+                    .withNamespace("test-namespace")
+                    .withHomepage("https://gitlab.org/test")
+                    .withUrl("git@gitlab.org:test.git")
+                    .withSshUrl("git@gitlab.org:test.git")
+                    .withHttpUrl("https://gitlab.org/test.git")
+                    .withWebUrl("https://gitlab.org/test.git")
+                    .build())
+                .withTarget(project()
+                    .withName("test")
+                    .withNamespace("test-namespace")
+                    .withHomepage("https://gitlab.org/test")
+                    .withUrl("git@gitlab.org:test.git")
+                    .withSshUrl("git@gitlab.org:test.git")
+                    .withHttpUrl("https://gitlab.org/test.git")
+                    .withWebUrl("https://gitlab.org/test.git")
+                    .build())
+                .build())
+            .build(),
+            false,
+            BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)));
+
+        if (blocking) {
+            //wait for hook to register build event - intended to make sure the trigger actually fires a build
+            project.getBuildNotifier().getLock().block(5000);
+            //....here we actually wait for the result of the build
+            blockUntilRunComplete(project.getTestProject());
+        }
+    }
+
+    private static void blockUntilRunComplete(FreeStyleProject testProject) throws InterruptedException {
+        int retries = 0;
+        while(testProject.getBuilds().filter(new Predicate<FreeStyleBuild>() {
+            @Override
+            public boolean apply(@Nullable FreeStyleBuild freeStyleBuild) {
+                return (freeStyleBuild != null && !freeStyleBuild.isBuilding());
+            }
+        }).isEmpty() || retries < 5) {
+            Thread.sleep(500L);
+            retries++;
+        }
+    }
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/JenkinsProjectTestFactory.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/JenkinsProjectTestFactory.java
@@ -1,0 +1,46 @@
+package com.dabsquared.gitlabjenkins.testhelpers;
+
+import com.dabsquared.gitlabjenkins.trigger.handler.merge.LockWrapper;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleProject;
+import hudson.model.Project;
+import hudson.plugins.git.GitSCM;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+
+import java.io.IOException;
+
+/**
+ * Factory to create Jenkins projects suitable for tests. Useful to avoid needless boilerplate.
+ *
+ * @author benjie332
+ */
+public class JenkinsProjectTestFactory {
+
+    public ProjectSetupResult createProject(final JenkinsRule jenkins,
+                                            final String gitRepoUrl) throws IOException {
+        final FreeStyleProject testProject = jenkins.createFreeStyleProject("test");
+        testProject.setScm(new GitSCM(gitRepoUrl));
+        testProject.setQuietPeriod(0);
+
+        final BuildNotifier buildNotifier = addNotifier(testProject);
+
+        return new ProjectSetupResult(testProject, buildNotifier);
+    }
+
+    private BuildNotifier addNotifier(Project<FreeStyleProject, hudson.model.FreeStyleBuild> project) throws IOException {
+            final BuildNotifier buildNotifier = new BuildNotifier(new LockWrapper());
+            project.getBuildersList().add(new TestBuilder() {
+                @Override
+                public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+
+                    buildNotifier.addBuild(build);
+                    buildNotifier.getLock().signal();
+                    return true;
+                }
+            });
+            return buildNotifier;
+        }
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/ProjectSetupResult.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/ProjectSetupResult.java
@@ -1,0 +1,23 @@
+package com.dabsquared.gitlabjenkins.testhelpers;
+
+import hudson.model.FreeStyleProject;
+
+public class ProjectSetupResult {
+
+    private FreeStyleProject testProject;
+    private BuildNotifier buildNotifier;
+
+    public ProjectSetupResult(FreeStyleProject testProject, BuildNotifier buildNotifier) {
+        this.testProject = testProject;
+        this.buildNotifier = buildNotifier;
+    }
+
+    public FreeStyleProject getTestProject() {
+        return testProject;
+    }
+
+    public BuildNotifier getBuildNotifier() {
+        return buildNotifier;
+    }
+
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/LockWrapper.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/LockWrapper.java
@@ -1,0 +1,36 @@
+package com.dabsquared.gitlabjenkins.trigger.handler.merge;
+
+/**
+ * A wrapper offering some easy-to-use methods for blocking.
+ * Primarily intended for testing multiple builds - the original inspiration was a "multi" version of {@link hudson.util.OneShotEvent}.
+ *
+ * @author benjie.gatt
+ */
+public final class LockWrapper {
+
+    private final Object lock;
+    
+    public LockWrapper() {
+        this.lock = this;
+    }
+    
+    /**
+     * Non-blocking method that signals this event.
+     */
+    public void signal() {
+        synchronized (lock) {
+            lock.notifyAll();
+        }
+    }
+    
+    /**
+     * Blocks until the event becomes the signaled state.
+     *
+     * If the specified amount of time elapses, this method returns null even if the value isn't offered.
+     */
+    public void block(long timeout) throws InterruptedException {
+        synchronized (lock) {
+            lock.wait(timeout);
+        }
+    }
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
@@ -6,6 +6,7 @@ import com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterType;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.plugins.git.GitSCM;
 import hudson.util.OneShotEvent;
@@ -32,6 +33,9 @@ import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.P
 import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.UserBuilder.user;
 import static com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterConfig.BranchFilterConfigBuilder.branchFilterConfig;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -130,4 +134,208 @@ public class MergeRequestHookTriggerHandlerImplTest {
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(true));
     }
+
+    @Test
+    public void mergeRequestUpdated_noGitSCMSet_alreadyBuilt_noBuildTriggered() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        Git.init().setDirectory(tmp.getRoot()).call();
+        tmp.newFile("test");
+        Git git = Git.open(tmp.getRoot());
+        git.add().addFilepattern("test");
+        RevCommit commit = git.commit().setMessage("test").call();
+        ObjectId head = git.getRepository().resolve(Constants.HEAD);
+
+        final FreeStyleProject project = jenkins.createFreeStyleProject();
+        final BuildNotifier buildNotifier = setupProjectWithNoGitScm(project);
+        assertThat(project.getLastBuild(), nullValue());
+
+        mergeRequestHookTriggerHandler.handle(project, mergeRequestHook()
+            .withObjectAttributes(mergeRequestObjectAttributes()
+                .withTargetBranch("refs/heads/" + git.nameRev().add(head).call().get(head))
+                .withState(State.opened)
+                .withIid(1)
+                .withTitle("test")
+                .withTargetProjectId(1)
+                .withSourceProjectId(1)
+                .withSourceBranch("feature")
+                .withTargetBranch("master")
+                .withLastCommit(commit().withAuthor(user().withName("test").build()).withId(commit.getName()).build())
+                .withSource(project()
+                    .withName("test")
+                    .withNamespace("test-namespace")
+                    .withHomepage("https://gitlab.org/test")
+                    .withUrl("git@gitlab.org:test.git")
+                    .withSshUrl("git@gitlab.org:test.git")
+                    .withHttpUrl("https://gitlab.org/test.git")
+                    .build())
+                .withTarget(project()
+                    .withName("test")
+                    .withNamespace("test-namespace")
+                    .withHomepage("https://gitlab.org/test")
+                    .withUrl("git@gitlab.org:test.git")
+                    .withSshUrl("git@gitlab.org:test.git")
+                    .withHttpUrl("https://gitlab.org/test.git")
+                    .build())
+                .build())
+            .build(), false, BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)));
+
+        final FreeStyleBuild lastBuild = assertFirstBuildTriggered(project, buildNotifier);
+
+        mergeRequestHookTriggerHandler.handle(project, mergeRequestHook()
+            .withObjectAttributes(mergeRequestObjectAttributes()
+                .withTargetBranch("refs/heads/" + git.nameRev().add(head).call().get(head))
+                .withState(State.opened)
+                .withIid(1)
+                .withTitle("BRAND NEW TITLE")
+                .withTargetProjectId(1)
+                .withSourceProjectId(1)
+                .withSourceBranch("feature")
+                .withTargetBranch("master")
+                .withLastCommit(commit().withAuthor(user().withName("test").build()).withId(commit.getName()).build())
+                .withSource(project()
+                    .withName("test")
+                    .withNamespace("test-namespace")
+                    .withHomepage("https://gitlab.org/test")
+                    .withUrl("git@gitlab.org:test.git")
+                    .withSshUrl("git@gitlab.org:test.git")
+                    .withHttpUrl("https://gitlab.org/test.git")
+                    .build())
+                .withTarget(project()
+                    .withName("test")
+                    .withNamespace("test-namespace")
+                    .withHomepage("https://gitlab.org/test")
+                    .withUrl("git@gitlab.org:test.git")
+                    .withSshUrl("git@gitlab.org:test.git")
+                    .withHttpUrl("https://gitlab.org/test.git")
+                    .build())
+                .build())
+            .build(), false, BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)));
+
+        buildNotifier.getLock().block(10000);
+        assertThat(project.getLastBuild(), is(lastBuild));
+    }
+
+    @Test
+    public void mergeRequestUpdated_noGitSCMSet_newCommit_buildTriggered() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        Git.init().setDirectory(tmp.getRoot()).call();
+        tmp.newFile("test");
+        Git git = Git.open(tmp.getRoot());
+        git.add().addFilepattern("test");
+        RevCommit commit = git.commit().setMessage("test").call();
+        ObjectId head = git.getRepository().resolve(Constants.HEAD);
+
+        final FreeStyleProject project = jenkins.createFreeStyleProject();
+        assertThat(project.getLastBuild(), nullValue());
+
+        final BuildNotifier buildNotifier = setupProjectWithNoGitScm(project);
+
+        mergeRequestHookTriggerHandler.handle(project, mergeRequestHook()
+            .withObjectAttributes(mergeRequestObjectAttributes()
+                .withTargetBranch("refs/heads/" + git.nameRev().add(head).call().get(head))
+                .withState(State.opened)
+                .withIid(1)
+                .withTitle("test")
+                .withTargetProjectId(1)
+                .withSourceProjectId(1)
+                .withSourceBranch("feature")
+                .withTargetBranch("master")
+                .withLastCommit(commit().withAuthor(user().withName("test").build()).withId(commit.getName()).build())
+                .withSource(project()
+                    .withName("test")
+                    .withNamespace("test-namespace")
+                    .withHomepage("https://gitlab.org/test")
+                    .withUrl("git@gitlab.org:test.git")
+                    .withSshUrl("git@gitlab.org:test.git")
+                    .withHttpUrl("https://gitlab.org/test.git")
+                    .build())
+                .withTarget(project()
+                    .withName("test")
+                    .withNamespace("test-namespace")
+                    .withHomepage("https://gitlab.org/test")
+                    .withUrl("git@gitlab.org:test.git")
+                    .withSshUrl("git@gitlab.org:test.git")
+                    .withHttpUrl("https://gitlab.org/test.git")
+                    .build())
+                .build())
+            .build(), false, BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)));
+
+        final FreeStyleBuild lastBuild = assertFirstBuildTriggered(project, buildNotifier);
+
+        mergeRequestHookTriggerHandler.handle(project, mergeRequestHook()
+            .withObjectAttributes(mergeRequestObjectAttributes()
+                .withTargetBranch("refs/heads/" + git.nameRev().add(head).call().get(head))
+                .withState(State.opened)
+                .withIid(1)
+                .withTitle("test")
+                .withTargetProjectId(1)
+                .withSourceProjectId(1)
+                .withSourceBranch("feature")
+                .withTargetBranch("master")
+                .withLastCommit(commit().withAuthor(user().withName("test").build()).withId("NEW COMMIT ID").build())
+                .withSource(project()
+                    .withName("test")
+                    .withNamespace("test-namespace")
+                    .withHomepage("https://gitlab.org/test")
+                    .withUrl("git@gitlab.org:test.git")
+                    .withSshUrl("git@gitlab.org:test.git")
+                    .withHttpUrl("https://gitlab.org/test.git")
+                    .build())
+                .withTarget(project()
+                    .withName("test")
+                    .withNamespace("test-namespace")
+                    .withHomepage("https://gitlab.org/test")
+                    .withUrl("git@gitlab.org:test.git")
+                    .withSshUrl("git@gitlab.org:test.git")
+                    .withHttpUrl("https://gitlab.org/test.git")
+                    .build())
+                .build())
+            .build(), false, BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)));
+
+        buildNotifier.getLock().block(10000);
+        assertThat(project.getLastBuild(), not(is(lastBuild)));
+    }
+
+    private BuildNotifier setupProjectWithNoGitScm(final FreeStyleProject project) throws IOException {
+        final BuildNotifier buildNotifier = new BuildNotifier(0, new LockWrapper());
+        project.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                buildNotifier.addBuild();
+                buildNotifier.getLock().signal();
+                return true;
+            }
+        });
+        project.setQuietPeriod(0);
+        return buildNotifier;
+    }
+
+    private class BuildNotifier {
+        private int buildsTriggered;
+        private final LockWrapper lock;
+
+        public BuildNotifier(final int buildsTriggered, final LockWrapper lock) {
+            this.buildsTriggered = buildsTriggered;
+            this.lock = lock;
+        }
+
+        public int getBuildsTriggered() {
+            return buildsTriggered;
+        }
+
+        public LockWrapper getLock() {
+            return lock;
+        }
+
+        public void addBuild() {
+            buildsTriggered++;
+        }
+    }
+	
+	 private FreeStyleBuild assertFirstBuildTriggered(final FreeStyleProject project, final BuildNotifier buildNotifier) throws InterruptedException {
+        buildNotifier.getLock().block(10000);
+        assertThat(buildNotifier.getBuildsTriggered(), is(1));
+        final FreeStyleBuild lastBuild = project.getLastBuild();
+        assertThat(lastBuild, notNullValue());
+        return lastBuild;
+    }
+
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/BuildStatusActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/BuildStatusActionTest.java
@@ -1,5 +1,12 @@
 package com.dabsquared.gitlabjenkins.webhook.status;
 
+import com.dabsquared.gitlabjenkins.testhelpers.HookTrigger;
+import com.dabsquared.gitlabjenkins.testhelpers.JenkinsProjectTestFactory;
+import com.dabsquared.gitlabjenkins.testhelpers.ProjectSetupResult;
+import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
+import com.dabsquared.gitlabjenkins.trigger.handler.merge.MergeRequestHookTriggerHandler;
+import com.dabsquared.gitlabjenkins.trigger.handler.merge.MergeRequestHookTriggerHandlerFactory;
+import com.google.common.base.Predicate;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
@@ -9,6 +16,9 @@ import hudson.model.Result;
 import hudson.plugins.git.GitSCM;
 import hudson.util.OneShotEvent;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.Before;
 import org.junit.Rule;
@@ -21,6 +31,7 @@ import org.kohsuke.stapler.StaplerResponse;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import javax.annotation.Nullable;
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import java.io.ByteArrayOutputStream;
@@ -48,58 +59,59 @@ public abstract class BuildStatusActionTest {
     @Mock
     private StaplerResponse response;
 
-    private String gitRepoUrl;
+    private ProjectSetupResult result;
+    private Git git;
+    private RevCommit commit;
 
     @Before
     public void setup() throws Exception {
         Git.init().setDirectory(tmp.getRoot()).call();
         tmp.newFile("test");
-        Git git = Git.open(tmp.getRoot());
+        git = Git.open(tmp.getRoot());
         git.add().addFilepattern("test");
-        RevCommit commit = git.commit().setMessage("test").call();
+        commit = git.commit().setMessage("test").call();
         commitSha1 = commit.getId().getName();
-        gitRepoUrl = tmp.getRoot().toURI().toString();
+        String gitRepoUrl = tmp.getRoot().toURI().toString();
+
+        result = new JenkinsProjectTestFactory().createProject(jenkins, gitRepoUrl);
+
     }
 
     @Test
-    public void successfulBuild() throws IOException, ExecutionException, InterruptedException {
-        FreeStyleProject testProject = jenkins.createFreeStyleProject("test");
-        testProject.setScm(new GitSCM(gitRepoUrl));
-        FreeStyleBuild build = testProject.scheduleBuild2(0).get();
+    public void successfulBuild() throws IOException, ExecutionException, InterruptedException, GitAPIException {
+        HookTrigger.triggerHookSynchronously(result, git, commit);
+        FreeStyleBuild build = (FreeStyleBuild) result.getBuildNotifier().getLastTriggeredBuild();
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         mockResponse(out);
-        getBuildStatusAction(testProject).execute(response);
+        getBuildStatusAction(result.getTestProject()).execute(response);
 
         assertSuccessfulBuild(build, out, response);
     }
 
     @Test
-    public void failedBuild() throws IOException, ExecutionException, InterruptedException {
-        FreeStyleProject testProject = jenkins.createFreeStyleProject("test");
-        testProject.setScm(new GitSCM(gitRepoUrl));
-        testProject.getBuildersList().add(new TestBuilder() {
+    public void failedBuild() throws IOException, ExecutionException, InterruptedException, GitAPIException {
+        result.getTestProject().getBuildersList().add(new TestBuilder() {
             @Override
             public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
                 build.setResult(Result.FAILURE);
                 return true;
             }
         });
-        FreeStyleBuild build = testProject.scheduleBuild2(0).get();
+        HookTrigger.triggerHookSynchronously(result, git, commit);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         mockResponse(out);
-        getBuildStatusAction(testProject).execute(response);
+        getBuildStatusAction(result.getTestProject()).execute(response);
 
-        assertFailedBuild(build, out, response);
+        assertFailedBuild(result.getBuildNotifier().getLastTriggeredBuild(), out, response);
     }
 
     @Test
-    public void runningBuild() throws IOException, ExecutionException, InterruptedException {
+    public void runningBuild() throws IOException, ExecutionException, InterruptedException, GitAPIException {
         final OneShotEvent buildStarted = new OneShotEvent();
         final OneShotEvent keepRunning = new OneShotEvent();
-        FreeStyleProject testProject = jenkins.createFreeStyleProject("test");
-        testProject.setScm(new GitSCM(gitRepoUrl));
+        final FreeStyleProject testProject = result.getTestProject();
         testProject.getBuildersList().add(new TestBuilder() {
             @Override
             public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
@@ -108,7 +120,7 @@ public abstract class BuildStatusActionTest {
                 return true;
             }
         });
-        FreeStyleBuild build = testProject.scheduleBuild2(0).waitForStart();
+        HookTrigger.triggerHookWithoutWaitingForResult(result, git, commit);
         buildStarted.block();
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -116,13 +128,12 @@ public abstract class BuildStatusActionTest {
         getBuildStatusAction(testProject).execute(response);
         keepRunning.signal();
 
-        assertRunningBuild(build, out, response);
+        assertRunningBuild(result.getBuildNotifier().getLastTriggeredBuild(), out, response);
     }
 
     @Test
-    public void canceledBuild() throws IOException, ExecutionException, InterruptedException, ServletException {
-        FreeStyleProject testProject = jenkins.createFreeStyleProject("test");
-        testProject.setScm(new GitSCM(gitRepoUrl));
+    public void canceledBuild() throws IOException, ExecutionException, InterruptedException, ServletException, GitAPIException {
+        final FreeStyleProject testProject = result.getTestProject();
         testProject.getBuildersList().add(new TestBuilder() {
             @Override
             public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
@@ -134,19 +145,18 @@ public abstract class BuildStatusActionTest {
                 return true;
             }
         });
-        FreeStyleBuild build = testProject.scheduleBuild2(0).get();
+        HookTrigger.triggerHookSynchronously(result, git, commit);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         mockResponse(out);
         getBuildStatusAction(testProject).execute(response);
 
-        assertCanceledBuild(build, out, response);
+        assertCanceledBuild(result.getBuildNotifier().getLastTriggeredBuild(), out, response);
     }
 
     @Test
-    public void unstableBuild() throws IOException, ExecutionException, InterruptedException, ServletException {
-        FreeStyleProject testProject = jenkins.createFreeStyleProject("test");
-        testProject.setScm(new GitSCM(gitRepoUrl));
+    public void unstableBuild() throws IOException, ExecutionException, InterruptedException, ServletException, GitAPIException {
+        final FreeStyleProject testProject = result.getTestProject();
         testProject.getBuildersList().add(new TestBuilder() {
             @Override
             public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
@@ -154,39 +164,36 @@ public abstract class BuildStatusActionTest {
                 return true;
             }
         });
-        FreeStyleBuild build = testProject.scheduleBuild2(0).get();
+
+        HookTrigger.triggerHookSynchronously(result, git, commit);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         mockResponse(out);
         getBuildStatusAction(testProject).execute(response);
 
-        assertUnstableBuild(build, out, response);
+        assertUnstableBuild(result.getBuildNotifier().getLastTriggeredBuild(), out, response);
     }
 
     @Test
     public void notFoundBuild() throws IOException, ExecutionException, InterruptedException {
-        FreeStyleProject testProject = jenkins.createFreeStyleProject("test");
-        testProject.setScm(new GitSCM(gitRepoUrl));
-
-
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
         mockResponse(out);
-        getBuildStatusAction(testProject).execute(response);
+        getBuildStatusAction(result.getTestProject()).execute(response);
 
         assertNotFoundBuild(out, response);
     }
 
     protected abstract BuildStatusAction getBuildStatusAction(FreeStyleProject project);
 
-    protected abstract void assertSuccessfulBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
+    protected abstract void assertSuccessfulBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
 
-    protected abstract void assertFailedBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
+    protected abstract void assertFailedBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
 
-    protected abstract void assertRunningBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
+    protected abstract void assertRunningBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
 
-    protected abstract void assertCanceledBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
+    protected abstract void assertCanceledBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
 
-    protected abstract void assertUnstableBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
+    protected abstract void assertUnstableBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
 
     protected abstract void assertNotFoundBuild(ByteArrayOutputStream out, StaplerResponse response) throws IOException;
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/StatusJsonActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/StatusJsonActionTest.java
@@ -1,6 +1,6 @@
 package com.dabsquared.gitlabjenkins.webhook.status;
 
-import hudson.model.FreeStyleBuild;
+import hudson.model.AbstractBuild;
 import hudson.model.FreeStyleProject;
 import net.sf.json.JSONObject;
 import org.junit.runner.RunWith;
@@ -25,7 +25,7 @@ public class StatusJsonActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertSuccessfulBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) {
+    protected void assertSuccessfulBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) {
         JSONObject object = JSONObject.fromObject(new String(out.toByteArray()));
         assertThat(object.getString("sha"), is(commitSha1));
         assertThat(object.getInt("id"), is(build.getNumber()));
@@ -33,7 +33,7 @@ public class StatusJsonActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertFailedBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) {
+    protected void assertFailedBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) {
         JSONObject object = JSONObject.fromObject(new String(out.toByteArray()));
         assertThat(object.getString("sha"), is(commitSha1));
         assertThat(object.getInt("id"), is(build.getNumber()));
@@ -41,7 +41,7 @@ public class StatusJsonActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertRunningBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) {
+    protected void assertRunningBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) {
         JSONObject object = JSONObject.fromObject(new String(out.toByteArray()));
         assertThat(object.getString("sha"), is(commitSha1));
         assertThat(object.getInt("id"), is(build.getNumber()));
@@ -49,7 +49,7 @@ public class StatusJsonActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertCanceledBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) {
+    protected void assertCanceledBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) {
         JSONObject object = JSONObject.fromObject(new String(out.toByteArray()));
         assertThat(object.getString("sha"), is(commitSha1));
         assertThat(object.getInt("id"), is(build.getNumber()));
@@ -57,7 +57,7 @@ public class StatusJsonActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertUnstableBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
+    protected void assertUnstableBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
         JSONObject object = JSONObject.fromObject(new String(out.toByteArray()));
         assertThat(object.getString("sha"), is(commitSha1));
         assertThat(object.getInt("id"), is(build.getNumber()));

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/StatusPngActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/StatusPngActionTest.java
@@ -1,6 +1,6 @@
 package com.dabsquared.gitlabjenkins.webhook.status;
 
-import hudson.model.FreeStyleBuild;
+import hudson.model.AbstractBuild;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.verify;
 public abstract class StatusPngActionTest extends BuildStatusActionTest {
 
     @Override
-    protected void assertSuccessfulBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
+    protected void assertSuccessfulBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
         verify(response).setHeader("Expires", "Fri, 01 Jan 1984 00:00:00 GMT");
         verify(response).setHeader("Cache-Control", "no-cache, private");
         verify(response).setHeader("Content-Type", "image/png");
@@ -25,7 +25,7 @@ public abstract class StatusPngActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertFailedBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
+    protected void assertFailedBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
         verify(response).setHeader("Expires", "Fri, 01 Jan 1984 00:00:00 GMT");
         verify(response).setHeader("Cache-Control", "no-cache, private");
         verify(response).setHeader("Content-Type", "image/png");
@@ -33,7 +33,7 @@ public abstract class StatusPngActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertRunningBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
+    protected void assertRunningBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
         verify(response).setHeader("Expires", "Fri, 01 Jan 1984 00:00:00 GMT");
         verify(response).setHeader("Cache-Control", "no-cache, private");
         verify(response).setHeader("Content-Type", "image/png");
@@ -41,7 +41,7 @@ public abstract class StatusPngActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertCanceledBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
+    protected void assertCanceledBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
         verify(response).setHeader("Expires", "Fri, 01 Jan 1984 00:00:00 GMT");
         verify(response).setHeader("Cache-Control", "no-cache, private");
         verify(response).setHeader("Content-Type", "image/png");
@@ -49,7 +49,7 @@ public abstract class StatusPngActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertUnstableBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
+    protected void assertUnstableBuild(AbstractBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
         verify(response).setHeader("Expires", "Fri, 01 Jan 1984 00:00:00 GMT");
         verify(response).setHeader("Cache-Control", "no-cache, private");
         verify(response).setHeader("Content-Type", "image/png");


### PR DESCRIPTION
Updated the BuildUtil (and all processes that query builds) to fallback to using the plugin's data regarding Git commits/branches if no Git data is stored with the build. This can occur if the job does not use a Git SCM (such as a multi-job that triggers other jobs).

Otherwise, merge request updates with no change in commit, such as a title change, would be registered as unbuilt by the plugin and trigger a (useless) new build.

Added tests for merge request handler for the case in question, and also manually tested this for Jenkins version 2.7.2 and GitLab version 8.9.1.

Feedback (especially for new tests) is more than welcome! No test failures were introduced with the change.
