### PR TITLE
Added Remove-Accept Encoding Filter

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/GitLabClientBuilder.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/GitLabClientBuilder.java
@@ -90,6 +90,7 @@ public class GitLabClientBuilder {
             .register(new JacksonConfig())
             .register(new ApiHeaderTokenFilter(getApiToken(gitlabApiTokenId)))
             .register(new LoggingFilter())
+            .register(new RemoveAcceptEncodingFilter())
             .build().target(gitlabHostUrl)
             .proxyBuilder(GitLabApi.class)
             .classloader(GitLabApi.class.getClassLoader())
@@ -214,6 +215,15 @@ public class GitLabClientBuilder {
             public String apply(@Nullable Map.Entry<String, List<String>> input) {
                 return input == null ? null : input.getKey() + " = [" + Joiner.on(", ").join(input.getValue()) + "]";
             }
+        }
+    }
+
+    @Priority(Priorities.HEADER_DECORATOR)
+    private static class RemoveAcceptEncodingFilter implements ClientRequestFilter {
+        RemoveAcceptEncodingFilter() {}
+        @Override
+        public void filter(ClientRequestContext clientRequestContext) throws IOException {
+            clientRequestContext.getHeaders().remove("Accept-Encoding");
         }
     }
 


### PR DESCRIPTION
Fix for https://github.com/jenkinsci/gitlab-plugin/issues/407

For unknown reasons the HTTP Requests sometimes sets the Accept-Encoding to "gzip; deflate" which will lead to exceptions in the Jackson-Library. The remove-filter simply eliminates the "Accept-Encoding" Value
