### PR TITLE
allow to trigger a jenkins build using the jenkins pipeline model syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,20 @@ node {
 2. Configure any other pre build, build or post build actions as necessary
 3. Click *Save* to preserve your changes in Jenkins.
 
+> If you are using the pipeline model definition syntax in your pipeline job, you can enable the gitlab plugin in the triggers section:
+
+```
+pipeline {
+    agent any
+
+    triggers {
+        gitlab(triggerOnPush: true, triggerOnMergeRequest: true, [...])
+    }
+
+   [...]
+}
+```
+
 ### Matrix/Multi-configuration jobs
 **The Jenkins Matrix/Multi-configuration job type is not supported.**
 

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>symbol-annotation</artifactId>
+      <version>1.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
       <version>3.5.2.201411120430-r</version>

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -44,6 +44,7 @@ import jenkins.triggers.SCMTriggerItem.SCMTriggerItems;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -293,6 +294,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
     }
 
     @Extension
+    @Symbol("gitlab")
     public static class DescriptorImpl extends TriggerDescriptor {
 
         private transient final SequentialExecutionQueue queue = new SequentialExecutionQueue(Jenkins.MasterComputer.threadPoolForRemoting);


### PR DESCRIPTION
Currenlty, it's not possible to trigger a jenkins job with the gitlab plugin using the `pipeline model definition` syntax in the Jenkinsfile.

This PR handle this issue by using the `@Symbol` Jenkins annotation.

 - [Pipeline model definition syntax](https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/master/SYNTAX.md)
 - [Pipeline model definition initial issue](https://issues.jenkins-ci.org/browse/JENKINS-40402)
 - [Pipeline model definition trigger run](https://github.com/jenkinsci/pipeline-model-definition-plugin/wiki/Trigger-runs#other-available-triggers)


