### PR TITLE
Send GitLab messages on unstable builds as well as failed ones

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisher.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisher.java
@@ -109,7 +109,7 @@ public class GitLabMessagePublisher extends MergeRequestNotifier {
     @Override
     protected void perform(Run<?, ?> build, TaskListener listener, GitLabApi client, Integer projectId, Integer mergeRequestId) {
         try {
-            if (!onlyForFailure || build.getResult() == Result.FAILURE) {
+            if (!onlyForFailure || build.getResult() == Result.FAILURE || build.getResult() == Result.UNSTABLE) {
                 client.createMergeRequestNote(projectId, mergeRequestId, getNote(build, listener));
             }
         } catch (WebApplicationException | ProcessingException e) {


### PR DESCRIPTION
I'm submitting this small fix for #452. It's not full configurable feature as described in #452, but it does the job without allowing to configure details.