### PR TITLE
Declarative pipeline syntax support for gitlab connection property (also incorporates #481)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you have a problem or question about using the plugin, please make sure you a
 * Jenkins version (e.g. 1.651.1)
 * Relevant log output from the plugin (see below for instructions on capturing this)
 
-Version 1.2.0 of the plugin introduced improved logging for debugging purposes. To enable it: 
+Version 1.2.0 of the plugin introduced improved logging for debugging purposes. To enable it:
 
 1. Go to Jenkins -> Manage Jenkins -> System Log
 2. Add new log recorder
@@ -69,7 +69,7 @@ To enable this functionality, a user should be set up on GitLab, with GitLab 'De
         ``+refs/heads/*:refs/remotes/origin/* +refs/merge-requests/*/head:refs/remotes/origin/merge-requests/*``
     3. In order to merge from forked repositories:  <br/>**Note:** this requires [configuring communication to the GitLab server](#configuring-access-to-gitlab)
       * Click *Add Repository* to specify the merge request source repository.  Then specify:
-        * *URL*: ``${gitlabSourceRepoURL}`` 
+        * *URL*: ``${gitlabSourceRepoURL}``
         * In the *Advanced* settings, set *Name* to ``${gitlabSourceRepoName}``.  Leave *Refspec* blank.
     4. In *Branch Specifier* enter:
       * For single-repository workflows: ``origin/${gitlabSourceBranch}``
@@ -77,13 +77,13 @@ To enable this functionality, a user should be set up on GitLab, with GitLab 'De
     5. In *Additional Behaviours*:
         * Click the *Add* drop-down button
         * Select *Merge before build* from the drop-down
-        * Set *Name of repository* to ``origin`` 
+        * Set *Name of repository* to ``origin``
         * Set *Branch to merge* as ``${gitlabTargetBranch}``
 
 **Note:** Since version **1.2.0** the *gitlab-plugin* sets the gitlab hook values through *environment variables* instead of *build parameters*. To set default values, consult [EnvInject Plugin](https://wiki.jenkins-ci.org/display/JENKINS/EnvInject+Plugin).
 
 ### Git configuration for Pipeline/Workflow jobs
-**Incompatibility note:** When upgrading to version 1.2.1 or later of the plugin, if you are using Pipeline jobs you will need to manually reconfigure your Pipeline scripts. In older versions the plugin set global Groovy variables that could be accessed as e.g. ${gitlabSourceBranch}. After version 1.2.1, these variables are only accessible in the env[] map. E.g. ${env.gitlabSourceBranch}. 
+**Incompatibility note:** When upgrading to version 1.2.1 or later of the plugin, if you are using Pipeline jobs you will need to manually reconfigure your Pipeline scripts. In older versions the plugin set global Groovy variables that could be accessed as e.g. ${gitlabSourceBranch}. After version 1.2.1, these variables are only accessible in the env[] map. E.g. ${env.gitlabSourceBranch}.
 
 * A Jenkins Pipeline bug will prevent the Git clone from working when you use a Pipeline script from SCM. It works if you use the Jenkins job config UI to edit the script. There is a workaround mentioned here: https://issues.jenkins-ci.org/browse/JENKINS-33719
 
@@ -102,7 +102,7 @@ Due to this the plugin just listens for GitLab Push Hooks for multibranch pipeli
 Example `Jenkinsfile` for multibranch pipeline jobs
 ```
 // Reference the GitLab connection name from your Jenkins Global configuration (http://JENKINS_URL/configure, GitLab section)
-properties([[$class: 'GitLabConnectionProperty', gitLabConnection: '<your-gitlab-connection-name']])
+properties([gitLabConnection('<your-gitlab-connection-name')])
 
 node {
     stage "checkout"
@@ -134,16 +134,27 @@ node {
 2. Configure any other pre build, build or post build actions as necessary
 3. Click *Save* to preserve your changes in Jenkins.
 
-> If you are using the pipeline model definition syntax in your pipeline job, you can enable the gitlab plugin in the triggers section:
+### Declarative Pipeline Syntax
+
+The plugin supports the new [declarative pipeline syntax](https://github.com/jenkinsci/pipeline-model-definition-plugin/wiki/Syntax-Reference). The example below configures the GitLab connection and triggers the job on a push to GitLab. It also sets the Gitlab commit status as the status of the build.
 
 ```
 pipeline {
     agent any
-
-    triggers {
-        gitlab(triggerOnPush: true, triggerOnMergeRequest: true, [...])
+    options {
+      gitLabConnection('<your-gitlab-connection-name')
+      gitlabCommitStatus(name: 'jenkins')
     }
-
+    triggers {
+        gitlab(triggerOnPush: true, triggerOnMergeRequest: true, branchFilterType: 'All')
+    }
+    stages {
+      stage("build") {
+        steps {
+          echo "hello world"
+        }
+      }
+    }
    [...]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ node {
 2. Configure any other pre build, build or post build actions as necessary
 3. Click *Save* to preserve your changes in Jenkins.
 
+> If you are using the pipeline model definition syntax in your pipeline job, you can enable the gitlab plugin in the triggers section:
+
+```
+pipeline {
+    agent any
+
+    triggers {
+        gitlab(triggerOnPush: true, triggerOnMergeRequest: true, [...])
+    }
+
+   [...]
+}
+```
+
 ### Matrix/Multi-configuration jobs
 **The Jenkins Matrix/Multi-configuration job type is not supported.**
 

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>symbol-annotation</artifactId>
+      <version>1.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
       <version>3.5.2.201411120430-r</version>

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -44,6 +44,7 @@ import jenkins.triggers.SCMTriggerItem.SCMTriggerItems;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -293,6 +294,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
     }
 
     @Extension
+    @Symbol("gitlab")
     public static class DescriptorImpl extends TriggerDescriptor {
 
         private transient final SequentialExecutionQueue queue = new SequentialExecutionQueue(Jenkins.MasterComputer.threadPoolForRemoting);

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
@@ -10,6 +10,7 @@ import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -46,6 +47,7 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
     }
 
     @Extension
+    @Symbol("gitLabConnection")
     public static class DescriptorImpl extends JobPropertyDescriptor {
 
         @Override


### PR DESCRIPTION
Added @Symbol notation to the GitLab Connection property so it can be used with the declarative syntax. Also incorporated the change from #481.

Essentially added support for 'gitlabConnection' to be included in the 'options' section in the declarative syntax.

Without this, jobs defined completely using the declarative syntax are not able to set the build status in GitLab.

Updated README with an example and also updated the syntax under the 'properties' section.