### PR TITLE
Append a "/" to the build URL for "pending" state

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/AbstractWebHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/AbstractWebHookTriggerHandler.java
@@ -69,8 +69,10 @@ public abstract class AbstractWebHookTriggerHandler<H extends WebHook> implement
                 if (client == null) {
                     LOGGER.log(Level.SEVERE, "No GitLab connection configured");
                 } else {
-                    client.changeBuildStatus(buildStatusUpdate.getProjectId(), buildStatusUpdate.getSha(), BuildState.pending, buildStatusUpdate.getRef(),
-                                             publisher.getName(), Jenkins.getInstance().getRootUrl() + job.getUrl() + job.getNextBuildNumber(), null);
+                    String targetUrl =
+                        Jenkins.getInstance().getRootUrl() + job.getUrl() + job.getNextBuildNumber() + "/";
+                    client.changeBuildStatus(buildStatusUpdate.getProjectId(), buildStatusUpdate.getSha(),
+                        BuildState.pending, buildStatusUpdate.getRef(), publisher.getName(), targetUrl, null);
                 }
             } catch (WebApplicationException | ProcessingException e) {
                 LOGGER.log(Level.SEVERE, "Failed to set build state to pending", e);

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
@@ -147,8 +147,8 @@ class OpenMergeRequestPushHookTriggerHandler implements PushHookTriggerHandler {
                 (GitLabCommitStatusPublisher) ((AbstractProject) job).getPublishersList().get(GitLabCommitStatusPublisher.class);
             GitLabApi client = job.getProperty(GitLabConnectionProperty.class).getClient();
             try {
-                client.changeBuildStatus(projectId, commit, BuildState.pending, ref, publisher.getName(),
-                                         Jenkins.getInstance().getRootUrl() + job.getUrl() + job.getNextBuildNumber(), null);
+                String targetUrl = Jenkins.getInstance().getRootUrl() + job.getUrl() + job.getNextBuildNumber() + "/";
+                client.changeBuildStatus(projectId, commit, BuildState.pending, ref, publisher.getName(), targetUrl, null);
             } catch (WebApplicationException | ProcessingException e) {
                 LOGGER.log(Level.SEVERE, "Failed to set build state to pending", e);
             }


### PR DESCRIPTION
The URL generated for the "pending" state was different from the URL of the finished build.

Closes #489