### PR TITLE
Adding gitlabMergeRequestTargetProjectId variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ These include:
 * gitMergedByUser
 * gitMergeRequestAssignee
 * gitlabMergeRequestLastCommit
+* gitlabMergeRequestTargetProjectId
 * gitlabTargetBranch
 * gitlabTargetRepoName
 * gitlabTargetNamespace

--- a/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
@@ -39,6 +39,7 @@ public final class CauseData {
     private final String mergeRequestState;
     private final String mergedByUser;
     private final String mergeRequestAssignee;
+    private final Integer mergeRequestTargetProjectId;
     private final String targetBranch;
     private final String targetRepoName;
     private final String targetNamespace;
@@ -55,9 +56,9 @@ public final class CauseData {
     CauseData(ActionType actionType, Integer sourceProjectId, Integer targetProjectId, String branch, String sourceBranch, String userName,
               String userEmail, String sourceRepoHomepage, String sourceRepoName, String sourceNamespace, String sourceRepoUrl,
               String sourceRepoSshUrl, String sourceRepoHttpUrl, String mergeRequestTitle, String mergeRequestDescription, Integer mergeRequestId,
-              Integer mergeRequestIid, String targetBranch, String targetRepoName, String targetNamespace, String targetRepoSshUrl,
-              String targetRepoHttpUrl, String triggeredByUser, String before, String after, String lastCommit, String targetProjectUrl,
-              String triggerPhrase, String mergeRequestState, String mergedByUser, String mergeRequestAssignee) {
+              Integer mergeRequestIid, Integer mergeRequestTargetProjectId, String targetBranch, String targetRepoName, String targetNamespace,
+              String targetRepoSshUrl, String targetRepoHttpUrl, String triggeredByUser, String before, String after, String lastCommit,
+              String targetProjectUrl, String triggerPhrase, String mergeRequestState, String mergedByUser, String mergeRequestAssignee) {
         this.actionType = checkNotNull(actionType, "actionType must not be null.");
         this.sourceProjectId = checkNotNull(sourceProjectId, "sourceProjectId must not be null.");
         this.targetProjectId = checkNotNull(targetProjectId, "targetProjectId must not be null.");
@@ -78,6 +79,7 @@ public final class CauseData {
         this.mergeRequestState = mergeRequestState == null ? "" : mergeRequestState;
         this.mergedByUser = mergedByUser == null ? "" : mergedByUser;
         this.mergeRequestAssignee = mergeRequestAssignee == null ? "" : mergeRequestAssignee;
+        this.mergeRequestTargetProjectId = mergeRequestTargetProjectId;
         this.targetBranch = checkNotNull(targetBranch, "targetBranch must not be null.");
         this.targetRepoName = checkNotNull(targetRepoName, "targetRepoName must not be null.");
         this.targetNamespace = checkNotNull(targetNamespace, "targetNamespace must not be null.");
@@ -108,6 +110,7 @@ public final class CauseData {
         variables.put("gitlabMergeRequestDescription", mergeRequestDescription);
         variables.put("gitlabMergeRequestId", mergeRequestId == null ? "" : mergeRequestId.toString());
         variables.put("gitlabMergeRequestIid", mergeRequestIid == null ? "" : mergeRequestIid.toString());
+        variables.put("gitlabMergeRequestTargetProjectId", mergeRequestTargetProjectId == null ? "" : mergeRequestTargetProjectId.toString());
         variables.put("gitlabMergeRequestLastCommit", lastCommit);
         variables.pufIfNotNull("gitlabMergeRequestState", mergeRequestState);
         variables.pufIfNotNull("gitlabMergedByUser", mergedByUser);
@@ -189,6 +192,10 @@ public final class CauseData {
 
     public Integer getMergeRequestIid() {
         return mergeRequestIid;
+    }
+
+    public Integer getMergeRequestTargetProjectId() {
+        return mergeRequestTargetProjectId;
     }
 
     public String getTargetBranch() {
@@ -277,6 +284,7 @@ public final class CauseData {
             .append(mergeRequestState, causeData.mergeRequestState)
             .append(mergedByUser, causeData.mergedByUser)
             .append(mergeRequestAssignee, causeData.mergeRequestAssignee)
+            .append(mergeRequestTargetProjectId, causeData.mergeRequestTargetProjectId)
             .append(targetBranch, causeData.targetBranch)
             .append(targetRepoName, causeData.targetRepoName)
             .append(targetNamespace, causeData.targetNamespace)
@@ -313,6 +321,7 @@ public final class CauseData {
             .append(mergeRequestState)
             .append(mergedByUser)
             .append(mergeRequestAssignee)
+            .append(mergeRequestTargetProjectId)
             .append(targetBranch)
             .append(targetRepoName)
             .append(targetNamespace)
@@ -349,6 +358,7 @@ public final class CauseData {
             .append("mergeRequestState", mergeRequestState)
             .append("mergedByUser", mergedByUser)
             .append("mergeRequestAssignee", mergeRequestAssignee)
+            .append("mergeRequestTargetProjectId", mergeRequestTargetProjectId)
             .append("targetBranch", targetBranch)
             .append("targetRepoName", targetRepoName)
             .append("targetNamespace", targetNamespace)

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -90,6 +90,7 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
                 .withMergeRequestState(hook.getObjectAttributes().getState().toString())
                 .withMergedByUser(hook.getUser() == null ? null : hook.getUser().getUsername())
                 .withMergeRequestAssignee(hook.getAssignee() == null ? null : hook.getAssignee().getUsername())
+                .withMergeRequestTargetProjectId(hook.getObjectAttributes().getTargetProjectId())
                 .withTargetBranch(hook.getObjectAttributes().getTargetBranch())
                 .withTargetRepoName(hook.getObjectAttributes().getTarget().getName())
                 .withTargetNamespace(hook.getObjectAttributes().getTarget().getNamespace())

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImpl.java
@@ -75,6 +75,7 @@ class NoteHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<NoteHook>
                 .withMergeRequestDescription(hook.getMergeRequest().getDescription())
                 .withMergeRequestId(hook.getMergeRequest().getId())
                 .withMergeRequestIid(hook.getMergeRequest().getIid())
+                .withMergeRequestTargetProjectId(hook.getMergeRequest().getTargetProjectId())
                 .withTargetBranch(hook.getMergeRequest().getTargetBranch())
                 .withTargetRepoName(hook.getMergeRequest().getTarget().getName())
                 .withTargetNamespace(hook.getMergeRequest().getTarget().getNamespace())

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
@@ -130,6 +130,7 @@ class OpenMergeRequestPushHookTriggerHandler implements PushHookTriggerHandler {
                 .withMergeRequestDescription(mergeRequest.getDescription())
                 .withMergeRequestId(mergeRequest.getId())
                 .withMergeRequestIid(mergeRequest.getIid())
+                .withMergeRequestTargetProjectId(mergeRequest.getTargetProjectId())
                 .withTargetBranch(mergeRequest.getTargetBranch())
                 .withTargetRepoName(hook.getRepository().getName())
                 .withTargetNamespace(hook.getProject().getNamespace())

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImpl.java
@@ -63,6 +63,7 @@ class PushHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<PushHook>
                 .withMergeRequestState(null)
                 .withMergedByUser("")
                 .withMergeRequestAssignee("")
+                .withMergeRequestTargetProjectId(null)
                 .withTargetBranch(getTargetBranch(hook))
                 .withTargetRepoName("")
                 .withTargetNamespace("")


### PR DESCRIPTION
The project ID is needed when using the GitLab rest API to get information about the merge request.