### PR TITLE
README: Better declarative pipeline example

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,16 @@ The plugin supports the new [declarative pipeline syntax](https://github.com/jen
 ```
 pipeline {
     agent any
+    post {
+      failure {
+        updateGitlabCommitStatus name: 'build', state: 'failed'
+      }
+      success {
+        updateGitlabCommitStatus name: 'build', state: 'success'
+      }
+    }
     options {
       gitLabConnection('<your-gitlab-connection-name')
-      gitlabCommitStatus(name: 'jenkins')
     }
     triggers {
         gitlab(triggerOnPush: true, triggerOnMergeRequest: true, branchFilterType: 'All')


### PR DESCRIPTION
With the current example for declarative pipelines, it is a bit unclear how to report the correct build status to GitLab. This pull request makes the example report the correct build status.

EDIT:
This also helps avoid confusions like #528 

EDIT2:
Now realizing that this may be a bug, not sure though.
Reference: https://github.com/jenkinsci/gitlab-plugin/issues/528#issuecomment-288636032