### PR TITLE
add Getter for new fields triggerOnAcceptedMergeRequest and triggerOnClosedMergeRequest

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -193,6 +193,14 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         return triggerOnMergeRequest;
     }
 
+    public boolean isTriggerOnAcceptedMergeRequest() {
+        return triggerOnAcceptedMergeRequest;
+    }
+
+    public boolean isTriggerOnClosedMergeRequest() {
+        return triggerOnClosedMergeRequest;
+    }
+
     public boolean getTriggerOnNoteRequest() {
         return triggerOnNoteRequest;
     }


### PR DESCRIPTION
The main of this PR is to fix the problem reported by @mreichel in PR #508. It adds 2 `Getter`s for fields `triggerOnAcceptedMergeRequest` and `triggerOnClosedMergeRequest`