### PR TITLE
Matrix/Multi-config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,19 @@ pipeline {
 ```
 
 ### Matrix/Multi-configuration jobs
-**The Jenkins Matrix/Multi-configuration job type is not supported.**
+
+This plugin can be used on Matrix/Multi-configuration jobs together with the [Flexible Publish](https://plugins.jenkins.io/flexible-publish) plugin which allows to run publishers after all axis jobs are done.
+
+To use GitLab with Flexible Publish, configure the *Post-build Actions* as follows:
+
+1. Add a *Flexible publish* action
+2. In the *Flexible publish* section:
+      1. *Add conditional action*
+      2. In the *Conditional action* section:
+          1. Set *Run?* to *Never*
+          2. Select *Condition for Matrix Aggregation*
+          3. Set *Run on Parent?* to *Always*
+          4. Add GitLab actions as required
 
 ## Gitlab Configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,11 @@
       <artifactId>org.eclipse.jgit</artifactId>
       <version>3.5.2.201411120430-r</version>
     </dependency>
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>matrix-project</artifactId>
+        <version>1.10</version>
+    </dependency>
 
     <!-- REST client dependencies -->
     <dependency>

--- a/src/main/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributor.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributor.java
@@ -3,6 +3,8 @@ package com.dabsquared.gitlabjenkins.environment;
 import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
 import hudson.EnvVars;
 import hudson.Extension;
+import hudson.matrix.MatrixRun;
+import hudson.matrix.MatrixBuild;
 import hudson.model.EnvironmentContributor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -17,7 +19,15 @@ import java.io.IOException;
 public class GitLabEnvironmentContributor extends EnvironmentContributor {
     @Override
     public void buildEnvironmentFor(@Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener) throws IOException, InterruptedException {
-        GitLabWebHookCause cause = (GitLabWebHookCause) r.getCause(GitLabWebHookCause.class);
+        GitLabWebHookCause cause = null;
+        if (r instanceof MatrixRun) {
+            MatrixBuild parent = ((MatrixRun)r).getParentBuild();
+            if (parent != null) {
+                cause = (GitLabWebHookCause) parent.getCause(GitLabWebHookCause.class);
+            }
+        } else {
+            cause = (GitLabWebHookCause) r.getCause(GitLabWebHookCause.class);
+        }
         if (cause != null) {
             envs.overrideAll(cause.getData().getBuildVariables());
         }

--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisher.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisher.java
@@ -4,6 +4,9 @@ import com.dabsquared.gitlabjenkins.gitlab.api.model.BuildState;
 import com.dabsquared.gitlabjenkins.util.CommitStatusUpdater;
 import hudson.Extension;
 import hudson.Launcher;
+import hudson.matrix.MatrixAggregatable;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
@@ -22,7 +25,7 @@ import java.io.IOException;
 /**
  * @author Robin Müller
  */
-public class GitLabCommitStatusPublisher extends Notifier {
+public class GitLabCommitStatusPublisher extends Notifier implements MatrixAggregatable {
 
     private String name;
     private boolean markUnstableAsSuccess;
@@ -69,6 +72,16 @@ public class GitLabCommitStatusPublisher extends Notifier {
             name = "jenkins";
         }
         return this;
+    }
+
+    public MatrixAggregator createAggregator(MatrixBuild build, Launcher launcher, BuildListener listener) {
+        return new MatrixAggregator(build, launcher, listener) {
+            @Override
+            public boolean endBuild() throws InterruptedException, IOException {
+                perform(build, launcher, listener);
+                return super.endBuild();
+            }
+        };
     }
 
     @Extension

--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/MergeRequestNotifier.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/MergeRequestNotifier.java
@@ -3,6 +3,9 @@ package com.dabsquared.gitlabjenkins.publisher;
 import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabApi;
 import hudson.Launcher;
+import hudson.matrix.MatrixAggregatable;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Run;
@@ -17,7 +20,7 @@ import static com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty.g
 /**
  * @author Robin Müller
  */
-public abstract class MergeRequestNotifier extends Notifier {
+public abstract class MergeRequestNotifier extends Notifier implements MatrixAggregatable {
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
     }
@@ -35,6 +38,16 @@ public abstract class MergeRequestNotifier extends Notifier {
             perform(build, listener, client, projectId, mergeRequestId);
         }
         return true;
+    }
+
+    public MatrixAggregator createAggregator(MatrixBuild build, Launcher launcher, BuildListener listener) {
+        return new MatrixAggregator(build, launcher, listener) {
+            @Override
+            public boolean endBuild() throws InterruptedException, IOException {
+                perform(build, launcher, listener);
+                return super.endBuild();
+            }
+        };
     }
 
     protected abstract void perform(Run<?, ?> build, TaskListener listener, GitLabApi client, Integer projectId, Integer mergeRequestId);

--- a/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
@@ -1,0 +1,124 @@
+package com.dabsquared.gitlabjenkins.environment;
+
+import com.dabsquared.gitlabjenkins.cause.CauseData;
+import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
+import hudson.EnvVars;
+import hudson.matrix.AxisList;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixProject;
+import hudson.matrix.MatrixRun;
+import hudson.matrix.TextAxis;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleProject;
+import hudson.model.FreeStyleBuild;
+import hudson.model.StreamBuildListener;
+import jenkins.model.Jenkins;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.dabsquared.gitlabjenkins.cause.CauseDataBuilder.causeData;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Evgeni Golov
+ */
+public class GitLabEnvironmentContributorTest {
+
+    @ClassRule
+    public static JenkinsRule jenkins = new JenkinsRule();
+
+    private BuildListener listener;
+
+    @Before
+    public void setup() {
+        listener = new StreamBuildListener(jenkins.createTaskListener().getLogger(), Charset.defaultCharset());
+    }
+
+    @Test
+    public void freeStyleProjectTest() throws IOException, InterruptedException, ExecutionException {
+        FreeStyleProject p = jenkins.createFreeStyleProject();
+        GitLabWebHookCause cause = new GitLabWebHookCause(generateCauseData());
+        FreeStyleBuild b = p.scheduleBuild2(0, cause).get();
+        EnvVars env = b.getEnvironment(listener);
+
+        assertEnv(env);
+    }
+
+    @Test
+    public void matrixProjectTest() throws IOException, InterruptedException, ExecutionException {
+        EnvVars env;
+        MatrixProject p = jenkins.jenkins.createProject(MatrixProject.class, "matrixbuild");
+        GitLabWebHookCause cause = new GitLabWebHookCause(generateCauseData());
+        // set up 2x2 matrix
+        AxisList axes = new AxisList();
+        axes.add(new TextAxis("db","mysql","oracle"));
+        axes.add(new TextAxis("direction","north","south"));
+        p.setAxes(axes);
+
+        MatrixBuild build = p.scheduleBuild2(0, cause).get();
+        List<MatrixRun> runs = build.getRuns();
+        assertEquals(4,runs.size());
+        for (MatrixRun run : runs) {
+            env = run.getEnvironment(listener);
+            assertNotNull(env.get("db"));
+            assertEnv(env);
+        }
+    }
+
+    private CauseData generateCauseData() {
+        return causeData()
+                .withActionType(CauseData.ActionType.MERGE)
+                .withSourceProjectId(1)
+                .withTargetProjectId(1)
+                .withBranch("feature")
+                .withSourceBranch("feature")
+                .withUserName("")
+                .withSourceRepoHomepage("https://gitlab.org/test")
+                .withSourceRepoName("test")
+                .withSourceNamespace("test-namespace")
+                .withSourceRepoUrl("git@gitlab.org:test.git")
+                .withSourceRepoSshUrl("git@gitlab.org:test.git")
+                .withSourceRepoHttpUrl("https://gitlab.org/test.git")
+                .withMergeRequestTitle("Test")
+                .withMergeRequestId(1)
+                .withMergeRequestIid(1)
+                .withTargetBranch("master")
+                .withTargetRepoName("test")
+                .withTargetNamespace("test-namespace")
+                .withTargetRepoSshUrl("git@gitlab.org:test.git")
+                .withTargetRepoHttpUrl("https://gitlab.org/test.git")
+                .withTriggeredByUser("test")
+                .withLastCommit("123")
+                .withTargetProjectUrl("https://gitlab.org/test")
+                .build();
+    }
+
+    private void assertEnv(EnvVars env) {
+        assertEquals("1", env.get("gitlabMergeRequestId"));
+        assertEquals("git@gitlab.org:test.git", env.get("gitlabSourceRepoUrl"));
+        assertEquals("master", env.get("gitlabTargetBranch"));
+        assertEquals("test", env.get("gitlabTargetRepoName"));
+        assertEquals("feature", env.get("gitlabSourceBranch"));
+        assertEquals("test", env.get("gitlabSourceRepoName"));
+    }
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
@@ -10,6 +10,10 @@ import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.BuildState;
 import hudson.EnvVars;
+import hudson.Launcher;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixConfiguration;
+import hudson.matrix.MatrixBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
@@ -53,6 +57,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -97,6 +102,23 @@ public class GitLabCommitStatusPublisherTest {
     @After
     public void cleanup() {
         mockServerClient.reset();
+    }
+
+    @Test
+    public void matrixAggregatable() throws UnsupportedEncodingException, InterruptedException, IOException {
+        AbstractBuild build = mock(AbstractBuild.class);
+        AbstractProject project = mock(MatrixConfiguration.class);
+        GitLabCommitStatusPublisher publisher = mock(GitLabCommitStatusPublisher.class);
+        MatrixBuild parentBuild = mock(MatrixBuild.class);
+
+        when(build.getParent()).thenReturn(project);
+        when(publisher.createAggregator(any(MatrixBuild.class), any(Launcher.class), any(BuildListener.class))).thenCallRealMethod();
+        when(publisher.perform(any(AbstractBuild.class), any(Launcher.class), any(BuildListener.class))).thenReturn(true);
+
+        MatrixAggregator aggregator = publisher.createAggregator(parentBuild, null, listener);
+        aggregator.startBuild();
+        aggregator.endBuild();
+        verify(publisher).perform(parentBuild, null, listener);
     }
 
     @Test

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisherTest.java
@@ -9,6 +9,10 @@ import com.dabsquared.gitlabjenkins.connection.GitLabConnection;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
 import hudson.EnvVars;
+import hudson.Launcher;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixConfiguration;
+import hudson.matrix.MatrixBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
@@ -45,6 +49,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -111,6 +116,23 @@ public class GitLabMessagePublisherTest {
         publisher.perform(build, null, listener);
 
         mockServerClient.verify(requests);
+    }
+
+    @Test
+    public void matrixAggregatable() throws UnsupportedEncodingException, InterruptedException, IOException {
+        AbstractBuild build = mock(AbstractBuild.class);
+        AbstractProject project = mock(MatrixConfiguration.class);
+        GitLabCommitStatusPublisher publisher = mock(GitLabCommitStatusPublisher.class);
+        MatrixBuild parentBuild = mock(MatrixBuild.class);
+
+        when(build.getParent()).thenReturn(project);
+        when(publisher.createAggregator(any(MatrixBuild.class), any(Launcher.class), any(BuildListener.class))).thenCallRealMethod();
+        when(publisher.perform(any(AbstractBuild.class), any(Launcher.class), any(BuildListener.class))).thenReturn(true);
+
+        MatrixAggregator aggregator = publisher.createAggregator(parentBuild, null, listener);
+        aggregator.startBuild();
+        aggregator.endBuild();
+        verify(publisher).perform(parentBuild, null, listener);
     }
 
     @Test

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabVotePublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabVotePublisherTest.java
@@ -8,6 +8,10 @@ import com.cloudbees.plugins.credentials.domains.Domain;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnection;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
+import hudson.Launcher;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixConfiguration;
+import hudson.matrix.MatrixBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
@@ -36,9 +40,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -83,6 +89,23 @@ public class GitLabVotePublisherTest {
     @After
     public void cleanup() {
         mockServerClient.reset();
+    }
+
+    @Test
+    public void matrixAggregatable() throws UnsupportedEncodingException, InterruptedException, IOException {
+        AbstractBuild build = mock(AbstractBuild.class);
+        AbstractProject project = mock(MatrixConfiguration.class);
+        GitLabCommitStatusPublisher publisher = mock(GitLabCommitStatusPublisher.class);
+        MatrixBuild parentBuild = mock(MatrixBuild.class);
+
+        when(build.getParent()).thenReturn(project);
+        when(publisher.createAggregator(any(MatrixBuild.class), any(Launcher.class), any(BuildListener.class))).thenCallRealMethod();
+        when(publisher.perform(any(AbstractBuild.class), any(Launcher.class), any(BuildListener.class))).thenReturn(true);
+
+        MatrixAggregator aggregator = publisher.createAggregator(parentBuild, null, listener);
+        aggregator.startBuild();
+        aggregator.endBuild();
+        verify(publisher).perform(parentBuild, null, listener);
     }
 
     @Test


### PR DESCRIPTION
This PR provides basic Matrix Job support by:
* injecting the environment variables also into MatrixRuns (the axis jobs)
* making the publishers MatrixAggregatable and thus allowing Flexible Publish and similar to execute them *after* all axis jobs have finished