### PR TITLE
#496 How to clear the secure token in build triggers?

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -419,5 +419,9 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
             String secretToken = Util.toHexString(random);
             response.setHeader("script", "document.getElementById('secretToken').value='" + secretToken + "'");
         }
+
+        public void doClearSecretToken(@AncestorInPath final Job<?, ?> project, StaplerResponse response) {;
+            response.setHeader("script", "document.getElementById('secretToken').value=''");
+        }
     }
 }

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -79,6 +79,7 @@
       <table>
         <f:readOnlyTextbox field="secretToken" id="secretToken"/>
         <f:validateButton title="${%Generate}" method="generateSecretToken"/>
+        <f:validateButton title="${%Clear}" method="clearSecretToken"/>
       </table>
     </f:entry>
   </f:advanced>


### PR DESCRIPTION
Since the field is read only I added a button to clear the secret token

Fixes #496 