### PR TITLE
Fix issue #523 - Build result sent to Pipeline library repo

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -1,28 +1,37 @@
 package com.dabsquared.gitlabjenkins.util;
 
-import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
-import com.dabsquared.gitlabjenkins.gitlab.api.GitLabApi;
-import com.dabsquared.gitlabjenkins.gitlab.api.model.BuildState;
-import hudson.EnvVars;
-import hudson.model.Run;
-import hudson.model.TaskListener;
-import hudson.plugins.git.Revision;
-import hudson.plugins.git.util.BuildData;
-import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import static com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty.getClient;
 
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty.getClient;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jgit.lib.ObjectId;
+
+import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
+import com.dabsquared.gitlabjenkins.gitlab.api.GitLabApi;
+import com.dabsquared.gitlabjenkins.gitlab.api.model.BuildState;
+
+import hudson.EnvVars;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.util.Build;
+import hudson.plugins.git.util.BuildData;
+import jenkins.model.Jenkins;
+import jenkins.plugins.git.AbstractGitSCMSource;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMRevisionAction;
 
 /**
  * @author Robin Müller
@@ -39,17 +48,16 @@ public class CommitStatusUpdater {
         }
 
         try {
-            String commitHash = getBuildRevision(build);
-            String buildUrl = getBuildUrl(build);
-
-            for (String gitlabProjectId : retrieveGitlabProjectIds(build, build.getEnvironment(listener))) {
+            final String buildUrl = getBuildUrl(build);
+            		
+            for (final GitLabBranchBuild gitLabBranchBuild : retrieveGitlabProjectIds(build, build.getEnvironment(listener))) {
                 try {
-                    if (existsCommit(client, gitlabProjectId, commitHash)) {
-                        client.changeBuildStatus(gitlabProjectId, commitHash, state, getBuildBranch(build), name, buildUrl, null);
+                    if (existsCommit(client, gitLabBranchBuild.getProjectId(), gitLabBranchBuild.getRevisionHash())) {
+                        client.changeBuildStatus(gitLabBranchBuild.getProjectId(), gitLabBranchBuild.getRevisionHash(), state, getBuildBranch(build), name, buildUrl, null);
                     }
                 } catch (WebApplicationException | ProcessingException e) {
-                    printf(listener, "Failed to update Gitlab commit status for project '%s': %s%n", gitlabProjectId, e.getMessage());
-                    LOGGER.log(Level.SEVERE, String.format("Failed to update Gitlab commit status for project '%s'", gitlabProjectId), e);
+                    printf(listener, "Failed to update Gitlab commit status for project '%s': %s%n", gitLabBranchBuild.getProjectId(), e.getMessage());
+                    LOGGER.log(Level.SEVERE, String.format("Failed to update Gitlab commit status for project '%s'", gitLabBranchBuild.getProjectId()), e);
                 }
             }
         } catch (IOException | InterruptedException | IllegalStateException e) {
@@ -73,25 +81,6 @@ public class CommitStatusUpdater {
         }
     }
 
-    private static String getBuildRevision(Run<?, ?> build) {
-        GitLabWebHookCause cause = build.getCause(GitLabWebHookCause.class);
-        if (cause != null) {
-            return cause.getData().getLastCommit();
-        }
-
-        BuildData action = build.getAction(BuildData.class);
-        if (action == null) {
-            throw new IllegalStateException("No (git-plugin) BuildData associated to current build");
-        }
-        Revision lastBuiltRevision = action.getLastBuiltRevision();
-
-        if (lastBuiltRevision == null) {
-            throw new IllegalStateException("Last build has no associated commit");
-        }
-
-        return action.getLastBuild(lastBuiltRevision.getSha1()).getMarked().getSha1String();
-    }
-
     private static boolean existsCommit(GitLabApi client, String gitlabProjectId, String commitHash) {
         try {
             client.getCommit(gitlabProjectId, commitHash);
@@ -111,48 +100,80 @@ public class CommitStatusUpdater {
         return Jenkins.getInstance().getRootUrl() + build.getUrl();
     }
 
-    private static List<String> retrieveGitlabProjectIds(Run<?, ?> build, EnvVars environment) {
+    private static List<GitLabBranchBuild> retrieveGitlabProjectIds(Run<?, ?> build, EnvVars environment) {
         LOGGER.log(Level.INFO, "Retrieving gitlab project ids");
-
+        final List<GitLabBranchBuild> result = new ArrayList<>();
+        
         GitLabWebHookCause cause = build.getCause(GitLabWebHookCause.class);
         if (cause != null) {
-            return Collections.singletonList(cause.getData().getSourceProjectId().toString());
+        	return Collections.singletonList(new GitLabBranchBuild(cause.getData().getSourceProjectId().toString(), cause.getData().getLastCommit()));
         }
 
-        List<String> result = new ArrayList<>();
-        GitLabApi gitLabClient = getClient(build);
+        final GitLabApi gitLabClient = getClient(build);
         if (gitLabClient == null) {
             LOGGER.log(Level.WARNING, "No gitlab client found.");
             return result;
         }
 
-        final BuildData buildData = build.getAction(BuildData.class);
-        if (buildData == null) {
+        final SCMRevisionAction scmRevisionAction = build.getAction(SCMRevisionAction.class);
+
+        final SCMRevision scmRevision = scmRevisionAction.getRevision();
+
+        String scmRevisionHash = null;
+        if (scmRevision instanceof AbstractGitSCMSource.SCMRevisionImpl) {
+        	scmRevisionHash = ((AbstractGitSCMSource.SCMRevisionImpl) scmRevision).getHash();
+        }
+        
+        final List<BuildData> buildDatas = build.getActions(BuildData.class);
+        if(CollectionUtils.isEmpty(buildDatas)) {
             LOGGER.log(Level.INFO, "Build does not contain build data.");
             return result;
         }
 
-        final Set<String> remoteUrls = buildData.getRemoteUrls();
-        for (String remoteUrl : remoteUrls) {
-            try {
-                LOGGER.log(Level.INFO, "Retrieving the gitlab project id from remote url {0}", remoteUrl);
-                final String projectNameWithNameSpace = ProjectIdUtil.retrieveProjectId(environment.expand(remoteUrl));
-                if (StringUtils.isNotBlank(projectNameWithNameSpace)) {
-                    String projectId = projectNameWithNameSpace;
-                    if (projectNameWithNameSpace.contains(".")) {
+        for(final BuildData buildData : buildDatas) {
+            for(final Entry<String, Build> buildByBranchName : buildData.getBuildsByBranchName().entrySet()) {
+            	if(buildByBranchName.getValue().getSHA1().equals(ObjectId.fromString(scmRevisionHash))) {
+                    final Set<String> remoteUrls = buildData.getRemoteUrls();
+                    for (String remoteUrl : remoteUrls) {
                         try {
-                            projectId = gitLabClient.getProject(projectNameWithNameSpace).getId().toString();
-                        } catch (WebApplicationException | ProcessingException e) {
-                            LOGGER.log(Level.SEVERE, String.format("Failed to retrieve projectId for project '%s'", projectNameWithNameSpace), e);
+                            LOGGER.log(Level.INFO, "Retrieving the gitlab project id from remote url {0}", remoteUrl);
+                            final String projectNameWithNameSpace = ProjectIdUtil.retrieveProjectId(environment.expand(remoteUrl));
+                            if (StringUtils.isNotBlank(projectNameWithNameSpace)) {
+                                String projectId = projectNameWithNameSpace;
+                                if (projectNameWithNameSpace.contains(".")) {
+                                    try {
+                                        projectId = gitLabClient.getProject(projectNameWithNameSpace).getId().toString();
+                                    } catch (WebApplicationException | ProcessingException e) {
+                                        LOGGER.log(Level.SEVERE, String.format("Failed to retrieve projectId for project '%s'", projectNameWithNameSpace), e);
+                                    }
+                                }
+                                result.add(new GitLabBranchBuild(projectId, scmRevisionHash));
+                            }
+                        } catch (ProjectIdUtil.ProjectIdResolutionException e) {
                         }
                     }
-                    result.add(projectId);
-                }
-            } catch (ProjectIdUtil.ProjectIdResolutionException e) {
-                // nothing to do
+            	}
             }
         }
+
         return result;
     }
 
+    public static class GitLabBranchBuild {
+    	private final String projectId;
+    	private final String revisionHash;
+    	
+    	public GitLabBranchBuild(final String projectId, final String revisionHash) {
+    		this.projectId = projectId;
+    		this.revisionHash = revisionHash;
+    	}
+    	
+    	public String getProjectId() {
+    		return this.projectId;
+    	}
+    	
+    	public String getRevisionHash() {
+    		return this.revisionHash;
+    	}
+    }
 }


### PR DESCRIPTION
Now using SCMRevisionAction for updating project status instead of library (is used).
Compare every build datas sha1 with the revision action's one to get the Gitlab project.

Fixes #523.