### PR TITLE
Change icon for build failure and aborted

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisher.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisher.java
@@ -122,11 +122,11 @@ public class GitLabMessagePublisher extends MergeRequestNotifier {
         if (result == Result.SUCCESS) {
             return ":white_check_mark:";
         } else if (result == Result.ABORTED) {
-            return ":point_up:";
+            return "";
         } else if (result == Result.UNSTABLE) {
             return ":warning:";
         } else {
-            return ":negative_squared_cross_mark:";
+            return ":x:";
         }
     }
 


### PR DESCRIPTION
Right now we're using [this](https://emojipedia.org/negative-squared-cross-mark/) icon for build failure comment which in a lot of browsers is a green square, which is quite misleading at a quick glance. I changed it to [this](https://emojipedia.org/cross-mark/) icon instead.

Also the current icon for an aborted build is a [thumb up](https://emojipedia.org/white-up-pointing-index/), which doesn't make any sense, however I can't find any appropriate icon for "aborted" so I just removed it.