### PR TITLE
Fix commit status exception

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -128,6 +128,11 @@ public class CommitStatusUpdater {
 		} else {
 	        final SCMRevisionAction scmRevisionAction = build.getAction(SCMRevisionAction.class);
 
+			if (scmRevisionAction == null) {
+				LOGGER.log(Level.INFO, "Build does not contain SCM revision action.");
+				return result;
+			}
+
 	        final SCMRevision scmRevision = scmRevisionAction.getRevision();
 
 	        String scmRevisionHash = null;


### PR DESCRIPTION
On push events, commit status fail with a NullPointerException because there's no SCMrevisionAction in the build actions.

Fixes #583.