### PR TITLE
If BlueOcean is installed, build URL does not point to BlueOcean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,9 +188,14 @@
       <version>3.5.2.201411120430-r</version>
     </dependency>
     <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>matrix-project</artifactId>
-        <version>1.10</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.10</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>display-url-api</artifactId>
+      <version>1.1.1</version>
     </dependency>
 
     <!-- REST client dependencies -->

--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -18,6 +18,7 @@ import javax.ws.rs.WebApplicationException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.lib.ObjectId;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 
 import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabApi;
@@ -98,7 +99,7 @@ public class CommitStatusUpdater {
     }
 
     private static String getBuildUrl(Run<?, ?> build) {
-        return Jenkins.getInstance().getRootUrl() + build.getUrl();
+        return DisplayURLProvider.get().getRunURL(build);
     }
 
 	private static List<GitLabBranchBuild> retrieveGitlabProjectIds(Run<?, ?> build, EnvVars environment) {


### PR DESCRIPTION
Doing the changes at @i386 was about to do in PR #524. Since he is not continuing that PR soon, this replaces his PR.

@omehegan @jkdeveyra this should fix the issue with pointing to Blue Ocean as mentioned in #518