### PR TITLE
Upgrade to use GitLab APIv4

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabApi.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabApi.java
@@ -25,7 +25,7 @@ import java.util.List;
 /**
  * @author Robin Müller
  */
-@Path("/api/v3")
+@Path("/api/v4")
 public interface GitLabApi {
 
     @POST
@@ -104,18 +104,18 @@ public interface GitLabApi {
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    @Path("/projects/{projectId}/merge_requests/{mergeRequestId}/merge")
+    @Path("/projects/{projectId}/merge_requests/{mergeRequestIid}/merge")
     void acceptMergeRequest(@PathParam("projectId") Integer projectId,
-                            @PathParam("mergeRequestId") Integer mergeRequestId,
+                            @PathParam("mergeRequestIid") Integer mergeRequestIid,
                             @FormParam("merge_commit_message") String mergeCommitMessage,
                             @FormParam("should_remove_source_branch") boolean shouldRemoveSourceBranch);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    @Path("/projects/{projectId}/merge_requests/{mergeRequestId}/notes")
+    @Path("/projects/{projectId}/merge_requests/{mergeRequestIid}/notes")
     void createMergeRequestNote(@PathParam("projectId") Integer projectId,
-                                @PathParam("mergeRequestId") Integer mergeRequestId,
+                                @PathParam("mergeRequestIid") Integer mergeRequestIid,
                                 @FormParam("body") String body);
 
     @GET

--- a/src/test/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfigTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfigTest.java
@@ -71,7 +71,7 @@ public class GitLabConnectionConfigTest {
 
     @Test
     public void doCheckConnection_success() {
-        HttpRequest request = request().withPath("/gitlab/api/v3/.*").withHeader("PRIVATE-TOKEN", API_TOKEN);
+        HttpRequest request = request().withPath("/gitlab/api/v4/.*").withHeader("PRIVATE-TOKEN", API_TOKEN);
         mockServerClient.when(request).respond(response().withStatusCode(Response.Status.OK.getStatusCode()));
 
         GitLabConnectionConfig connectionConfig = jenkins.get(GitLabConnectionConfig.class);
@@ -83,7 +83,7 @@ public class GitLabConnectionConfigTest {
 
     @Test
     public void doCheckConnection_forbidden() throws IOException {
-        HttpRequest request = request().withPath("/gitlab/api/v3/.*").withHeader("PRIVATE-TOKEN", API_TOKEN);
+        HttpRequest request = request().withPath("/gitlab/api/v4/.*").withHeader("PRIVATE-TOKEN", API_TOKEN);
         mockServerClient.when(request).respond(response().withStatusCode(Response.Status.FORBIDDEN.getStatusCode()));
 
         GitLabConnectionConfig connectionConfig = jenkins.get(GitLabConnectionConfig.class);

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabAcceptMergeRequestPublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabAcceptMergeRequestPublisherTest.java
@@ -148,7 +148,7 @@ public class GitLabAcceptMergeRequestPublisherTest {
 
     private HttpRequest prepareAcceptMergeRequest(Integer projectId, Integer mergeRequestId) throws UnsupportedEncodingException {
         return request()
-                .withPath("/gitlab/api/v3/projects/" + projectId + "/merge_requests/" + mergeRequestId + "/merge")
+                .withPath("/gitlab/api/v4/projects/" + projectId + "/merge_requests/" + mergeRequestId + "/merge")
                 .withMethod("PUT")
                 .withHeader("PRIVATE-TOKEN", "secret")
                 .withBody("merge_commit_message=Merge+Request+accepted+by+jenkins+build+success&should_remove_source_branch=false");

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
@@ -352,7 +352,7 @@ public class GitLabCommitStatusPublisherTest {
 
     private HttpRequest prepareUpdateCommitStatus(String projectId, String sha, String targetUrl, BuildState state) throws UnsupportedEncodingException {
         return request()
-                .withPath("/gitlab/api/v3/projects/" + URLEncoder.encode(projectId, "UTF-8") + "/statuses/" + sha)
+                .withPath("/gitlab/api/v4/projects/" + URLEncoder.encode(projectId, "UTF-8") + "/statuses/" + sha)
                 .withMethod("POST")
                 .withHeader("PRIVATE-TOKEN", "secret")
                 .withBody("state=" + URLEncoder.encode(state.name(), "UTF-8") + "&context=jenkins&" + "target_url=" + URLEncoder.encode(targetUrl, "UTF-8"));
@@ -366,14 +366,14 @@ public class GitLabCommitStatusPublisherTest {
 
     private HttpRequest prepareExistsCommit(String projectId, String sha) throws UnsupportedEncodingException {
         return request()
-                .withPath("/gitlab/api/v3/projects/" + URLEncoder.encode(projectId, "UTF-8") + "/repository/commits/" + sha)
+                .withPath("/gitlab/api/v4/projects/" + URLEncoder.encode(projectId, "UTF-8") + "/repository/commits/" + sha)
                 .withMethod("GET")
                 .withHeader("PRIVATE-TOKEN", "secret");
     }
 
     private HttpRequest prepareGetProjectResponse(String projectName, int projectId) throws IOException {
         HttpRequest request= request()
-                     .withPath("/gitlab/api/v3/projects/" + URLEncoder.encode(projectName, "UTF-8"))
+                     .withPath("/gitlab/api/v4/projects/" + URLEncoder.encode(projectName, "UTF-8"))
                      .withMethod("GET")
                    .  withHeader("PRIVATE-TOKEN", "secret");
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisherTest.java
@@ -304,7 +304,7 @@ public class GitLabMessagePublisherTest {
 
     private HttpRequest prepareSendMessageStatus(Integer projectId, Integer mergeRequestId, String body) throws UnsupportedEncodingException {
         return request()
-                .withPath("/gitlab/api/v3/projects/" + projectId + "/merge_requests/" + mergeRequestId + "/notes")
+                .withPath("/gitlab/api/v4/projects/" + projectId + "/merge_requests/" + mergeRequestId + "/notes")
                 .withMethod("POST")
                 .withHeader("PRIVATE-TOKEN", "secret")
                 .withBody("body=" + URLEncoder.encode(body, "UTF-8"));

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabVotePublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabVotePublisherTest.java
@@ -160,7 +160,7 @@ public class GitLabVotePublisherTest {
 
     private HttpRequest prepareSendMessageStatus(Integer projectId, Integer mergeRequestId, String body) throws UnsupportedEncodingException {
         return request()
-                .withPath("/gitlab/api/v3/projects/" + projectId + "/merge_requests/" + mergeRequestId + "/notes")
+                .withPath("/gitlab/api/v4/projects/" + projectId + "/merge_requests/" + mergeRequestId + "/notes")
                 .withMethod("POST")
                 .withHeader("PRIVATE-TOKEN", "secret")
                 .withBody("body=" + URLEncoder.encode(body, "UTF-8"));


### PR DESCRIPTION
This commit is the simplest change which seems to suffice to move the
Jenkins plugin to APIv4. [The docs][api-docs] regarding the move from
v3 to v4 and going through most of the source, suggest that is the only
change too.

To summerize, the path changed from `api/v3` to `api/v4` and when
referencing merge requests in paths the IID is now needed instead of the
ID.

Tests are passing, but in this case I feel like that doesn't suggest
anything and this branch will undergo some manual testing soon.

Fixes #530 

[api-docs]: https://docs.gitlab.com/ce/api/v3_to_v4.html