### PR TITLE
Fixes GitLabIT#buildOnNote()

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabApi.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabApi.java
@@ -38,7 +38,7 @@ public interface GitLabApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/merge_requests")
-    void createMergeRequest(
+    MergeRequest createMergeRequest(
         @PathParam("projectId") Integer projectId,
         @FormParam("source_branch") String sourceBranch,
         @FormParam("target_branch") String targetBranch,

--- a/src/test/java/com/dabsquared/gitlabjenkins/testing/gitlab/rule/GitLabRule.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testing/gitlab/rule/GitLabRule.java
@@ -2,6 +2,7 @@ package com.dabsquared.gitlabjenkins.testing.gitlab.rule;
 
 import com.dabsquared.gitlabjenkins.gitlab.JacksonConfig;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabApi;
+import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.Project;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.User;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
@@ -69,11 +70,15 @@ public class GitLabRule implements TestRule {
         return project.getHttpUrlToRepo();
     }
 
-    public void createMergeRequest(final Integer projectId,
-                                   final String sourceBranch,
-                                   final String targetBranch,
-                                   final String title) {
-        client.createMergeRequest(projectId, sourceBranch, targetBranch, title);
+    public MergeRequest createMergeRequest(final Integer projectId,
+                                           final String sourceBranch,
+                                           final String targetBranch,
+                                           final String title) {
+        return client.createMergeRequest(projectId, sourceBranch, targetBranch, title);
+    }
+
+    public void createMergeRequestNote(Integer projectId, Integer mergeRequestId, String body) {
+        client.createMergeRequestNote(projectId, mergeRequestId, body);
     }
 
     public String getUsername() {


### PR DESCRIPTION
Hi,

currently the Integration-Test GitLabIT#buildOnNote() is failing (see https://travis-ci.org/Argelbargel/gitlab-plugin/jobs/269206641).

This PR fixes the tests an ensures that the tests build is triggered by the note (see https://travis-ci.org/Argelbargel/gitlab-plugin/jobs/269210380)