### PR TITLE
make it clear that the note is a regex, not a plain string

### DIFF
--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -21,7 +21,7 @@
       <f:entry title="Comments" field="triggerOnNoteRequest">
         <f:checkbox default="true"/>
       </f:entry>
-      <f:entry title="Comment for triggering a build" help="/plugin/gitlab-plugin/help/help-noteRegex.html">
+      <f:entry title="Comment (regex) for triggering a build" help="/plugin/gitlab-plugin/help/help-noteRegex.html">
         <f:textbox field="noteRegex" default="Jenkins please retry a build"/>
       </f:entry>
     </table>

--- a/src/main/webapp/help/help-noteRegex.html
+++ b/src/main/webapp/help/help-noteRegex.html
@@ -1,5 +1,5 @@
 <div>
     <div>
-        <p>When filled, commenting this phrase in the merge request will trigger a build.</p>
+        <p>When filled, a comment in the merge request matching this regular expression will trigger a build.</p>
     </div>
 </div>


### PR DESCRIPTION
otherwise people might enter '[test]' and wonder why a '[test]' comment does not trigger a build.