### PR TITLE
Fixes #638 - Don't NPE if one of the filter specs is not specified in a Jenkinsfile

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/NameBasedFilter.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/NameBasedFilter.java
@@ -4,6 +4,7 @@ import com.google.common.base.Splitter;
 import org.springframework.util.AntPathMatcher;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -49,6 +50,9 @@ class NameBasedFilter implements BranchFilter {
     }
 
     private List<String> convert(String commaSeparatedString) {
+        if (commaSeparatedString == null)
+            return Collections.EMPTY_LIST;
+
         ArrayList<String> result = new ArrayList<>();
         for (String s : Splitter.on(',').omitEmptyStrings().trimResults().split(commaSeparatedString)) {
             result.add(s);

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/filter/NameBasedFilterTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/filter/NameBasedFilterTest.java
@@ -16,6 +16,7 @@ public class NameBasedFilterTest {
 
         assertThat(nameBasedFilter.isBranchAllowed("master"), is(true));
         assertThat(nameBasedFilter.isBranchAllowed("develop"), is(true));
+        assertThat(nameBasedFilter.isBranchAllowed("not-included-branch"), is(false));
     }
 
     @Test
@@ -34,5 +35,30 @@ public class NameBasedFilterTest {
         assertThat(nameBasedFilter.isBranchAllowed("master"), is(true));
         assertThat(nameBasedFilter.isBranchAllowed("develop"), is(false));
         assertThat(nameBasedFilter.isBranchAllowed("not-excluded-and-not-included-branch"), is(false));
+    }
+
+    @Test
+    public void allowIncludeAndExcludeToBeNull() {
+      NameBasedFilter nameBasedFilter = new NameBasedFilter(null, null);
+
+      assertThat(nameBasedFilter.isBranchAllowed("master"), is(true));
+    }
+
+    @Test
+    public void allowIncludeToBeNull() {
+      NameBasedFilter nameBasedFilter = new NameBasedFilter(null, "master, develop");
+
+      assertThat(nameBasedFilter.isBranchAllowed("master"), is(false));
+      assertThat(nameBasedFilter.isBranchAllowed("develop"), is(false));
+      assertThat(nameBasedFilter.isBranchAllowed("not-excluded-branch"), is(true));
+    }
+
+    @Test
+    public void allowExcludeToBeNull() {
+      NameBasedFilter nameBasedFilter = new NameBasedFilter("master, develop", null);
+
+      assertThat(nameBasedFilter.isBranchAllowed("master"), is(true));
+      assertThat(nameBasedFilter.isBranchAllowed("develop"), is(true));
+      assertThat(nameBasedFilter.isBranchAllowed("not-included-branch"), is(false));
     }
 }


### PR DESCRIPTION
This should fix #638 and adds tests to validate operation.