### PR TITLE
Added new hook events sent by Gitlab starting in 9.5.4

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/ActionResolver.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/ActionResolver.java
@@ -106,13 +106,18 @@ public class ActionResolver {
         String tokenHeader = request.getHeader("X-Gitlab-Token");
         switch (eventHeader) {
             case "Merge Request Hook":
+            case "Merge Requests Event":
                 return new MergeRequestBuildAction(project, getRequestBody(request), tokenHeader);
             case "Push Hook":
+            case "Push Event":
             case "Tag Push Hook":
+            case "Tag Push Event":
                 return new PushBuildAction(project, getRequestBody(request), tokenHeader);
             case "Note Hook":
+            case "Note Event":
                 return new NoteBuildAction(project, getRequestBody(request), tokenHeader);
             case "Pipeline Hook":
+            case "Pipeline Event":
                 return new PipelineBuildAction(project, getRequestBody(request), tokenHeader);
             default:
                 LOGGER.log(Level.FINE, "Unsupported X-Gitlab-Event header: {0}", eventHeader);


### PR DESCRIPTION

Since the 9.5.4 upgrade of Gitlab, when testing the hooks from the "integrations" section, the "X-Gitlab-Event" with the event description is sent in the form "xxx Event" (i.e. "Push Event") instead of the regular "xxx Hook", showing a 404 error on the Gitlab side when the hook is actually working as Gitlab does send "xxx Hook" kind of headers when the actual event is triggered.

Although it looks like a bug/inconsistency from Gitlab, this change extends the list of supported headers to overcome this inconsistency.