### PR TITLE
Fix unsupported date format in merge request trigger

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/util/JsonUtil.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/JsonUtil.java
@@ -46,7 +46,7 @@ public final class JsonUtil {
 
     private static class DateModule extends SimpleModule {
         private static final String[] DATE_FORMATS = new String[] {
-                "yyyy-MM-dd HH:mm:ss Z", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "yyyy-MM-dd'T'HH:mm:ssX"
+                "yyyy-MM-dd HH:mm:ss Z", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "yyyy-MM-dd'T'HH:mm:ssX", "yyyy-MM-dd'T'HH:mm:ss.SSSX", "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
         };
 
         private DateModule() {


### PR DESCRIPTION
GitLab now submits new formats for dates on the MR trigger. This change prevents the plugin from crashing when receiving such a trigger from a new version of GitLab. Old formats are preserved for compatibility.