### PR TITLE
Trigger builds when MR is approved

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Action.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Action.java
@@ -4,5 +4,5 @@ package com.dabsquared.gitlabjenkins.gitlab.hook.model;
  * @author Robin Müller
  */
 public enum Action {
-    open, update
+    open, update, approved
 }


### PR DESCRIPTION
The builds are not triggered because parsing of the action field fails.

I can't find this field being actually read anywhere,  hence no automated tests.

I verified manually that this works using our staging Jenkins instance and gitlab  10.0.4-ee