### PR TITLE
fixes #655

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfig.java
@@ -138,7 +138,7 @@ public class GitLabConnectionConfig extends GlobalConfiguration {
                                            @QueryParameter int connectionTimeout,
                                            @QueryParameter int readTimeout) {
         try {
-            new GitLabConnection("", url, apiTokenId, clientBuilderId, ignoreCertificateErrors, connectionTimeout, readTimeout).getClient().headCurrentUser();
+            new GitLabConnection("", url, apiTokenId, clientBuilderId, ignoreCertificateErrors, connectionTimeout, readTimeout).getClient().getCurrentUser();
             return FormValidation.ok(Messages.connection_success());
         } catch (WebApplicationException e) {
             return FormValidation.error(Messages.connection_error(e.getMessage()));

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClient.java
@@ -36,8 +36,6 @@ public interface GitLabClient {
 
     Branch getBranch(String projectId, String branch);
 
-    void headCurrentUser();
-
     User getCurrentUser();
 
     User addUser(String email, String username, String name, String password);

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
@@ -199,18 +199,6 @@ final class AutodetectingGitLabClient implements GitLabClient {
     }
 
     @Override
-    public void headCurrentUser() {
-        execute(
-            new GitLabOperation<Void>() {
-                @Override
-                Void execute(GitLabClient client) {
-                    client.headCurrentUser();
-                    return null;
-                }
-            });
-    }
-
-    @Override
     public User getCurrentUser() {
         return execute(
             new GitLabOperation<User>() {
@@ -287,7 +275,7 @@ final class AutodetectingGitLabClient implements GitLabClient {
         for (GitLabClientBuilder candidate : builders) {
             GitLabClient client = candidate.buildClient(url, token, ignoreCertificateErrors, connectionTimeout, readTimeout);
             try {
-                client.headCurrentUser();
+                client.getCurrentUser();
                 return client;
             } catch (NotFoundException ignored) {
                 // api-endpoint not found (== api-level not supported by this client)

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClient.java
@@ -96,11 +96,6 @@ final class ResteasyGitLabClient implements GitLabClient {
     }
 
     @Override
-    public void headCurrentUser() {
-        api.headCurrentUser();
-    }
-
-    @Override
     public User getCurrentUser() {
         return api.getCurrentUser();
     }

--- a/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClientTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClientTest.java
@@ -46,7 +46,7 @@ public class AutodetectingGitLabClientTest {
     @Test
     public void buildClient_success_v3() throws Exception {
         mockServerClient.when(v3Request).respond(responseOk());
-        api.headCurrentUser();
+        api.getCurrentUser();
         assertApiImpl(api, V3GitLabApiProxy.class);
         mockServerClient.verify(v3Request, v3Request);
     }
@@ -55,7 +55,7 @@ public class AutodetectingGitLabClientTest {
     public void buildClient_success_v4() throws Exception {
         mockServerClient.when(v3Request).respond(responseNotFound());
         mockServerClient.when(v4Request).respond(responseOk());
-        api.headCurrentUser();
+        api.getCurrentUser();
         assertApiImpl(api, V4GitLabApiProxy.class);
         mockServerClient.verify(v3Request, v4Request, v4Request);
     }
@@ -64,12 +64,12 @@ public class AutodetectingGitLabClientTest {
     public void buildClient_success_switching_apis() throws Exception {
         mockServerClient.when(v3Request, once()).respond(responseNotFound());
         mockServerClient.when(v4Request, exactly(2)).respond(responseOk());
-        api.headCurrentUser();
+        api.getCurrentUser();
         assertApiImpl(api, V4GitLabApiProxy.class);
 
         mockServerClient.when(v4Request, once()).respond(responseNotFound());
         mockServerClient.when(v3Request, exactly(2)).respond(responseOk());
-        api.headCurrentUser();
+        api.getCurrentUser();
         assertApiImpl(api, V3GitLabApiProxy.class);
 
         mockServerClient.verify(v3Request, v4Request, v4Request, v3Request, v3Request);
@@ -80,7 +80,7 @@ public class AutodetectingGitLabClientTest {
         mockServerClient.when(v3Request).respond(responseNotFound());
         mockServerClient.when(v4Request).respond(responseNotFound());
         try {
-            api.headCurrentUser();
+            api.getCurrentUser();
             fail("endpoint should throw exception when no matching delegate is found");
         } catch (NoSuchElementException e) {
             mockServerClient.verify(v3Request, v4Request);

--- a/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/TestUtility.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/TestUtility.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.List;
 
-import static javax.ws.rs.HttpMethod.HEAD;
+import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,7 +46,7 @@ class TestUtility {
     }
 
     static HttpRequest versionRequest(String id) {
-        return request().withMethod(HEAD).withPath("/gitlab/api/" + id + "/.*").withHeader("PRIVATE-TOKEN", API_TOKEN);
+        return request().withMethod(GET).withPath("/gitlab/api/" + id + "/.*").withHeader("PRIVATE-TOKEN", API_TOKEN);
     }
 
     static HttpResponse responseOk() {

--- a/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabClientStub.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabClientStub.java
@@ -140,11 +140,6 @@ class GitLabClientStub implements GitLabClient {
     }
 
     @Override
-    public void headCurrentUser() {
-
-    }
-
-    @Override
     public User getCurrentUser() {
         return null;
     }

--- a/src/test/java/com/dabsquared/gitlabjenkins/util/GitLabClientStub.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/util/GitLabClientStub.java
@@ -89,11 +89,6 @@ class GitLabClientStub implements GitLabClient {
     }
 
     @Override
-    public void headCurrentUser() {
-
-    }
-
-    @Override
     public User getCurrentUser() {
         return null;
     }


### PR DESCRIPTION
Fixes #655 
Swtiches to getCurrentUser() for connection-testing and autodetecting the gitlab-api-level to use and removes removes GitlabClient#headCurrentUser(). Should fix the problems reported in #655 