### PR TITLE
Make it possible to send pending build status to gitlab when a pipeline job is queued

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,11 @@
       <version>1.15</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>1.15</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
       <version>2.1.0</version>

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -100,6 +100,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
     private String targetBranchRegex;
     private MergeRequestLabelFilterConfig mergeRequestLabelFilterConfig;
     private volatile Secret secretToken;
+    private String pendingBuildName;
 
     private transient BranchFilter branchFilter;
     private transient PushHookTriggerHandler pushHookTriggerHandler;
@@ -120,8 +121,8 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
                              boolean setBuildDescription, boolean addNoteOnMergeRequest, boolean addCiMessage, boolean addVoteOnMergeRequest,
                              boolean acceptMergeRequestOnSuccess, BranchFilterType branchFilterType,
                              String includeBranchesSpec, String excludeBranchesSpec, String targetBranchRegex,
-                             MergeRequestLabelFilterConfig mergeRequestLabelFilterConfig, String secretToken, boolean triggerOnPipelineEvent, 
-                             boolean triggerOnApprovedMergeRequest) {
+                             MergeRequestLabelFilterConfig mergeRequestLabelFilterConfig, String secretToken, boolean triggerOnPipelineEvent,
+                             boolean triggerOnApprovedMergeRequest, String pendingBuildName) {
         this.triggerOnPush = triggerOnPush;
         this.triggerOnMergeRequest = triggerOnMergeRequest;
         this.triggerOnAcceptedMergeRequest = triggerOnAcceptedMergeRequest;
@@ -144,6 +145,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         this.mergeRequestLabelFilterConfig = mergeRequestLabelFilterConfig;
         this.secretToken = Secret.fromString(secretToken);
         this.triggerOnApprovedMergeRequest = triggerOnApprovedMergeRequest;
+        this.pendingBuildName = pendingBuildName;
 
         initializeTriggerHandler();
         initializeBranchFilter();
@@ -269,6 +271,10 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         return secretToken == null ? null : secretToken.getPlainText();
     }
 
+    public String getPendingBuildName() {
+        return pendingBuildName;
+    }
+
     @DataBoundSetter
     public void setTriggerOnPush(boolean triggerOnPush) {
         this.triggerOnPush = triggerOnPush;
@@ -377,6 +383,11 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
     @DataBoundSetter
     public void setAcceptMergeRequestOnSuccess(boolean acceptMergeRequestOnSuccess) {
         this.acceptMergeRequestOnSuccess = acceptMergeRequestOnSuccess;
+    }
+
+    @DataBoundSetter
+    public void setPendingBuildName(String pendingBuildName) {
+        this.pendingBuildName = pendingBuildName;
     }
 
     // executes when the Trigger receives a push request

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -42,6 +42,9 @@
     <f:entry title="Build on successful pipeline events" field="triggerOnPipelineEvent">
       <f:checkbox default="false"/>
     </f:entry>
+    <f:entry title="Pending build name for pipeline" help="/plugin/gitlab-plugin/help/help-pendingBuildName.html">
+      <f:textbox field="pendingBuildName"/>
+    </f:entry>
 
     <f:entry title="Allowed branches">
       <table>

--- a/src/main/webapp/help/help-pendingBuildName.html
+++ b/src/main/webapp/help/help-pendingBuildName.html
@@ -1,0 +1,8 @@
+<div>
+  <div>
+    <p>Applicable only for pipelines.</p>
+    <p>When filled, a 'pending' build status with the given build name is published to Gitlab when the pipeline is
+      triggered. Further status updates should be defined in pipeline steps.</p>
+    <p>For other types of jobs, the 'Publish build status to Gitlab commit' post-build action can be used.</p>
+  </div>
+</div>


### PR DESCRIPTION
It seems that it is currently not possible to update the build status to 'pending' in Gitlab immediately when a pipeline job is triggered. This is not good if pipeline has to wait a long time in a queue before the execution starts. Updating the status to 'pending' works for normal jobs.

This pull request contains one way to implement the 'pending' status update for pipelines but it is probably not the best possible. So, if someone who is more familiar with Gitlab-plugin and Jenkins in general has an idea how this could be implemented cleanly, I might have some time to work on it.