### PR TITLE
Fix MergeRequestBuildActionTest

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -73,7 +73,7 @@ import static com.dabsquared.gitlabjenkins.trigger.handler.push.PushHookTriggerH
  *
  * @author Daniel Brooks
  */
-public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
+public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeRequestTriggerConfig {
 
     private static final SecureRandom RANDOM = new SecureRandom();
 
@@ -213,18 +213,22 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         return triggerOnPush;
     }
 
+    @Override
     public boolean getTriggerOnMergeRequest() {
         return triggerOnMergeRequest;
     }
 
+    @Override
     public boolean isTriggerOnAcceptedMergeRequest() {
         return triggerOnAcceptedMergeRequest;
     }
 
+    @Override
     public boolean isTriggerOnApprovedMergeRequest() {
 		return triggerOnApprovedMergeRequest;
 	}    
     
+    @Override
     public boolean isTriggerOnClosedMergeRequest() {
         return triggerOnClosedMergeRequest;
     }
@@ -239,6 +243,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         return this.noteRegex == null ? "" : this.noteRegex;
     }
 
+    @Override
     public TriggerOpenMergeRequest getTriggerOpenMergeRequestOnPush() {
         return triggerOpenMergeRequestOnPush;
     }
@@ -251,6 +256,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         return ciSkip;
     }
 
+    @Override
     public boolean isSkipWorkInProgressMergeRequest() {
         return skipWorkInProgressMergeRequest;
     }
@@ -287,6 +293,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         return pendingBuildName;
     }
 
+    @Override
     public boolean getCancelPendingBuildsOnUpdate() {
         return this.cancelPendingBuildsOnUpdate;
     }
@@ -475,9 +482,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
     }
 
     private void initializeTriggerHandler() {
-		mergeRequestHookTriggerHandler = newMergeRequestHookTriggerHandler(triggerOnMergeRequest,
-				triggerOnAcceptedMergeRequest, triggerOnClosedMergeRequest, triggerOpenMergeRequestOnPush,
-				skipWorkInProgressMergeRequest, triggerOnApprovedMergeRequest, cancelPendingBuildsOnUpdate);
+		mergeRequestHookTriggerHandler = newMergeRequestHookTriggerHandler(this);
         noteHookTriggerHandler = newNoteHookTriggerHandler(triggerOnNoteRequest, noteRegex);
         pushHookTriggerHandler = newPushHookTriggerHandler(triggerOnPush, triggerOpenMergeRequestOnPush, skipWorkInProgressMergeRequest);
         pipelineTriggerHandler = newPipelineHookTriggerHandler(triggerOnPipelineEvent);

--- a/src/main/java/com/dabsquared/gitlabjenkins/MergeRequestTriggerConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/MergeRequestTriggerConfig.java
@@ -1,0 +1,19 @@
+package com.dabsquared.gitlabjenkins;
+
+import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
+
+public interface MergeRequestTriggerConfig {
+    boolean getTriggerOnMergeRequest();
+
+    boolean isTriggerOnAcceptedMergeRequest();
+
+    boolean isTriggerOnApprovedMergeRequest();
+
+    boolean isTriggerOnClosedMergeRequest();
+
+    TriggerOpenMergeRequest getTriggerOpenMergeRequestOnPush();
+
+    boolean isSkipWorkInProgressMergeRequest();
+
+    boolean getCancelPendingBuildsOnUpdate();
+}

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Action.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Action.java
@@ -4,5 +4,5 @@ package com.dabsquared.gitlabjenkins.gitlab.hook.model;
  * @author Robin Müller
  */
 public enum Action {
-    open, reopen, update, merge, approved
+    open, update, approved, merge, closed, reopen
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
@@ -1,5 +1,6 @@
 package com.dabsquared.gitlabjenkins.trigger.handler.merge;
 
+import com.dabsquared.gitlabjenkins.MergeRequestTriggerConfig;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.Action;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
 import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
@@ -35,4 +36,101 @@ public final class MergeRequestHookTriggerHandlerFactory {
         return new MergeRequestHookTriggerHandlerImpl(chain, skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);
     }
 
+    public static MergeRequestHookTriggerHandler newMergeRequestHookTriggerHandler(MergeRequestTriggerConfig config) {
+        return newMergeRequestHookTriggerHandler(config.getTriggerOnMergeRequest(),
+            config.isTriggerOnAcceptedMergeRequest(),
+            config.isTriggerOnClosedMergeRequest(),
+            config.getTriggerOpenMergeRequestOnPush(),
+            config.isSkipWorkInProgressMergeRequest(),
+            config.isTriggerOnApprovedMergeRequest(),
+            config.getCancelPendingBuildsOnUpdate());
+    }
+
+    public static Config withConfig() {
+        return new Config();
+    }
+
+    public static class Config implements MergeRequestTriggerConfig {
+        private boolean triggerOnMergeRequest = true;
+        private boolean triggerOnAcceptedMergeRequest = false;
+        private boolean triggerOnClosedMergeRequest = false;
+        private TriggerOpenMergeRequest triggerOpenMergeRequest = TriggerOpenMergeRequest.never;
+        private boolean skipWorkInProgressMergeRequest = false;
+        private boolean triggerOnApprovedMergeRequest = false;
+        private boolean cancelPendingBuildsOnUpdate = false;
+
+        @Override
+        public boolean getTriggerOnMergeRequest() {
+            return triggerOnMergeRequest;
+        }
+
+        @Override
+        public boolean isTriggerOnAcceptedMergeRequest() {
+            return triggerOnAcceptedMergeRequest;
+        }
+
+        @Override
+        public boolean isTriggerOnApprovedMergeRequest() {
+            return triggerOnApprovedMergeRequest;
+        }
+
+        @Override
+        public boolean isTriggerOnClosedMergeRequest() {
+            return triggerOnClosedMergeRequest;
+        }
+
+        @Override
+        public TriggerOpenMergeRequest getTriggerOpenMergeRequestOnPush() {
+            return triggerOpenMergeRequest;
+        }
+
+        @Override
+        public boolean isSkipWorkInProgressMergeRequest() {
+            return skipWorkInProgressMergeRequest;
+        }
+
+        @Override
+        public boolean getCancelPendingBuildsOnUpdate() {
+            return cancelPendingBuildsOnUpdate;
+        }
+
+        public Config setTriggerOnMergeRequest(boolean triggerOnMergeRequest) {
+            this.triggerOnMergeRequest = triggerOnMergeRequest;
+            return this;
+        }
+
+        public Config setTriggerOnAcceptedMergeRequest(boolean triggerOnAcceptedMergeRequest) {
+            this.triggerOnAcceptedMergeRequest = triggerOnAcceptedMergeRequest;
+            return this;
+        }
+
+        public Config setTriggerOnClosedMergeRequest(boolean triggerOnClosedMergeRequest) {
+            this.triggerOnClosedMergeRequest = triggerOnClosedMergeRequest;
+            return this;
+        }
+
+        public Config setTriggerOpenMergeRequest(TriggerOpenMergeRequest triggerOpenMergeRequest) {
+            this.triggerOpenMergeRequest = triggerOpenMergeRequest;
+            return this;
+        }
+
+        public Config setSkipWorkInProgressMergeRequest(boolean skipWorkInProgressMergeRequest) {
+            this.skipWorkInProgressMergeRequest = skipWorkInProgressMergeRequest;
+            return this;
+        }
+
+        public Config setTriggerOnApprovedMergeRequest(boolean triggerOnApprovedMergeRequest) {
+            this.triggerOnApprovedMergeRequest = triggerOnApprovedMergeRequest;
+            return this;
+        }
+
+        public Config setCancelPendingBuildsOnUpdate(boolean cancelPendingBuildsOnUpdate) {
+            this.cancelPendingBuildsOnUpdate = cancelPendingBuildsOnUpdate;
+            return this;
+        }
+
+        public MergeRequestHookTriggerHandler build() {
+            return newMergeRequestHookTriggerHandler(this);
+        }
+    }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
@@ -4,11 +4,6 @@ import com.dabsquared.gitlabjenkins.gitlab.hook.model.Action;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
 import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
 
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Set;
-
 import static com.dabsquared.gitlabjenkins.trigger.handler.merge.StateAndActionConfig.notEqual;
 import static com.dabsquared.gitlabjenkins.trigger.handler.merge.StateAndActionConfig.nullOrContains;
 import static java.util.EnumSet.of;
@@ -29,11 +24,12 @@ public final class MergeRequestHookTriggerHandlerFactory {
                                                                                    boolean cancelPendingBuildsOnUpdate) {
 
         TriggerConfigChain chain = new TriggerConfigChain();
-        chain.addIf(triggerOnMergeRequest, nullOrContains(of(State.opened, State.reopened)), notEqual(Action.approved))
-            .addIf(triggerOnAcceptedMergeRequest, null, of(Action.merge))
-            .addIf(triggerOnClosedMergeRequest, null, of(Action.closed))
-            .addIf(triggerOpenMergeRequest != TriggerOpenMergeRequest.never, of(State.updated), null)
-            .addIf(triggerOnApprovedMergeRequest, null, of(Action.approved))
+        chain
+            .acceptOnlyIf(triggerOnApprovedMergeRequest, null, of(Action.approved))
+            .acceptIf(triggerOnMergeRequest, of(State.opened, State.reopened), null)
+            .acceptIf(triggerOnAcceptedMergeRequest, null, of(Action.merge))
+            .acceptIf(triggerOnClosedMergeRequest, null, of(Action.closed))
+            .acceptIf(triggerOpenMergeRequest != TriggerOpenMergeRequest.never, of(State.updated), null)
         ;
 
         return new MergeRequestHookTriggerHandlerImpl(chain, skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -49,8 +49,11 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
         this(allowedStates, EnumSet.noneOf(Action.class), skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);
     }
 
+    // this retains internal API, however, the plugin code no longer instantiates the handler this way.
+    // any code using it should test it on higher level
+    @Deprecated
     MergeRequestHookTriggerHandlerImpl(Collection<State> allowedStates, Collection<Action> allowedActions, boolean skipWorkInProgressMergeRequest, boolean cancelPendingBuildsOnUpdate) {
-        this(new StateAndActionConfig(allowedStates, allowedActions), skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);
+        this(new TriggerConfigChain().add(allowedStates, null).add(null, allowedActions), skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);
     }
 
     MergeRequestHookTriggerHandlerImpl(Predicate<MergeRequestObjectAttributes> triggerConfig, boolean skipWorkInProgressMergeRequest, boolean cancelPendingBuildsOnUpdate) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/StateAndActionConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/StateAndActionConfig.java
@@ -1,0 +1,50 @@
+package com.dabsquared.gitlabjenkins.trigger.handler.merge;
+
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.Action;
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.MergeRequestObjectAttributes;
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Objects;
+
+class StateAndActionConfig implements Predicate<MergeRequestObjectAttributes> {
+    private final Predicate<State> states;
+    private final Predicate<Action> actions;
+
+    public StateAndActionConfig(Collection<State> allowedStates, Collection<Action> allowedActions) {
+        this(nullOrContains(allowedStates), nullOrContains(allowedActions));
+    }
+
+    public StateAndActionConfig(Predicate<State> states, Predicate<Action> actions) {
+        this.states = states == null ? Predicates.<State>alwaysTrue() : states;
+        this.actions = actions == null ? Predicates.<Action>alwaysTrue() : actions;
+    }
+
+    @Override
+    public boolean apply(MergeRequestObjectAttributes mergeRequestObjectAttributes) {
+        return
+            states.apply(mergeRequestObjectAttributes.getState()) &&
+            actions.apply(mergeRequestObjectAttributes.getAction());
+    }
+
+    static <T> Predicate<T> nullOrContains(final Collection<T> collection) {
+        return collection == null ? Predicates.<T>alwaysTrue() : new Predicate<T>() {
+            @Override
+            public boolean apply(@Nullable T t) {
+                return t == null || collection.contains(t);
+            }
+        };
+    }
+
+    static <T> Predicate<T> notEqual(final T value) {
+        return new Predicate<T>() {
+            @Override
+            public boolean apply(@Nullable T t) {
+                return !Objects.equals(t, value);
+            }
+        };
+    }
+}

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/TriggerConfigChain.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/TriggerConfigChain.java
@@ -1,0 +1,40 @@
+package com.dabsquared.gitlabjenkins.trigger.handler.merge;
+
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.Action;
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.MergeRequestObjectAttributes;
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
+import com.google.common.base.Predicate;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+public class TriggerConfigChain implements Predicate<MergeRequestObjectAttributes> {
+    private final List<Predicate<MergeRequestObjectAttributes>> chain = new ArrayList<>();
+
+    public TriggerConfigChain addIf(boolean condition, Predicate<MergeRequestObjectAttributes> trigger) {
+        if (condition) {
+            this.chain.add(trigger);
+        }
+        return this;
+    }
+
+    public TriggerConfigChain addIf(boolean condition, EnumSet<State> states, EnumSet<Action> actions) {
+        return addIf(condition, new StateAndActionConfig(states, actions));
+    }
+
+    public TriggerConfigChain addIf(boolean condition, Predicate<State> states, Predicate<Action> actions) {
+        return addIf(condition, new StateAndActionConfig(states, actions));
+    }
+
+    @Override
+    public boolean apply(@Nullable MergeRequestObjectAttributes mergeRequestObjectAttributes) {
+        for (Predicate<MergeRequestObjectAttributes> predicate : chain) {
+            if (predicate.apply(mergeRequestObjectAttributes)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
@@ -3,6 +3,7 @@ package com.dabsquared.gitlabjenkins.trigger.handler.merge;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.Action;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.MergeRequestObjectAttributesBuilder;
+import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
 import com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterFactory;
 import com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterType;
 import hudson.Launcher;
@@ -12,15 +13,7 @@ import hudson.model.FreeStyleProject;
 import hudson.plugins.git.GitSCM;
 import hudson.util.OneShotEvent;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.ConcurrentRefUpdateException;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.api.errors.NoHeadException;
-import org.eclipse.jgit.api.errors.NoMessageException;
-import org.eclipse.jgit.api.errors.UnmergedPathsException;
-import org.eclipse.jgit.api.errors.WrongRepositoryStateException;
-import org.eclipse.jgit.errors.AmbiguousObjectException;
-import org.eclipse.jgit.errors.IncorrectObjectTypeException;
-import org.eclipse.jgit.errors.MissingObjectException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -196,8 +189,12 @@ public class MergeRequestHookTriggerHandlerImplTest {
     }
 
     @Test
-    public void mergeRequest_do_not_build_for_updated_state_and_approved_action_when_updated_enabled_but_approved_not() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.updated), EnumSet.noneOf(Action.class), false, false);
+    public void mergeRequest_do_not_build_for_updated_state_and_approved_action_when_updated_enabled_but_approved_not() throws IOException, InterruptedException, GitAPIException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler =
+            MergeRequestHookTriggerHandlerFactory.newMergeRequestHookTriggerHandler(
+                true, false, false, TriggerOpenMergeRequest.source,
+                true, false, false
+            );
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
 
         assertThat(buildTriggered.isSignaled(), is(false));
@@ -294,9 +291,8 @@ public class MergeRequestHookTriggerHandlerImplTest {
     }
 
 	private OneShotEvent doHandle(MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler,
-			MergeRequestObjectAttributesBuilder objectAttributes) throws GitAPIException, IOException, NoHeadException,
-			NoMessageException, UnmergedPathsException, ConcurrentRefUpdateException, WrongRepositoryStateException,
-			AmbiguousObjectException, IncorrectObjectTypeException, MissingObjectException, InterruptedException {
+			MergeRequestObjectAttributesBuilder objectAttributes) throws GitAPIException, IOException,
+            InterruptedException {
 		Git.init().setDirectory(tmp.getRoot()).call();
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
@@ -28,8 +28,12 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+import org.junit.runner.Description;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -49,10 +53,28 @@ import static org.junit.Assert.assertThat;
 /**
  * @author Robin Müller
  */
+// TODO: This class should rather use triggers instantiated by MergeRequestHookTriggerHandlerFactory and test real-world scenarios
 public class MergeRequestHookTriggerHandlerImplTest {
+    private static final Logger logger = LoggerFactory.getLogger(MergeRequestHookTriggerHandlerImplTest.class);
 
     @ClassRule
-    public static JenkinsRule jenkins = new JenkinsRule();
+    public static JenkinsRule jenkins;
+
+    static {
+        // Every negative (or failing positive) test adds 10 seconds to run time. The default 180 seconds might not
+        // suffice
+        System.setProperty("jenkins.test.timeout", "300");
+        jenkins = new JenkinsRule();
+    }
+
+    @Rule
+    public TestName name = new TestName() {
+        @Override
+        protected void starting(Description d) {
+            super.starting(d);
+            logger.info(">> Starting test {}", getMethodName());
+        }
+    };
 
     @Rule
     public TemporaryFolder tmp = new TemporaryFolder();

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
@@ -40,13 +40,13 @@ import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.P
 import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.UserBuilder.user;
 import static com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterConfig.BranchFilterConfigBuilder.branchFilterConfig;
 import static com.dabsquared.gitlabjenkins.trigger.filter.MergeRequestLabelFilterFactory.newMergeRequestLabelFilter;
+import static com.dabsquared.gitlabjenkins.trigger.handler.merge.MergeRequestHookTriggerHandlerFactory.withConfig;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 /**
  * @author Robin Müller
  */
-// TODO: This class should rather use triggers instantiated by MergeRequestHookTriggerHandlerFactory and test real-world scenarios
 public class MergeRequestHookTriggerHandlerImplTest {
     private static final Logger logger = LoggerFactory.getLogger(MergeRequestHookTriggerHandlerImplTest.class);
 
@@ -81,7 +81,7 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
     @Test
     public void mergeRequest_build_when_opened() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened, State.reopened), EnumSet.noneOf(Action.class), false, false);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig().build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.opened);
 
         assertThat(buildTriggered.isSignaled(), is(true));
@@ -89,7 +89,8 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
     @Test
     public void mergeRequest_build_when_reopened() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened, State.reopened), EnumSet.noneOf(Action.class), false, false);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.reopened);
 
         assertThat(buildTriggered.isSignaled(), is(true));
@@ -97,7 +98,9 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
     @Test
     public void mergeRequest_build_when_opened_with_approved_action_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened, State.reopened), Arrays.asList(Action.approved), false, false);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnApprovedMergeRequest(true)
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.opened);
 
         assertThat(buildTriggered.isSignaled(), is(true));
@@ -105,16 +108,21 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
     @Test
     public void mergeRequest_build_when_accepted() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.merged), EnumSet.noneOf(Action.class), false, false);
-        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.merged);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnAcceptedMergeRequest(true)
+            .build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.merged, Action.merge);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
     public void mergeRequest_build_when_accepted_with_approved_action_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.merged), Arrays.asList(Action.approved), false, false);
-        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.merged);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnAcceptedMergeRequest(true)
+            .setTriggerOnApprovedMergeRequest(true)
+            .build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.merged, Action.merge);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
@@ -122,16 +130,21 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
     @Test
     public void mergeRequest_build_when_closed() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.closed), EnumSet.noneOf(Action.class), false, false);
-        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.closed);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnClosedMergeRequest(true)
+            .build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.closed, Action.closed);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
     public void mergeRequest_build_when_closed_with_actions_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.closed), Arrays.asList(Action.approved), false, false);
-        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.closed);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnClosedMergeRequest(true)
+            .setTriggerOnApprovedMergeRequest(true)
+            .build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.closed, Action.closed);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
@@ -158,15 +171,21 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
     @Test
     public void mergeRequest_do_not_build_when_accepted_some_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened, State.updated), Arrays.asList(Action.approved), false, false);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
+            .setTriggerOnApprovedMergeRequest(true)
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.merged);
 
         assertThat(buildTriggered.isSignaled(), is(false));
     }
 
     @Test
-    public void mergeRequest_build_for_accepted_state_when_approved_action_triggered() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened, State.updated), Arrays.asList(Action.approved), false, false);
+    public void mergeRequest_build_for_accepted_state_when_approved_action_triggered() throws IOException, InterruptedException, GitAPIException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnApprovedMergeRequest(true)
+            .setTriggerOnAcceptedMergeRequest(true)
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.merged, Action.approved);
 
         assertThat(buildTriggered.isSignaled(), is(true));
@@ -174,15 +193,20 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
     @Test
     public void mergeRequest_do_not_build_when_closed() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened, State.updated), Arrays.asList(Action.approved), false, false);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
+            .setTriggerOnApprovedMergeRequest(true)
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.closed);
 
         assertThat(buildTriggered.isSignaled(), is(false));
     }
 
     @Test
-    public void mergeRequest_do_not_build_for_updated_state_and_approved_action_when_both_not_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened), EnumSet.noneOf(Action.class), false, false);
+    public void mergeRequest_do_not_build_for_updated_state_and_approved_action_when_both_not_enabled() throws IOException, InterruptedException, GitAPIException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
 
         assertThat(buildTriggered.isSignaled(), is(false));
@@ -191,18 +215,18 @@ public class MergeRequestHookTriggerHandlerImplTest {
     @Test
     public void mergeRequest_do_not_build_for_updated_state_and_approved_action_when_updated_enabled_but_approved_not() throws IOException, InterruptedException, GitAPIException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler =
-            MergeRequestHookTriggerHandlerFactory.newMergeRequestHookTriggerHandler(
-                true, false, false, TriggerOpenMergeRequest.source,
-                true, false, false
-            );
+            withConfig()
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
 
         assertThat(buildTriggered.isSignaled(), is(false));
     }
 
     @Test
-    public void mergeRequest_build_for_update_state_when_updated_state_and_approved_action_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened, State.updated), Arrays.asList(Action.approved), false, false);
+    public void mergeRequest_build_for_update_state_when_updated_state_and_approved_action_enabled() throws IOException, InterruptedException, GitAPIException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnApprovedMergeRequest(true)
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
 
         assertThat(buildTriggered.isSignaled(), is(true));
@@ -210,7 +234,10 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
     @Test
     public void mergeRequest_build_for_update_state_and_action_when_updated_state_and_approved_action_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened, State.updated), Arrays.asList(Action.approved), false, false);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnApprovedMergeRequest(true)
+            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.update);
 
         assertThat(buildTriggered.isSignaled(), is(true));
@@ -218,7 +245,9 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
     @Test
     public void mergeRequest_do_not_build_for_update_state_and_action_when_opened_state_and_approved_action_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened), Arrays.asList(Action.approved), false, false);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnApprovedMergeRequest(true)
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.update);
 
         assertThat(buildTriggered.isSignaled(), is(false));
@@ -226,7 +255,9 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
     @Test
     public void mergeRequest_build_for_update_state_when_updated_state_and_merge_action() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened, State.updated), Arrays.asList(Action.approved), false, false);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnAcceptedMergeRequest(true)
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.merge);
 
         assertThat(buildTriggered.isSignaled(), is(true));
@@ -234,15 +265,19 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
     @Test
     public void mergeRequest_build_for_approved_action_when_opened_state_and_approved_action_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened), Arrays.asList(Action.approved), false, false);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnApprovedMergeRequest(true)
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
-
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
     public void mergeRequest_build_for_approved_action_when_only_approved_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(EnumSet.noneOf(State.class), EnumSet.of(Action.approved), false, false);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnMergeRequest(false)
+            .setTriggerOnApprovedMergeRequest(true)
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
 
         assertThat(buildTriggered.isSignaled(), is(true));
@@ -264,7 +299,9 @@ public class MergeRequestHookTriggerHandlerImplTest {
     }
 
     private void do_not_build_for_state_when_nothing_enabled(State state) throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(EnumSet.noneOf(State.class), EnumSet.noneOf(Action.class), false, false);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnMergeRequest(false)
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, state);
 
         assertThat(buildTriggered.isSignaled(), is(false));
@@ -272,7 +309,10 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
 	private void mergeRequest_build_only_when_approved(Action action)
 			throws GitAPIException, IOException, InterruptedException {
-		MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(EnumSet.noneOf(State.class), EnumSet.of(Action.approved), false, false);
+		MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnMergeRequest(false)
+            .setTriggerOnApprovedMergeRequest(true)
+            .build();
 	    OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, action);
 
 	    assertThat(buildTriggered.isSignaled(), is(false));

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildActionTest.java
@@ -142,8 +142,6 @@ public class MergeRequestBuildActionTest {
         FreeStyleProject testProject = jenkins.createFreeStyleProject();
         testProject.addTrigger(trigger);
         testProject.setScm(new GitSCM(gitRepoUrl));
-        QueueTaskFuture<?> future = testProject.scheduleBuild2(0, new ParametersAction(new StringParameterValue("gitlabTargetBranch", "master")));
-        future.get();
 
         executeMergeRequestAction(testProject, getJson("MergeRequestEvent_approvedMR.json"));
 
@@ -160,7 +158,20 @@ public class MergeRequestBuildActionTest {
 
         executeMergeRequestAction(testProject, getJson("MergeRequestEvent_alreadyBuiltMR.json"));
         assertFalse(wouldFire);
+    }
 
+    @Test
+    public void build_acceptedMr() throws IOException, ExecutionException, InterruptedException {
+        FreeStyleProject testProject = jenkins.createFreeStyleProject();
+        trigger.setTriggerOnAcceptedMergeRequest(true);
+        trigger.setTriggerOnMergeRequest(false);
+        testProject.addTrigger(trigger);
+        testProject.setScm(new GitSCM(gitRepoUrl));
+        QueueTaskFuture<?> future = testProject.scheduleBuild2(0, new ParametersAction(new StringParameterValue("gitlabTargetBranch", "master")));
+        future.get();
+
+        executeMergeRequestAction(testProject, getJson("MergeRequestEvent_merged.json"));
+        assertTrue(wouldFire);
     }
 
     @Test

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildActionTest.java
@@ -112,7 +112,6 @@ public class MergeRequestBuildActionTest {
         try {
             wouldFire = false;
 
-            // spy always feels wrong, we should likely rather directly check whether job has been scheduled after call.
             trigger.start(testProject, false);
 
             new MergeRequestBuildAction(testProject, json, null)

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildActionTest.java
@@ -120,7 +120,7 @@ public class MergeRequestBuildActionTest {
             // Test for OK status of a response.
             try {
                 hre.generateResponse(null, response, null);
-                verify(response).setStatus(200);
+                verify(response, atLeastOnce()).setStatus(200);
             } catch (ServletException e) {
                 throw new IOException(e);
             }
@@ -149,13 +149,12 @@ public class MergeRequestBuildActionTest {
     }
 
     @Test
-    public void skip_alreadyBuiltMR() throws IOException, ExecutionException, InterruptedException {
+    public void skip_alreadyBuiltMR() throws Exception {
         FreeStyleProject testProject = jenkins.createFreeStyleProject();
         testProject.addTrigger(trigger);
         testProject.setScm(new GitSCM(gitRepoUrl));
-        QueueTaskFuture<?> future = testProject.scheduleBuild2(0, new ParametersAction(new StringParameterValue("gitlabTargetBranch", "master")));
-        future.get();
-
+        executeMergeRequestAction(testProject, getJson("MergeRequestEvent_alreadyBuiltMR_initialBuild.json"));
+        jenkins.waitUntilNoActivity();
         executeMergeRequestAction(testProject, getJson("MergeRequestEvent_alreadyBuiltMR.json"));
         assertFalse(wouldFire);
     }
@@ -206,7 +205,7 @@ public class MergeRequestBuildActionTest {
                 .build()));
         future.get();
 
-        executeMergeRequestAction(testProject, getJson("MergeRequestEvent_alreadyBuiltMR.json"));
+        executeMergeRequestAction(testProject, getJson("MergeRequestEvent_alreadyBuiltMR_differentTargetBranch.json"));
 
         assertTrue(wouldFire);
     }

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/BuildPageRedirectActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/BuildPageRedirectActionTest.java
@@ -72,7 +72,7 @@ public abstract class BuildPageRedirectActionTest {
         testProject.setScm(new GitSCM(gitRepoUrl));
         testProject.setQuietPeriod(0);
         QueueTaskFuture<FreeStyleBuild> future = testProject.scheduleBuild2(0);
-        FreeStyleBuild build = future.get(5, TimeUnit.SECONDS);
+        FreeStyleBuild build = future.get(15, TimeUnit.SECONDS);
 
         doThrow(IOException.class).when(response).sendRedirect2(jenkins.getInstance().getRootUrl() + build.getUrl());
         getBuildPageRedirectAction(testProject).execute(response);

--- a/src/test/resources/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestEvent_alreadyBuiltMR_differentTargetBranch.json
+++ b/src/test/resources/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestEvent_alreadyBuiltMR_differentTargetBranch.json
@@ -67,7 +67,7 @@
     },
     "work_in_progress": false,
     "url": "http://example.com/diaspora/merge_requests/1",
-    "action": "open",
+    "action": "update",
     "assignee": {
       "name": "User1",
       "username": "user1",

--- a/src/test/resources/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestEvent_alreadyBuiltMR_initialBuild.json
+++ b/src/test/resources/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestEvent_alreadyBuiltMR_initialBuild.json
@@ -67,7 +67,7 @@
     },
     "work_in_progress": false,
     "url": "http://example.com/diaspora/merge_requests/1",
-    "action": "reopen",
+    "action": "open",
     "assignee": {
       "name": "User1",
       "username": "user1",

--- a/src/test/resources/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestEvent_merged.json
+++ b/src/test/resources/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestEvent_merged.json
@@ -1,0 +1,91 @@
+{
+  "object_kind": "merge_request",
+  "user": {
+    "name": "Administrator",
+    "username": "root",
+    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
+  },
+  "object_attributes": {
+    "id": 99,
+    "target_branch": "master",
+    "source_branch": "ms-viewport",
+    "source_project_id": 14,
+    "author_id": 51,
+    "assignee_id": 6,
+    "title": "MS-Viewport",
+    "created_at": "2013-12-03T17:23:34.123Z",
+    "updated_at": "2013-12-03T17:23:34.123Z",
+    "st_commits": null,
+    "st_diffs": null,
+    "milestone_id": null,
+    "state": "merged",
+    "merge_status": "unchecked",
+    "target_project_id": 14,
+    "iid": 1,
+    "description": "",
+    "source": {
+      "name": "Awesome Project",
+      "description": "Aut reprehenderit ut est.",
+      "web_url": "http://example.com/awesome_space/awesome_project",
+      "avatar_url": null,
+      "git_ssh_url": "git@example.com:awesome_space/awesome_project.git",
+      "git_http_url": "http://example.com/awesome_space/awesome_project.git",
+      "namespace": "Awesome Space",
+      "visibility_level": 20,
+      "path_with_namespace": "awesome_space/awesome_project",
+      "default_branch": "master",
+      "homepage": "http://example.com/awesome_space/awesome_project",
+      "url": "http://example.com/awesome_space/awesome_project.git",
+      "ssh_url": "git@example.com:awesome_space/awesome_project.git",
+      "http_url": "http://example.com/awesome_space/awesome_project.git"
+    },
+    "target": {
+      "name": "Awesome Project",
+      "description": "Aut reprehenderit ut est.",
+      "web_url": "http://example.com/awesome_space/awesome_project",
+      "avatar_url": null,
+      "git_ssh_url": "git@example.com:awesome_space/awesome_project.git",
+      "git_http_url": "http://example.com/awesome_space/awesome_project.git",
+      "namespace": "Awesome Space",
+      "visibility_level": 20,
+      "path_with_namespace": "awesome_space/awesome_project",
+      "default_branch": "master",
+      "homepage": "http://example.com/awesome_space/awesome_project",
+      "url": "http://example.com/awesome_space/awesome_project.git",
+      "ssh_url": "git@example.com:awesome_space/awesome_project.git",
+      "http_url": "http://example.com/awesome_space/awesome_project.git"
+    },
+    "last_commit": {
+      "id": "${commitSha1}",
+      "message": "fixed readme",
+      "timestamp": "2012-01-03T23:36:29+02:00",
+      "url": "http://example.com/awesome_space/awesome_project/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "author": {
+        "name": "GitLab dev user",
+        "email": "gitlabdev@dv6700.(none)"
+      }
+    },
+    "changes" : {
+      "state" : {
+        "previous" : "locked",
+        "current" : "merged"
+      },
+      "updated_at" : {
+        "previous" : "2018-03-28 15:36:42 UTC",
+        "current" : "2018-03-28 15:36:42 UTC"
+      },
+      "total_time_spent" : {
+        "previous" : null,
+        "current" : 0
+      }
+    },
+    "work_in_progress": false,
+    "url": "http://example.com/diaspora/merge_requests/1",
+    "action": "merge",
+    "assignee": {
+      "name": "User1",
+      "username": "user1",
+      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
+    }
+  }
+}


### PR DESCRIPTION
Call to MergeRequestBuildAction.execute always thrown an exception and so mock
verifications were never performed - the tests passed because of ExpectedException rule.

All the decisions on whether or not to build a project are inside mergeRequestHookTriggerHandler,
therefore mocking GitLabPushTrigger didn't exercise any of the build triggering logic, and so some
of the tests now fail, demonstrating actual issues.

Fixes #734.