### PR TITLE
Update Commit Status for specific projects and for specific connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,9 +462,6 @@ In order to build when a new tag is pushed:
 ## Add a note to merge requests
 To add a note to GitLab merge requests after the build completes, select 'Add note with build status on GitLab merge requests' from the optional Post-build actions. Optionally, click the 'Advanced' button to customize the content of the note depending on the build result.
 
-## Parameterized builds
-You can trigger a job manually by clicking 'This build is parameterized' in the job configuration and adding any of the relevant build parameters. See the [defined parameters](#defined-parameters) list. If you only care about jobs being triggered from GitLab webhooks, this step is unnecessary.
-
 ## Notify Specific project by a specific gitlab connection
 You can specify a map of project builds to notify a vary of gitlab repositories which could be located on different servers
 This is useful if you want to create a complex CI/CD which involve several jenkins and gitlab projects, see examples bellow:

--- a/README.md
+++ b/README.md
@@ -462,6 +462,51 @@ In order to build when a new tag is pushed:
 ## Add a note to merge requests
 To add a note to GitLab merge requests after the build completes, select 'Add note with build status on GitLab merge requests' from the optional Post-build actions. Optionally, click the 'Advanced' button to customize the content of the note depending on the build result.
 
+## Parameterized builds
+You can trigger a job manually by clicking 'This build is parameterized' in the job configuration and adding any of the relevant build parameters. See the [defined parameters](#defined-parameters) list. If you only care about jobs being triggered from GitLab webhooks, this step is unnecessary.
+
+## Notify Specific project by a specific gitlab connection
+You can specify a map of project builds to notify a vary of gitlab repositories which could be located on different servers
+This is useful if you want to create a complex CI/CD which involve several jenkins and gitlab projects, see examples bellow:
+
+* Notify several gitlab projects using gitlab connection data from the trigger context
+```groovy
+gitlabCommitStatus(name: 'stage1',
+        builds: [
+            [projectId: 'test/test', revisionHash: 'master'],
+            [projectId: 'test/utils', revisionHash: 'master'],
+        ])
+    {
+            echo 'Hello World'
+    }
+```
+
+* Notify several gitlab projects using specific gitlab connection
+```groovy
+gitlabCommitStatus( name: 'stage1', connection:[gitLabConnection:'site1-connection'],
+        builds: [
+            [projectId: 'test/test', revisionHash: 'master'],
+            [projectId: 'test/utils', revisionHash: 'master'],
+        ])
+    {
+            echo 'Hello World'
+    }
+```
+
+* Notify several gitlab repositories located on different gitlab servers
+```groovy
+gitlabCommitStatus(
+        builds: [
+            [name:'stage1',connection:[gitLabConnection:'site1-connection'], projectId: 'group/project1', revisionHash: 'master'],
+            [name:'stage1',connection:[gitLabConnection:'site2-connection'], projectId: 'group/project1', revisionHash: 'master'],
+            [name:'stage1',connection:[gitLabConnection:'site2-connection'], projectId: 'test/test', revisionHash: 'master'],
+            [name:'stage1',connection:[gitLabConnection:'site2-connection'], projectId: 'test/utils', revisionHash: 'master'],
+        ])
+    {
+            echo 'Hello World'
+    }
+```
+
 # Contributing to the Plugin
 
 Plugin source code is hosted on [Github](https://github.com/jenkinsci/gitlab-plugin).

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
@@ -48,7 +48,6 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
     }
 
     @Extension
-    @Symbol("gitLabConnection")
     public static class DescriptorImpl extends JobPropertyDescriptor {
 
         @Override

--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -81,7 +81,7 @@ public class CommitStatusUpdater {
 
                 if (existsCommit(current_client, gitLabBranchBuild.getProjectId(), gitLabBranchBuild.getRevisionHash())) {
                     LOGGER.log(Level.INFO, String.format("Updating build '%s' to '%s'", gitLabBranchBuild.getProjectId(),state));
-                    client.changeBuildStatus(gitLabBranchBuild.getProjectId(), gitLabBranchBuild.getRevisionHash(), state, getBuildBranch(build), current_build_name, buildUrl, state.name());
+                    current_client.changeBuildStatus(gitLabBranchBuild.getProjectId(), gitLabBranchBuild.getRevisionHash(), state, getBuildBranch(build), current_build_name, buildUrl, state.name());
                 }
             } catch (WebApplicationException | ProcessingException e) {
                 printf(listener, "Failed to update Gitlab commit status for project '%s': %s%n", gitLabBranchBuild.getProjectId(), e.getMessage());

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabBranchBuild.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabBranchBuild.java
@@ -1,0 +1,82 @@
+package com.dabsquared.gitlabjenkins.workflow;
+
+import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GitLabBranchBuild extends AbstractDescribableImpl<GitLabBranchBuild> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GitLabBranchBuild.class);
+
+
+    private String name;
+    private String projectId;
+    private String revisionHash;
+    private GitLabConnectionProperty connection;
+
+    @DataBoundConstructor
+    public GitLabBranchBuild() {
+    }
+
+    public GitLabBranchBuild(String projectId, String revisionHash) {
+        this.name = null;
+        this.projectId = projectId;
+        this.revisionHash = revisionHash;
+        this.connection = null;
+    }
+
+    @DataBoundSetter
+    public void setName(String name) {
+        this.name = StringUtils.isEmpty(name) ? null : name;
+    }
+
+    @DataBoundSetter
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    @DataBoundSetter
+    public void setRevisionHash(String revisionHash) {
+        this.revisionHash = revisionHash;
+    }
+
+    @DataBoundSetter
+    public void setConnection(GitLabConnectionProperty connection) {
+        this.connection = connection;
+    }
+
+    public void setConnection(String connection) {
+        this.connection = StringUtils.isEmpty(connection) ? null : new GitLabConnectionProperty(connection);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public String getRevisionHash() {
+        return revisionHash;
+    }
+
+    public GitLabConnectionProperty getConnection() {
+        return connection;
+    }
+
+
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<GitLabBranchBuild> {
+        @Override
+        public String getDisplayName() {
+            return "Gitlab Branch Build";
+        }
+    }
+}

--- a/src/main/resources/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty/config.groovy
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty/config.groovy
@@ -1,0 +1,7 @@
+package com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
+
+f = namespace(lib.FormTagLib)
+
+f.entry(title:"Gitlab Connection", field:"gitLabConnection") {
+  f.select()
+}

--- a/src/main/resources/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty/config.jelly
@@ -1,6 +1,0 @@
-<?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-  <f:entry title="${%GitLab connection}" field="gitLabConnection">
-    <f:select/>
-  </f:entry>
-</j:jelly>

--- a/src/main/resources/com/dabsquared/gitlabjenkins/workflow/GitLabBranchBuild/config.groovy
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/workflow/GitLabBranchBuild/config.groovy
@@ -1,0 +1,19 @@
+package com.dabsquared.gitlabjenkins.workflow.GitLabBranchBuild;
+
+f = namespace(lib.FormTagLib)
+
+f.entry(title:"Build Name",field:"name") {
+  f.textbox()
+}
+
+f.entry(title:"Gitlab Project id", field:"projectId") {
+  f.textbox()
+}
+
+f.entry(title:"Gitlab Commit sha1", field:"revisionHash") {
+  f.textbox()
+}
+
+f.entry() {
+  f.property(field: "connection")
+}

--- a/src/main/resources/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep/config.groovy
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep/config.groovy
@@ -1,0 +1,20 @@
+package com.dabsquared.gitlabjenkins.workflow.GitLabCommitStatusStep;
+
+f = namespace(lib.FormTagLib)
+
+f.entry(title:"Build name", field:"name") {
+    f.textbox()
+}
+
+f.entry(title:"Gitalb connection") {
+    f.property(field: "connection")
+}
+
+f.entry(title:"Gitlab Projects To Notify") {
+    f.repeatableHeteroProperty(field: "builds", hasHeader: "true")
+}
+
+
+
+
+

--- a/src/main/resources/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep/config.jelly
@@ -1,6 +1,0 @@
-<?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-  <f:entry title="${%Build name}" field="name" help="/plugin/gitlab-plugin/help/help-buildName.html">
-    <f:textbox default="jenkins"/>
-  </f:entry>
-</j:jelly>

--- a/src/main/webapp/help/help-connection.html
+++ b/src/main/webapp/help/help-connection.html
@@ -1,0 +1,3 @@
+<p>
+  Select the associated gitlab connection
+</p>

--- a/src/main/webapp/help/help-gitalbBranchBuilds.html
+++ b/src/main/webapp/help/help-gitalbBranchBuilds.html
@@ -1,0 +1,3 @@
+<p>
+  Pair of gitlab project id and commit sha1
+</p>

--- a/src/main/webapp/help/help-project.html
+++ b/src/main/webapp/help/help-project.html
@@ -1,0 +1,3 @@
+<p>
+  Gtialb project: a String like namespace/project or the exactly project id (an integer like 1)
+</p>

--- a/src/test/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdaterTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdaterTest.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
 import com.dabsquared.gitlabjenkins.workflow.GitLabBranchBuild;
+import hudson.Functions;
 import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.junit.Before;
@@ -91,7 +92,12 @@ public class CommitStatusUpdaterTest {
 	    when(build.getCauses()).thenReturn(new ArrayList<Cause>(Collections.singletonList(upCauseLevel1)));
 	    when(upCauseLevel1.getUpstreamCauses()).thenReturn(new ArrayList<Cause>(Collections.singletonList(upCauseLevel2)));
 	    when(upCauseLevel2.getUpstreamCauses()).thenReturn(new ArrayList<Cause>(Collections.singletonList(gitlabCause)));
-	    when(taskListener.getLogger()).thenReturn(new PrintStream("/dev/null"));
+	    if(Functions.isWindows()) {
+	        when(taskListener.getLogger()).thenReturn(new PrintStream("nul"));
+	    } else {
+	        when(taskListener.getLogger()).thenReturn(new PrintStream("/dev/null"));
+	    }
+
 
 	    causeData = causeData()
                 .withActionType(CauseData.ActionType.NOTE)


### PR DESCRIPTION
#746
This PR allows pipeline folks to define a map of "builds" which are linked with different gitlab projects via different gitlab connections. So you can build you own "buidness-logic" to interact with several gitlab repositories. 

```groovy
node('master') {
    git 'http://gitlab/test/test.git'
    gitlabCommitStatus(
        builds: [
            [name:'pre-build-site1',connection:[gitLabConnection:'test-connection'], projectId: 'test/test', revisionHash: 'master'],
            [name:'pre-build-site1',connection:[gitLabConnection:'test-connection'], projectId: 'test/utils', revisionHash: 'master'],
            [name:'pre-build-site2',connection:[gitLabConnection:'test-connection2'], projectId: 'test/test', revisionHash: 'master'],
            [name:'pre-build-site2',connection:[gitLabConnection:'test-connection2'], projectId: 'test/utils', revisionHash: 'master'],
        ]) 
    {
            echo 'Hello World'
    }
}
```