### PR TITLE
Bug fix for issue 454

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/BranchFilterFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/BranchFilterFactory.java
@@ -8,6 +8,10 @@ public final class BranchFilterFactory {
     private BranchFilterFactory() { }
 
     public static BranchFilter newBranchFilter(BranchFilterConfig config) {
+		
+		if(config == null)
+			return new AllBranchesFilter();
+		
         switch (config.getType()) {
             case NameBasedFilter:
                 return new NameBasedFilter(config.getIncludeBranchesSpec(), config.getExcludeBranchesSpec());


### PR DESCRIPTION
Add null pointer check which returns the default new AllBranchesFilter instance in null case.

This should solve the following issue:

Saving config throws exception if branch filter is not defined #454

Fixes #454 