### PR TITLE
Fix for triggering Accepted Merge Request 

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Action.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Action.java
@@ -4,5 +4,5 @@ package com.dabsquared.gitlabjenkins.gitlab.hook.model;
  * @author Robin Müller
  */
 public enum Action {
-    open, update, approved
+    open, reopen, update, merge, approved
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
@@ -33,7 +33,7 @@ public final class MergeRequestHookTriggerHandlerFactory {
     }
 
 	private static Set<Action> retrieveAllowedActions(boolean triggerOnApprovedMergeRequest) {
-		Set<Action> allowedActions = EnumSet.of(Action.open, Action.update);
+		Set<Action> allowedActions = EnumSet.noneOf(Action.class);
 		if (triggerOnApprovedMergeRequest)
 			allowedActions.add(Action.approved);
 		return allowedActions;

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -43,7 +43,7 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
     private final boolean cancelPendingBuildsOnUpdate;
 
     MergeRequestHookTriggerHandlerImpl(Collection<State> allowedStates, boolean skipWorkInProgressMergeRequest, boolean cancelPendingBuildsOnUpdate) {
-        this(allowedStates, EnumSet.allOf(Action.class), skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);
+        this(allowedStates, EnumSet.noneOf(Action.class), skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);
     }
 
     MergeRequestHookTriggerHandlerImpl(Collection<State> allowedStates, Collection<Action> allowedActions, boolean skipWorkInProgressMergeRequest, boolean cancelPendingBuildsOnUpdate) {
@@ -185,7 +185,7 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
 
 	private boolean isAllowedByConfig(MergeRequestObjectAttributes objectAttributes) {
 		return allowedStates.contains(objectAttributes.getState())
-        	&& allowedActions.contains(objectAttributes.getAction());
+			|| allowedActions.contains(objectAttributes.getAction());
 	}
 
     private boolean isNotSkipWorkInProgressMergeRequest(MergeRequestObjectAttributes objectAttributes) {

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
@@ -118,40 +118,36 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
         assertThat(buildTriggered.isSignaled(), is(false));
     }
-    
+
     @Test
     public void mergeRequest_build_when_approved() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(EnumSet.allOf(State.class), EnumSet.of(Action.approved), false, false);
-
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(EnumSet.noneOf(State.class), EnumSet.of(Action.approved), false, false);
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, Action.approved);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_do_not_build_when_when_approved() throws Exception {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(EnumSet.allOf(State.class), EnumSet.of(Action.update), false, false);
-        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, defaultMergeRequestObjectAttributes().withState(State.opened).withAction(Action.approved));
-
-        assertThat(buildTriggered.isSignaled(), is (false));
+    public void mergeRequest_build_only_when_approved_and_not_when_updated() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        mergeRequest_build_only_when_approved(Action.update);
     }
-    
+
     @Test
     public void mergeRequest_build_only_when_approved_and_not_when_opened() throws IOException, InterruptedException, GitAPIException, ExecutionException {
         mergeRequest_build_only_when_approved(Action.open);
     }
 
     @Test
-    public void mergeRequest_build_only_when_approved_and_not_when_updated() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        mergeRequest_build_only_when_approved(Action.update);
+    public void mergeRequest_build_only_when_approved_and_not_when_merge() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        mergeRequest_build_only_when_approved(Action.merge);
     }
-    
-    
+
+
 	private void mergeRequest_build_only_when_approved(Action action)
 			throws GitAPIException, IOException, InterruptedException {
-		MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(EnumSet.allOf(State.class), EnumSet.of(Action.approved), false, false);
+		MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(EnumSet.noneOf(State.class), EnumSet.of(Action.approved), false, false);
 	    OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, action);
-	
+
 	    assertThat(buildTriggered.isSignaled(), is(false));
 	}
 


### PR DESCRIPTION
…rison

This is revert of https://github.com/jenkinsci/gitlab-plugin/commit/554bb618a554850c73a2e636928bbb7df15cdb5f to fix bug related to https://github.com/jenkinsci/gitlab-plugin/issues/734

"Approved Merge Requests (EE-only)" action option in GUI is similar to state based options:
- Opened Merge Request Events
- Accepted Merge Request Events
- Closed Merge Request Events

Each option looks like individual trigger option without dependency between. Therefore "approved" option is natural to be compared with OR among with state based options. 

Action "approved" is only one of the possible action values provided by gitlab API throughout life cycle of merge request and the action values overlaps at least partially with states (some Action enum values added). Previous implementation with AND statement required one or more state options to be selected in order to approved option would take effect (what combinations are even possible in practise?). This AND operation was not obvious logic in GUI but each look like individual trigger. Moreover, as Action enum did not contain all actual values sent by gitlab API, it led to functionality where mere Accepted state trigger option did not work (maybe even closed state events didn't work too?). Instead of trying to list all possible action values sent by gitlab API, it's simpler and more future proof just to use OR statement for current action option available in GUI. 

If there will be need for more complex logic or more sophisticated trigger options/conditions functionality, the GUI options should be adapted accordingly to illustrate properly the functionality behind options. Then also the life cycle of merge requests should be evaluated, clearly present and taken into account in GUI, implementation and test cases.

