### PR TITLE
Fix NPE in GitLabPushTrigger

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -432,6 +432,9 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 
     // executes when the Trigger receives a pipeline event
     public void onPost(final PipelineHook hook) {
+        if (pipelineTriggerHandler == null) {
+            initializeTriggerHandler();
+        }
         pipelineTriggerHandler.handle(job, hook, ciSkip, branchFilter, mergeRequestLabelFilter);
     }
 


### PR DESCRIPTION
because missing of it was causing NPE during processing pipeline hook
