### PR TITLE
Fix backward compatibility of the Pipeline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ gitlabCommitStatus(name: 'stage1',
 
 * Notify several gitlab projects using specific gitlab connection
 ```groovy
-gitlabCommitStatus( name: 'stage1', connection:[gitLabConnection:'site1-connection'],
+gitlabCommitStatus( name: 'stage1', connection:gitLabConnection('site1-connection'),
         builds: [
             [projectId: 'test/test', revisionHash: 'master'],
             [projectId: 'test/utils', revisionHash: 'master'],
@@ -516,10 +516,10 @@ gitlabCommitStatus( name: 'stage1', connection:[gitLabConnection:'site1-connecti
 ```groovy
 gitlabCommitStatus(
         builds: [
-            [name:'stage1',connection:[gitLabConnection:'site1-connection'], projectId: 'group/project1', revisionHash: 'master'],
-            [name:'stage1',connection:[gitLabConnection:'site2-connection'], projectId: 'group/project1', revisionHash: 'master'],
-            [name:'stage1',connection:[gitLabConnection:'site2-connection'], projectId: 'test/test', revisionHash: 'master'],
-            [name:'stage1',connection:[gitLabConnection:'site2-connection'], projectId: 'test/utils', revisionHash: 'master'],
+            [name:'stage1',connection:gitLabConnection('site1-connection'), projectId: 'group/project1', revisionHash: 'master'],
+            [name:'stage1',connection:gitLabConnection('site2-connection'), projectId: 'group/project1', revisionHash: 'master'],
+            [name:'stage1',connection:gitLabConnection('site2-connection'), projectId: 'test/test', revisionHash: 'master'],
+            [name:'stage1',connection:gitLabConnection('site2-connection'), projectId: 'test/utils', revisionHash: 'master'],
         ])
     {
             echo 'Hello World'

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
@@ -48,6 +48,7 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
     }
 
     @Extension
+    @Symbol("gitLabConnection")
     public static class DescriptorImpl extends JobPropertyDescriptor {
 
         @Override

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep.java
@@ -45,12 +45,10 @@ public class GitLabCommitStatusStep extends Step {
     private GitLabConnectionProperty connection;
 
     @DataBoundConstructor
-    public GitLabCommitStatusStep(String name, List<GitLabBranchBuild> builds, GitLabConnectionProperty connection) {
+    public GitLabCommitStatusStep(String name) {
         this.name = StringUtils.isEmpty(name) ? null : name;
-        this.builds = builds;
-        this.connection = connection ;
     }
-    
+
 	@Override
 	public StepExecution start(StepContext context) throws Exception {
 		return new GitLabCommitStatusStepExecution(context, this);
@@ -59,11 +57,6 @@ public class GitLabCommitStatusStep extends Step {
 
     public String getName() {
         return name;
-    }
-
-    @DataBoundSetter
-    public void setName(String name) {
-        this.name = StringUtils.isEmpty(name) ? null : name;
     }
 
     public List<GitLabBranchBuild> getBuilds() {

--- a/src/main/resources/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty/config.groovy
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty/config.groovy
@@ -2,6 +2,6 @@ package com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
 
 f = namespace(lib.FormTagLib)
 
-f.entry(title:"Gitlab Connection", field:"gitLabConnection") {
+f.entry(title:"GitLab Connection", field:"gitLabConnection") {
   f.select()
 }

--- a/src/main/resources/com/dabsquared/gitlabjenkins/workflow/GitLabBranchBuild/config.groovy
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/workflow/GitLabBranchBuild/config.groovy
@@ -6,11 +6,11 @@ f.entry(title:"Build Name",field:"name") {
   f.textbox()
 }
 
-f.entry(title:"Gitlab Project id", field:"projectId") {
+f.entry(title:"GitLab Project Id", field:"projectId") {
   f.textbox()
 }
 
-f.entry(title:"Gitlab Commit sha1", field:"revisionHash") {
+f.entry(title:"GitLab Commit sha1", field:"revisionHash") {
   f.textbox()
 }
 

--- a/src/main/resources/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep/config.groovy
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep/config.groovy
@@ -6,12 +6,12 @@ f.entry(title:"Build name", field:"name") {
     f.textbox()
 }
 
-f.entry(title:"Gitalb connection") {
-    f.property(field: "connection")
-}
+f.advanced() {
+    f.optionalProperty(field: "connection", title: "Select specific GitLab Connection")
 
-f.entry(title:"Gitlab Projects To Notify") {
-    f.repeatableHeteroProperty(field: "builds", hasHeader: "true")
+    f.entry(title:"GitLab Projects To Notify") {
+        f.repeatableHeteroProperty(field: "builds", hasHeader: "true")
+    }
 }
 
 

--- a/src/main/webapp/help/help-gitalbBranchBuilds.html
+++ b/src/main/webapp/help/help-gitalbBranchBuilds.html
@@ -1,3 +1,3 @@
 <p>
-  Pair of gitlab project id and commit sha1
+  Pair of GitLab project id and commit sha1
 </p>


### PR DESCRIPTION
JENKINS-52267 / Fixes #789 

According with https://jenkins.io/doc/developer/plugin-development/pipeline-integration/#constructor-vs-setters
Restored previous version of `gitlabCommitStatus` step constructor
Removed setter for `name` so Pipeline Syntax builder would produce simple snippet
```groovy
gitlabCommitStatus('somestage') {
    // some block
}
```  
Hid optional fields behind `advanced` overlay
![image](https://user-images.githubusercontent.com/1569458/42173228-05901354-7e27-11e8-8991-f99f4dfe4fe6.png)

