### PR TITLE
gitlabCommitStatus step should process name arg as optional

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep.java
@@ -45,18 +45,20 @@ public class GitLabCommitStatusStep extends Step {
     private GitLabConnectionProperty connection;
 
     @DataBoundConstructor
-    public GitLabCommitStatusStep(String name) {
-        this.name = StringUtils.isEmpty(name) ? null : name;
-    }
+    public GitLabCommitStatusStep(){ }
 
 	@Override
 	public StepExecution start(StepContext context) throws Exception {
 		return new GitLabCommitStatusStepExecution(context, this);
 	}
 
-
     public String getName() {
         return name;
+    }
+
+    @DataBoundSetter
+    public void setName(String name) {
+        this.name = StringUtils.isEmpty(name) ? null : name;
     }
 
     public List<GitLabBranchBuild> getBuilds() {


### PR DESCRIPTION
Fixes  #795 
Name argument should be optional
Captured on 
Jenkins: 2.121.1
Gitlab: 10.8.2-ee
Gitlab plugin 1.5.8