### PR TITLE
Update README.md to point to new location for gitlab-plugin CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ Plugin source code is hosted on [Github](https://github.com/jenkinsci/gitlab-plu
 New feature proposals and bug fix proposals should be submitted as
 [Github pull requests](https://help.github.com/articles/creating-a-pull-request).
 Fork the repository on Github, prepare your change on your forked
-copy, and submit a pull request (see [here](https://github.com/jenkinsci/gitlab-plugin/pulls) for open pull requests). Your pull request will be evaluated by the [Cloudbees Jenkins job](https://jenkins.ci.cloudbees.com/job/plugins/job/gitlab-plugin/).
+copy, and submit a pull request (see [here](https://github.com/jenkinsci/gitlab-plugin/pulls) for open pull requests). Your pull request will be evaluated by the [Cloudbees Jenkins job](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fgitlab-plugin/).
 
 If you are adding new features please make sure that they support the Jenkins Workflow Plugin.
 See [here](https://github.com/jenkinsci/workflow-plugin/blob/master/COMPATIBILITY.md) for some information.


### PR DESCRIPTION
I noticed that the link in the README.md file points to the old location for the Jenkins Cloudbees location where the job to test PRs is disabled.

This pull request only updates the README file to point to the new location which I've determined from the checks of recent PRs.

Old: https://jenkins.ci.cloudbees.com/job/plugins/job/gitlab-plugin/
New: https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fgitlab-plugin/