### PR TITLE
new MR trigger checks last commit message for [ci-skip]

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -78,8 +78,16 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
     @Override
     protected boolean isCiSkip(MergeRequestHook hook) {
         return hook.getObjectAttributes() != null
-                && hook.getObjectAttributes().getDescription() != null
-                && hook.getObjectAttributes().getDescription().contains("[ci-skip]");
+            && (
+                (hook.getObjectAttributes().getDescription() != null
+                    && hook.getObjectAttributes().getDescription().contains("[ci-skip]")
+                ) ||
+                (
+                    hook.getObjectAttributes().getLastCommit() != null &&
+                        hook.getObjectAttributes().getLastCommit().getMessage() != null &&
+                        hook.getObjectAttributes().getLastCommit().getMessage().contains("[ci-skip]")
+                )
+        );
     }
 
     @Override


### PR DESCRIPTION
When there is a new push to a branch, then it will generate a push hook and a MR hook.
The push hook is properly checked for the `[ci-skip]` message, but the MR hook inly checks for  the `[ci-skip]` string in the MR description.
So if I push a new commit to an already opened MR, then it will trigger a new build even though there is the `[ci-skip]` in the commit message.
I modified the code to also search the MR's description and the `last_commit.description` as well. If any if them contains the `[ci-skip]` then the build will not be triggered.

I think it fixes #468 