### PR TITLE
Implement approval for merge requests

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClient.java
@@ -36,6 +36,10 @@ public interface GitLabClient {
 
     void deleteMergeRequestEmoji(MergeRequest mr, Integer awardId);
 
+    void approveMergeRequest(MergeRequest mr);
+
+    void unapproveMergeRequest(MergeRequest mr);
+
     List<MergeRequest> getMergeRequests(String projectId, State state, int page, int perPage);
 
     List<Branch> getBranches(String projectId);

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
@@ -205,6 +205,32 @@ final class AutodetectingGitLabClient implements GitLabClient {
     }
 
     @Override
+    public void approveMergeRequest(final MergeRequest mr) {
+        execute(
+            new GitLabOperation<Void>() {
+                @Override
+                Void execute(GitLabClient client) {
+                    client.approveMergeRequest(mr);
+                    return null;
+                }
+            }
+        );
+    }
+
+    @Override
+    public void unapproveMergeRequest(final MergeRequest mr) {
+        execute(
+            new GitLabOperation<Void>() {
+                @Override
+                Void execute(GitLabClient client) {
+                    client.unapproveMergeRequest(mr);
+                    return null;
+                }
+            }
+        );
+    }
+
+    @Override
     public List<MergeRequest> getMergeRequests(final String projectId, final State state, final int page, final int perPage) {
         return execute(
             new GitLabOperation<List<MergeRequest>>() {

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/GitLabApiProxy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/GitLabApiProxy.java
@@ -36,6 +36,10 @@ interface GitLabApiProxy {
 
     void deleteMergeRequestEmoji(Integer projectId, Integer mergeRequestId, Integer awardId);
 
+    void approveMergeRequest(Integer projectId, Integer mergeRequestId);
+
+    void unapproveMergeRequest(Integer projectId, Integer mergeRequestId);
+
     List<MergeRequest> getMergeRequests(String projectId, State state, int page, int perPage);
 
     List<Branch> getBranches(String projectId);

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClient.java
@@ -96,6 +96,16 @@ final class ResteasyGitLabClient implements GitLabClient {
     }
 
     @Override
+    public void approveMergeRequest(MergeRequest mr) {
+        api.approveMergeRequest(mr.getProjectId(), mergeRequestIdProvider.apply(mr));
+    }
+
+    @Override
+    public void unapproveMergeRequest(MergeRequest mr) {
+        api.unapproveMergeRequest(mr.getProjectId(), mergeRequestIdProvider.apply(mr));
+    }
+
+    @Override
     public List<MergeRequest> getMergeRequests(String projectId, State state, int page, int perPage) {
         return api.getMergeRequests(projectId, state, page, perPage);
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V3GitLabApiProxy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V3GitLabApiProxy.java
@@ -46,6 +46,26 @@ interface V3GitLabApiProxy extends GitLabApiProxy {
         @FormParam("target_branch") String targetBranch,
         @FormParam("title") String title);
 
+    /**
+     * Unsupported in API v3
+     */
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Path("/projects/{projectId}/merge_requests/{mergeRequestIid}/approve")
+    @Override
+    void approveMergeRequest(@PathParam("projectId") Integer projectId, @PathParam("mergeRequestIid") Integer mergeRequestId);
+
+    /**
+     * Unsupported in API v3
+     */
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Path("/projects/{projectId}/merge_requests/{mergeRequestIid}/unapprove")
+    @Override
+    void unapproveMergeRequest(Integer projectId, Integer mergeRequestId);
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/projects/{projectName}")

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V4GitLabApiProxy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V4GitLabApiProxy.java
@@ -46,6 +46,20 @@ interface V4GitLabApiProxy extends GitLabApiProxy {
         @FormParam("target_branch") String targetBranch,
         @FormParam("title") String title);
 
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Path("/projects/{projectId}/merge_requests/{mergeRequestIid}/approve")
+    @Override
+    void approveMergeRequest(@PathParam("projectId") Integer projectId, @PathParam("mergeRequestIid") Integer mergeRequestId);
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Path("/projects/{projectId}/merge_requests/{mergeRequestIid}/unapprove")
+    @Override
+    void unapproveMergeRequest(@PathParam("projectId") Integer  projectId, @PathParam("mergeRequestIid") Integer mergeRequestId);
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/projects/{projectName}")

--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabApproveMergeRequestPublisher.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabApproveMergeRequestPublisher.java
@@ -1,0 +1,81 @@
+package com.dabsquared.gitlabjenkins.publisher;
+
+import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
+import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Publisher;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class GitLabApproveMergeRequestPublisher extends MergeRequestNotifier {
+    private static final Logger LOGGER = Logger.getLogger(GitLabApproveMergeRequestPublisher.class.getName());
+
+    private final boolean approveUnstableBuilds;
+
+    @DataBoundConstructor
+    public GitLabApproveMergeRequestPublisher(boolean approveUnstableBuilds) {
+        this.approveUnstableBuilds = approveUnstableBuilds;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            return true;
+        }
+
+        @Override
+        public String getHelpFile() {
+            return "/plugin/gitlab-plugin/help/help-approve-gitlab-mergerequest.html";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.GitLabApproveMergeRequestPublisher_DisplayName();
+        }
+    }
+
+    public boolean isApproveUnstableBuilds() {
+        return approveUnstableBuilds;
+    }
+
+    @Override
+    protected void perform(Run<?, ?> build, TaskListener listener, GitLabClient client, MergeRequest mergeRequest) {
+        try {
+            Result buildResult = build.getResult();
+            if (build.getResult() == Result.SUCCESS || (buildResult == Result.UNSTABLE && isApproveUnstableBuilds())) {
+                client.approveMergeRequest(mergeRequest);
+            } else {
+                client.unapproveMergeRequest(mergeRequest);
+            }
+        } catch (NotFoundException e) {
+            String message = String.format(
+                "Failed to approve/unapprove merge request '%s' for project '%s'.\n"
+                    + "Got unexpected 404. Does your GitLab edition or GitLab.com tier really support approvals, and are you are an eligible approver for this merge request?", mergeRequest.getIid(), mergeRequest.getProjectId());
+            listener.getLogger().printf(message);
+            LOGGER.log(Level.WARNING, message, e);
+        } catch (NotAuthorizedException e) {
+            String message = String.format(
+                "Failed to approve/unapprove merge request '%s' for project '%s'.\n"
+                + "Got unexpected 401, are you using the wrong credentials?", mergeRequest.getIid(), mergeRequest.getProjectId());
+            listener.getLogger().printf(message);
+            LOGGER.log(Level.WARNING, message, e);
+        } catch (WebApplicationException | ProcessingException e) {
+            listener.getLogger().printf("Failed to approve/unapprove merge request for project '%s': %s%n", mergeRequest.getProjectId(), e.getMessage());
+            LOGGER.log(Level.SEVERE, String.format("Failed to approve/unapprove merge request for project '%s'", mergeRequest.getProjectId()), e);
+        }
+    }
+
+}

--- a/src/main/resources/com/dabsquared/gitlabjenkins/publisher/GitLabApproveMergeRequestPublisher/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/publisher/GitLabApproveMergeRequestPublisher/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:advanced>
+    <f:entry title="${%Approve unstable builds}" field="approveUnstableBuilds">
+      <f:checkbox default="false"/>
+    </f:entry>
+  </f:advanced>
+</j:jelly>

--- a/src/main/resources/com/dabsquared/gitlabjenkins/publisher/Messages.properties
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/publisher/Messages.properties
@@ -3,3 +3,4 @@ name.required=Build name required.
 GitLabMessagePublisher.DisplayName=Add note with build status on GitLab merge requests
 GitLabVotePublisher.DisplayName=Add vote for build status on GitLab merge requests
 GitLabAcceptMergeRequestPublisher.DisplayName=Accept GitLab merge request on success
+GitLabApproveMergeRequestPublisher.DisplayName=Approve / Revoke approval on GitLab merge request (EE-only)

--- a/src/main/webapp/help/help-approve-gitlab-mergerequest.html
+++ b/src/main/webapp/help/help-approve-gitlab-mergerequest.html
@@ -1,0 +1,8 @@
+<div>
+  Approve the GitLab merge request if builds succeeds, or revoke the approval if it fails.<br/>
+  The approval will be visible in the merge request UI. You must have at least one GitLab connection/server configured in the Jenkins global configuration.
+  <p>
+    <b><span style="background-color:#ff5c33;">Feature availability warning:</span></b>
+    Merge request approvals were introduced in GitLab EE 9.0. They are not available in every <a href="https://docs.gitlab.com/ee/user/project/merge_requests/merge_request_approvals.html" target="_blank">GitLab Edition or GitLab.com tier</a>.
+  </p>
+</div>

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabApproveMergeRequestPublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabApproveMergeRequestPublisherTest.java
@@ -1,0 +1,123 @@
+package com.dabsquared.gitlabjenkins.publisher;
+
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.StreamBuildListener;
+import org.junit.*;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockserver.client.server.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.HttpRequest;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+
+import static com.dabsquared.gitlabjenkins.publisher.TestUtility.*;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+public class GitLabApproveMergeRequestPublisherTest {
+
+    @ClassRule
+    public static MockServerRule mockServer = new MockServerRule(new Object());
+
+    @ClassRule
+    public static JenkinsRule jenkins = new JenkinsRule();
+
+    private MockServerClient mockServerClient;
+    private BuildListener listener;
+
+    @BeforeClass
+    public static void setupClass() throws IOException {
+        setupGitLabConnections(jenkins, mockServer);
+    }
+
+    @Before
+    public void setup() {
+        listener = new StreamBuildListener(jenkins.createTaskListener().getLogger(), Charset.defaultCharset());
+        mockServerClient = new MockServerClient("localhost", mockServer.getPort());
+    }
+
+    @After
+    public void cleanup() {
+        mockServerClient.reset();
+    }
+
+    @Test
+    public void matrixAggregatable() throws InterruptedException, IOException {
+        verifyMatrixAggregatable(GitLabApproveMergeRequestPublisher.class, listener);
+    }
+
+    @Test
+    public void success_approve_unstable_v4() throws IOException, InterruptedException {
+        performApprovalAndVerify(mockSimpleBuild(GITLAB_CONNECTION_V4, Result.SUCCESS), "v4", MERGE_REQUEST_IID, true);
+    }
+
+    @Test
+    public void success_v4() throws IOException, InterruptedException {
+        performApprovalAndVerify(mockSimpleBuild(GITLAB_CONNECTION_V4, Result.SUCCESS), "v4", MERGE_REQUEST_IID, false);
+    }
+
+    @Test
+    public void unstable_approve_unstable_v4() throws IOException, InterruptedException {
+        performApprovalAndVerify(mockSimpleBuild(GITLAB_CONNECTION_V4, Result.UNSTABLE), "v4", MERGE_REQUEST_IID, true);
+    }
+
+    @Test
+    public void unstable_dontapprove_v4() throws IOException, InterruptedException {
+        performUnapprovalAndVerify(mockSimpleBuild(GITLAB_CONNECTION_V4, Result.UNSTABLE), "v4", MERGE_REQUEST_IID, false);
+    }
+
+    @Test
+    public void failed_approve_unstable_v4() throws IOException, InterruptedException {
+        performUnapprovalAndVerify(mockSimpleBuild(GITLAB_CONNECTION_V4, Result.FAILURE), "v4", MERGE_REQUEST_IID, true);
+    }
+
+    @Test
+    public void failed_v4() throws IOException, InterruptedException {
+        performUnapprovalAndVerify(mockSimpleBuild(GITLAB_CONNECTION_V4, Result.FAILURE), "v4", MERGE_REQUEST_IID, false);
+    }
+
+    private void performApprovalAndVerify(AbstractBuild build, String apiLevel, int mergeRequestId, boolean approveUnstable) throws InterruptedException, IOException {
+        GitLabApproveMergeRequestPublisher publisher = preparePublisher(new GitLabApproveMergeRequestPublisher(approveUnstable), build);
+        publisher.perform(build, null, listener);
+
+        mockServerClient.verify(prepareSendApprovalWithSuccessResponse(build, apiLevel, mergeRequestId));
+    }
+
+    private void performUnapprovalAndVerify(AbstractBuild build, String apiLevel, int mergeRequestId, boolean approveUnstable) throws InterruptedException, IOException {
+        GitLabApproveMergeRequestPublisher publisher = preparePublisher(new GitLabApproveMergeRequestPublisher(approveUnstable), build);
+        publisher.perform(build, null, listener);
+
+        mockServerClient.verify(prepareSendUnapprovalWithSuccessResponse(build, apiLevel, mergeRequestId));
+    }
+
+    private HttpRequest prepareSendApprovalWithSuccessResponse(AbstractBuild build, String apiLevel, int mergeRequestId) throws UnsupportedEncodingException {
+        HttpRequest approvalRequest = prepareSendApproval(apiLevel, mergeRequestId);
+        mockServerClient.when(approvalRequest).respond(response().withStatusCode(200));
+        return approvalRequest;
+    }
+
+    private HttpRequest prepareSendUnapprovalWithSuccessResponse(AbstractBuild build, String apiLevel, int mergeRequestId) throws UnsupportedEncodingException {
+        HttpRequest unapprovalRequest = prepareSendUnapproval(apiLevel, mergeRequestId);
+        mockServerClient.when(unapprovalRequest).respond(response().withStatusCode(200));
+        return unapprovalRequest;
+    }
+
+    private HttpRequest prepareSendApproval(final String apiLevel, int mergeRequestId) throws UnsupportedEncodingException {
+        return request()
+            .withPath("/gitlab/api/" + apiLevel + "/projects/" + PROJECT_ID + "/merge_requests/" + mergeRequestId + "/approve")
+            .withMethod("POST")
+            .withHeader("PRIVATE-TOKEN", "secret");
+    }
+
+    private HttpRequest prepareSendUnapproval(final String apiLevel, int mergeRequestId) throws UnsupportedEncodingException {
+        return request()
+            .withPath("/gitlab/api/" + apiLevel + "/projects/" + PROJECT_ID + "/merge_requests/" + mergeRequestId + "/unapprove")
+            .withMethod("POST")
+            .withHeader("PRIVATE-TOKEN", "secret");
+    }
+
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabClientStub.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabClientStub.java
@@ -143,6 +143,16 @@ class GitLabClientStub implements GitLabClient {
     public void deleteMergeRequestEmoji(MergeRequest mr, Integer awardId) {
 
     }
+    
+    @Override
+    public void approveMergeRequest(MergeRequest mr) {
+
+    }
+
+    @Override
+    public void unapproveMergeRequest(MergeRequest mr) {
+
+    }
 
     @Override
     public List<MergeRequest> getMergeRequests(String projectId, State state, int page, int perPage) {

--- a/src/test/java/com/dabsquared/gitlabjenkins/util/GitLabClientStub.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/util/GitLabClientStub.java
@@ -89,6 +89,16 @@ class GitLabClientStub implements GitLabClient {
     }
 
     @Override
+    public void approveMergeRequest(MergeRequest mr) {
+
+    }
+
+    @Override
+    public void unapproveMergeRequest(MergeRequest mr) {
+
+    }
+    
+    @Override
     public List<MergeRequest> getMergeRequests(String projectId, State state, int page, int perPage) {
         return null;
     }


### PR DESCRIPTION
This PR adds a new post-build action to the plugin: The ability to approve / unapprove a merge request depending on the build result (resolves issue #95). It offers a configuration option whether unstable builds should be approved anyway (default: no).

Note: The GitLab approval feature is not available in the self-hosted Community Edition (only Enterprise Edition Starter, or above). The approval feature is available for all public repositories on GitLab.com or in the Bronze tier, or above.

The basic implementation works, but there are several points in need of discussion in this PR before it is ready for merging:

- [x] Approvals are only available in the API v4. How can we handle it - or should we at all handle the case that a v3 API is used?
- [X] Is the "EE only" warning in the post-build action title and help sufficient?
- [x] The API description doesn't mention HTTP result codes and the actual result body contains undescribed elements. The post-build action should only try to un-/approve, if the API user can do so (is an eligible approver) and hasn't done so yet. 

My experimentation yielded these results so far, the last two 

- Approvals are unsupported: 404
- Not an eligible approver: 401
- Approving if the request is already approved: 401
- Unapproving if the request is already approved: 404  (!)
- Un-/Approving if everything works: 201

The result body contains two very useful attributes, but these aren't mentioned in the API docs - so I'm unsure about relying on them since I don't know if they are available since 8.9: `user_has_approved` and `user_can_approve`.

I'd appreciate your input.


Acceptance criteria so far:

- [ ]     your changes work with the oldest and latest supported GitLab version
- [x]     new features are provided with tests
- [ ]     refactored code is provided with regression tests
- [ ]     the code formatting follows the plugin standard
- [x]     imports are organised
- [x]     you updated the help docs
- [ ]     you updated the README
- [ ]     you have used findbugs to see if you haven't introduced any new warnings

Fixes #95