### PR TITLE
NPE-Fix for Bug 794: Initialize BranchFilter on PipelineHooks as well.

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -454,6 +454,9 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 
     // executes when the Trigger receives a pipeline event
     public void onPost(final PipelineHook hook) {
+        if (branchFilter == null) {
+            initializeBranchFilter();
+        }
         if (pipelineTriggerHandler == null) {
             initializeTriggerHandler();
         }


### PR DESCRIPTION
Fix for Issue: https://github.com/jenkinsci/gitlab-plugin/issues/794

Reproduced mentioned Bug with the smallest possible setup.
Jobconfiguration looked like the following: [XML](https://pastebin.com/zLEFpefV)

Posting the GitLab hook data given in the above Issue caused NPE without the fix. After the fix NPE was gone.