### PR TITLE
Actually use the maven-shade-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,34 +141,36 @@
             <compatibleSinceVersion>1.4.0</compatibleSinceVersion>
           </configuration>
         </plugin>
-	<plugin>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>3.0.0</version>
-          <executions>
-            <execution>
-              <id>shade</id>
-              <phase>package</phase>
-              <goals>
-                <goal>shade</goal>
-              </goals>
-            </execution>
-          </executions>
-	  <configuration>
-	    <artifactSet>
-	      <includes>
-		<include>javax.ws.rs.ext:*</include>
-	      </includes>
-	    </artifactSet>
-            <relocations>
-              <relocation>
-                <pattern>javax.ws.rs.ext</pattern>
-                <shadedPattern>javax.shaded.ws.rs.ext</shadedPattern>
-              </relocation>
-            </relocations>
-          </configuration>
-	</plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <artifactSet>
+            <includes>
+              <include>javax.ws.rs.ext:*</include>
+            </includes>
+          </artifactSet>
+          <relocations>
+            <relocation>
+              <pattern>javax.ws.rs.ext</pattern>
+              <shadedPattern>javax.shaded.ws.rs.ext</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
   <dependencies>


### PR DESCRIPTION
Previously it was just in the `<build><pluginManagement>` section. It needed
to be in `<build><plugins>`. `<pluginManagement>` lets you define
versions and configuration for plugins that either aren't actually
invoked in your POM, but are invoked in POMs that inherit from your
POM. See, for example,
https://github.com/jenkinsci/plugin-pom/blob/master/pom.xml#L293. In
practice, it also will override `<pluginManagement>` or `<plugins>`
definitions in your POM's parent, but you can do that in `<plugins>`
as well. `<plugins>` defines what will actually be executed in your
POM. So...yeah. Tada?

cc @omehegan 