### PR TITLE
Fix pipeline job mergeStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ checkout changelog: true, poll: true, scm: [
     $class: 'GitSCM',
     branches: [[name: "origin/${env.gitlabSourceBranch}"]],
     doGenerateSubmoduleConfigurations: false,
-    extensions: [[$class: 'PreBuildMerge', options: [fastForwardMode: 'FF', mergeRemote: 'origin', mergeStrategy: 'default', mergeTarget: "${env.gitlabTargetBranch}"]]],
+    extensions: [[$class: 'PreBuildMerge', options: [fastForwardMode: 'FF', mergeRemote: 'origin', mergeStrategy: 'DEFAULT', mergeTarget: "${env.gitlabTargetBranch}"]]],
     submoduleCfg: [],
     userRemoteConfigs: [[name: 'origin', url: 'git@gitlab.example.com:foo/testrepo.git']]
     ]


### PR DESCRIPTION
Using the latest gitlab plugin version, I ran into the error described [here](https://issues.jenkins-ci.org/browse/JENKINS-51638).
Changing the mergeStrategy to DEFAULT made it work again.

