### PR TITLE
Allow merge requests to trigger multibranch builds.

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildAction.java
@@ -5,17 +5,25 @@ import com.dabsquared.gitlabjenkins.gitlab.hook.model.MergeRequestHook;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.MergeRequestObjectAttributes;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.Project;
 import com.dabsquared.gitlabjenkins.util.JsonUtil;
+import com.dabsquared.gitlabjenkins.webhook.build.SCMSourceOwnerNotifier;
 import com.fasterxml.jackson.databind.JsonNode;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.security.ACL;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceOwner;
 
+import java.net.URISyntaxException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.jgit.transport.URIish;
+
 import static com.dabsquared.gitlabjenkins.util.JsonUtil.toPrettyPrint;
+import static com.dabsquared.gitlabjenkins.util.LoggerUtil.toArray;
 
 /**
  * @author Robin Müller
@@ -69,15 +77,19 @@ public class MergeRequestBuildAction extends BuildWebHookAction {
     }
 
     public void execute() {
-        if (!(project instanceof Job<?, ?>)) {
-            throw HttpResponses.errorWithoutStack(409, "Merge Request Hook is not supported for this project");
+        if (project instanceof Job<?, ?>) {
+            ACL.impersonate(ACL.SYSTEM, new TriggerNotifier(project, secretToken, Jenkins.getAuthentication()) {
+                @Override
+                protected void performOnPost(GitLabPushTrigger trigger) {
+                    trigger.onPost(mergeRequestHook);
+                }
+            });
+            throw HttpResponses.ok();
         }
-        ACL.impersonate(ACL.SYSTEM, new TriggerNotifier(project, secretToken, Jenkins.getAuthentication()) {
-            @Override
-            protected void performOnPost(GitLabPushTrigger trigger) {
-                trigger.onPost(mergeRequestHook);
-            }
-        });
-        throw HttpResponses.ok();
+        if (project instanceof SCMSourceOwner) {
+            ACL.impersonate(ACL.SYSTEM, new SCMSourceOwnerNotifier(project));
+            throw HttpResponses.ok();
+        }
+        throw HttpResponses.errorWithoutStack(409, "Merge Request Hook is not supported for this project");
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
@@ -4,6 +4,7 @@ import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.Project;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.PushHook;
 import com.dabsquared.gitlabjenkins.util.JsonUtil;
+import com.dabsquared.gitlabjenkins.webhook.build.SCMSourceOwnerNotifier;
 import com.fasterxml.jackson.databind.JsonNode;
 import hudson.model.Item;
 import hudson.model.Job;
@@ -89,34 +90,9 @@ public class PushBuildAction extends BuildWebHookAction {
             throw HttpResponses.ok();
         }
         if (project instanceof SCMSourceOwner) {
-            ACL.impersonate(ACL.SYSTEM, new SCMSourceOwnerNotifier());
+            ACL.impersonate(ACL.SYSTEM, new SCMSourceOwnerNotifier(project));
             throw HttpResponses.ok();
         }
         throw HttpResponses.errorWithoutStack(409, "Push Hook is not supported for this project");
     }
-
-    private class SCMSourceOwnerNotifier implements Runnable {
-        public void run() {
-            for (SCMSource scmSource : ((SCMSourceOwner) project).getSCMSources()) {
-                if (scmSource instanceof GitSCMSource) {
-                    GitSCMSource gitSCMSource = (GitSCMSource) scmSource;
-                    try {
-                        if (new URIish(gitSCMSource.getRemote()).equals(new URIish(gitSCMSource.getRemote()))) {
-                            if (!gitSCMSource.isIgnoreOnPushNotifications()) {
-                                LOGGER.log(Level.FINE, "Notify scmSourceOwner {0} about changes for {1}",
-                                           toArray(project.getName(), gitSCMSource.getRemote()));
-                                ((SCMSourceOwner) project).onSCMSourceUpdated(scmSource);
-                            } else {
-                                LOGGER.log(Level.FINE, "Ignore on push notification for scmSourceOwner {0} about changes for {1}",
-                                           toArray(project.getName(), gitSCMSource.getRemote()));
-                            }
-                        }
-                    } catch (URISyntaxException e) {
-                        // nothing to do
-                    }
-                }
-            }
-        }
-    }
-
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/SCMSourceOwnerNotifier.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/SCMSourceOwnerNotifier.java
@@ -1,0 +1,46 @@
+package com.dabsquared.gitlabjenkins.webhook.build;
+
+import java.net.URISyntaxException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.jgit.transport.URIish;
+
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceOwner;
+import hudson.model.Item;
+
+import static com.dabsquared.gitlabjenkins.util.LoggerUtil.toArray;
+
+public class SCMSourceOwnerNotifier implements Runnable{
+
+    private final static Logger LOGGER = Logger.getLogger(PushBuildAction.class.getName());
+    private final Item project;
+
+    public SCMSourceOwnerNotifier(Item project) {
+        this.project = project;
+    }
+
+    public void run() {
+        for (SCMSource scmSource : ((SCMSourceOwner) project).getSCMSources()) {
+            if (scmSource instanceof GitSCMSource) {
+                GitSCMSource gitSCMSource = (GitSCMSource) scmSource;
+                try {
+                    if (new URIish(gitSCMSource.getRemote()).equals(new URIish(gitSCMSource.getRemote()))) {
+                        if (!gitSCMSource.isIgnoreOnPushNotifications()) {
+                            LOGGER.log(Level.FINE, "Notify scmSourceOwner {0} about changes for {1}",
+                                toArray(project.getName(), gitSCMSource.getRemote()));
+                            ((SCMSourceOwner) project).onSCMSourceUpdated(scmSource);
+                        } else {
+                            LOGGER.log(Level.FINE, "Ignore on push notification for scmSourceOwner {0} about changes for {1}",
+                                toArray(project.getName(), gitSCMSource.getRemote()));
+                        }
+                    }
+                } catch (URISyntaxException e) {
+                    // nothing to do
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #416.

The plugin's original implementation of Pipeline Multibranch job triggering only supported triggering from GitLab push webhooks. My understanding is that this was because, in the case of Multibranch jobs, the plugin just triggers branch indexing and lets Jenkins trigger the builds themselves for whichever branches have changes. As a result, there is no way to pass any of the data from the GitLab webhook to a Multibranch job, and so when building from an MR the job would not have any of the data about source and target branch which could be used for performing a local merge and so on.

However, enough people have complained about the fact that you cannot even trigger a Multibranch build from a Merge Request that I have tried to remedy that. A better long-term solution would be to add Jenkins SCM Branch Source support to the plugin, and refactor the way Multibranch jobs are triggered in the process.