### PR TITLE
Better compatibility with casc plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ChangeLog
 
+1.5.14 - to be released
+=====================
+* #866: Better compatibility with Configuration as Code plugin (useAuthenticatedEndpoint)
+
 1.5.13
 =====================
 * #972: Security fixes for jackson databind & httpclient

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfig.java
@@ -64,7 +64,7 @@ public class GitLabConnectionConfig extends GlobalConfiguration {
         return useAuthenticatedEndpoint;
     }
 
-    void setUseAuthenticatedEndpoint(boolean useAuthenticatedEndpoint) {
+    public void setUseAuthenticatedEndpoint(boolean useAuthenticatedEndpoint) {
         this.useAuthenticatedEndpoint = useAuthenticatedEndpoint;
     }
 


### PR DESCRIPTION
Package visible setters are ignored by the Jenkins Configuration as
Code plugin. As a result setting the `useAuthenticatedEndpoint` field
was not possible.
See: https://github.com/jenkinsci/configuration-as-code-plugin/issues/676