### PR TITLE
Explicitly add generated (test) sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -481,6 +481,39 @@
               </execution>
             </executions>
           </plugin>
+
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>add-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>${basedir}/target/generated-sources</source>
+                  </sources>
+                </configuration>
+              </execution>
+              <execution>
+                <id>add-test-source</id>
+                <phase>generate-test-sources</phase>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>${basedir}/target/generated-test-sources</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
To be automatically visiable in Idea (probably also Eclipse) on import.
Without that they had to be added manually after the initial import.

Tested with Idea 2018.3, but should work also with other versions.

![image](https://user-images.githubusercontent.com/148013/49686396-2f759780-faf4-11e8-8853-40036695122e.png)
