### PR TITLE
Fix so 'Never rebuild merge requests' feature works

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Action.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Action.java
@@ -4,5 +4,5 @@ package com.dabsquared.gitlabjenkins.gitlab.hook.model;
  * @author Robin Müller
  */
 public enum Action {
-    open, update, approved, merge, closed, reopen
+    open, update, approved, merge, close, reopen
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
@@ -28,6 +28,7 @@ public final class MergeRequestHookTriggerHandlerFactory {
             .acceptIf(triggerOnMergeRequest, of(State.opened, State.reopened), null)
             .acceptIf(triggerOnAcceptedMergeRequest, null, of(Action.merge))
             .acceptIf(triggerOnClosedMergeRequest, null, of(Action.close))
+            .acceptIf(triggerOnClosedMergeRequest, of(State.closed), null)
             .acceptIf(triggerOpenMergeRequest != TriggerOpenMergeRequest.never, of(State.updated), null)
         ;
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
@@ -24,12 +24,12 @@ public final class MergeRequestHookTriggerHandlerFactory {
 
         TriggerConfigChain chain = new TriggerConfigChain();
         chain
+            .acceptOnlyIf(triggerOpenMergeRequest != TriggerOpenMergeRequest.never, of(State.opened, State.updated), of(Action.update))
             .acceptOnlyIf(triggerOnApprovedMergeRequest, null, of(Action.approved))
             .acceptIf(triggerOnMergeRequest, of(State.opened, State.reopened), null)
             .acceptIf(triggerOnAcceptedMergeRequest, null, of(Action.merge))
             .acceptIf(triggerOnClosedMergeRequest, null, of(Action.close))
             .acceptIf(triggerOnClosedMergeRequest, of(State.closed), null)
-            .acceptIf(triggerOpenMergeRequest != TriggerOpenMergeRequest.never, of(State.updated), null)
         ;
 
         return new MergeRequestHookTriggerHandlerImpl(chain, skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
@@ -5,8 +5,6 @@ import com.dabsquared.gitlabjenkins.gitlab.hook.model.Action;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
 import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
 
-import static com.dabsquared.gitlabjenkins.trigger.handler.merge.StateAndActionConfig.notEqual;
-import static com.dabsquared.gitlabjenkins.trigger.handler.merge.StateAndActionConfig.nullOrContains;
 import static java.util.EnumSet.of;
 
 /**
@@ -29,7 +27,7 @@ public final class MergeRequestHookTriggerHandlerFactory {
             .acceptOnlyIf(triggerOnApprovedMergeRequest, null, of(Action.approved))
             .acceptIf(triggerOnMergeRequest, of(State.opened, State.reopened), null)
             .acceptIf(triggerOnAcceptedMergeRequest, null, of(Action.merge))
-            .acceptIf(triggerOnClosedMergeRequest, null, of(Action.closed))
+            .acceptIf(triggerOnClosedMergeRequest, null, of(Action.close))
             .acceptIf(triggerOpenMergeRequest != TriggerOpenMergeRequest.never, of(State.updated), null)
         ;
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.concurrent.ExecutionException;
 
 import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.CommitBuilder.commit;
@@ -80,11 +79,33 @@ public class MergeRequestHookTriggerHandlerImplTest {
     }
 
     @Test
-    public void mergeRequest_build_when_opened() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig().build();
+    public void mergeRequest_build_when_opened_with_source() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
+            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.opened);
 
         assertThat(buildTriggered.isSignaled(), is(true));
+    }
+
+    @Test
+    public void mergeRequest_build_when_opened_with_both() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
+            .build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.opened);
+
+        assertThat(buildTriggered.isSignaled(), is(true));
+    }
+
+    @Test
+    public void mergeRequest_build_when_opened_with_never() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.never)
+            .build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.opened, Action.update);
+
+        assertThat(buildTriggered.isSignaled(), is(false));
     }
 
     @Test
@@ -100,6 +121,7 @@ public class MergeRequestHookTriggerHandlerImplTest {
     public void mergeRequest_build_when_opened_with_approved_action_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
             .setTriggerOnApprovedMergeRequest(true)
+            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
             .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.opened);
 
@@ -133,7 +155,17 @@ public class MergeRequestHookTriggerHandlerImplTest {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
             .setTriggerOnClosedMergeRequest(true)
             .build();
-        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.closed, Action.closed);
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.closed, Action.close);
+
+        assertThat(buildTriggered.isSignaled(), is(true));
+    }
+
+    @Test
+    public void mergeRequest_build_when_close() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnClosedMergeRequest(true)
+            .build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, Action.close);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
@@ -144,7 +176,7 @@ public class MergeRequestHookTriggerHandlerImplTest {
             .setTriggerOnClosedMergeRequest(true)
             .setTriggerOnApprovedMergeRequest(true)
             .build();
-        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.closed, Action.closed);
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.closed, Action.close);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
@@ -205,7 +237,6 @@ public class MergeRequestHookTriggerHandlerImplTest {
     @Test
     public void mergeRequest_do_not_build_for_updated_state_and_approved_action_when_both_not_enabled() throws IOException, InterruptedException, GitAPIException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
             .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
 
@@ -392,7 +423,7 @@ public class MergeRequestHookTriggerHandlerImplTest {
 	private MergeRequestObjectAttributesBuilder defaultMergeRequestObjectAttributes() {
 		return mergeRequestObjectAttributes()
 		    .withIid(1)
-            .withAction(Action.update)
+            .withAction(Action.open)
             .withState(State.opened)
 		    .withTitle("test")
 		    .withTargetProjectId(1)


### PR DESCRIPTION
I started from this issues https://github.com/jenkinsci/gitlab-plugin/issues/705. The main problem was we get 'update' action not only when State is updated but when State is open (you open MR and add some fix push). After that I found that my closed MR doesn't trigger job. After investigation I got that hook was with Action close, not closed. I think It isn't all problem and issues from this scope (MR and webhooks). But it's more popular cases and I think in the future we should to verify what is State and what is Action, and which rule should compare them.

Fixes #705.