### PR TITLE
Change GitLabApiToken parent from Standard to StringCredentials

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabApiToken.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabApiToken.java
@@ -2,17 +2,25 @@ package com.dabsquared.gitlabjenkins.connection;
 
 import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 import com.cloudbees.plugins.credentials.NameWith;
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import hudson.Util;
 import hudson.util.Secret;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+
+import javax.annotation.Nonnull;
 
 /**
  * @author Robin Müller
  */
 @NameWith(GitLabApiToken.NameProvider.class)
-public interface GitLabApiToken extends StandardCredentials {
+public interface GitLabApiToken extends StringCredentials {
 
     Secret getApiToken();
+
+    @Nonnull
+    @Override
+    default Secret getSecret() {
+        return getApiToken();
+    }
 
     class NameProvider extends CredentialsNameProvider<GitLabApiToken> {
         @Override


### PR DESCRIPTION
Fixes JENKINS-48552 and #494. 
Makes Api token compatible with Credentials Binding plugin.