### PR TITLE
Fixed unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,12 +309,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>matrix-auth</artifactId>
-      <version>2.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
       <version>2.19</version>
@@ -327,6 +321,18 @@
       <scope>test</scope>
     </dependency>
     <!-- parent pom test dependencies needs overriding-->
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-core</artifactId>
+      <version>3.10.2</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
   </dependencies>
 


### PR DESCRIPTION
``mvn clean install`` does not work on MacOS because JVM prefers org.apache.commons.io.IOUtils class shipped with commons-io-1.3.2 (mockserver-core transitive dependency) to commons-io-2.4

Replacing GlobalMatrixAuthorizationStrategy by MockAuthorizationStrategy intended to remove annoying exceptions from jetty logs:

```
WARNING	hudson.ExtensionFinder$Sezpoz#scout: Failed to scout org.jenkinsci.plugins.matrixauth.AuthorizationMatrixNodeProperty$NodeListenerImpl
java.lang.ClassNotFoundException: jenkins.model.NodeListener
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
Caused: java.lang.NoClassDefFoundError: jenkins/model/NodeListener
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:760)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:411)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at net.java.sezpoz.IndexItem.element(IndexItem.java:134)
Caused: java.lang.InstantiationException
```
