### PR TITLE
make setUseAuthenticatedEndpoint public

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfig.java
@@ -61,7 +61,7 @@ public class GitLabConnectionConfig extends GlobalConfiguration {
         return useAuthenticatedEndpoint;
     }
 
-    void setUseAuthenticatedEndpoint(boolean useAuthenticatedEndpoint) {
+    public void setUseAuthenticatedEndpoint(boolean useAuthenticatedEndpoint) {
         this.useAuthenticatedEndpoint = useAuthenticatedEndpoint;
     }
 


### PR DESCRIPTION
I'm using groovy script to configure the gitlab plugin when jenkins instance is started. I'd like to set useAuthenticatedEndpoint property using setUseAuthenticatedEndpoint(false). However, it's not public function. Any particular reason why not?
