### PR TITLE
Retrieve GitlabHook data in upstream builds if available

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributor.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributor.java
@@ -1,16 +1,19 @@
 package com.dabsquared.gitlabjenkins.environment;
 
 import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
+import com.dabsquared.gitlabjenkins.util.CauseUtil;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.matrix.MatrixRun;
 import hudson.matrix.MatrixBuild;
+import hudson.model.Cause;
 import hudson.model.EnvironmentContributor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * @author Robin Müller
@@ -19,15 +22,17 @@ import java.io.IOException;
 public class GitLabEnvironmentContributor extends EnvironmentContributor {
     @Override
     public void buildEnvironmentFor(@Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener) throws IOException, InterruptedException {
-        GitLabWebHookCause cause = null;
+        List<Cause> causes = null;
         if (r instanceof MatrixRun) {
             MatrixBuild parent = ((MatrixRun)r).getParentBuild();
             if (parent != null) {
-                cause = (GitLabWebHookCause) parent.getCause(GitLabWebHookCause.class);
+                causes = parent.getCauses();
             }
         } else {
-            cause = (GitLabWebHookCause) r.getCause(GitLabWebHookCause.class);
+            causes = r.getCauses();
         }
+
+        GitLabWebHookCause cause = CauseUtil.findCauseFromUpstreamCauses(causes, GitLabWebHookCause.class);
         if (cause != null) {
             envs.overrideAll(cause.getData().getBuildVariables());
         }

--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CauseUtil.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CauseUtil.java
@@ -1,0 +1,32 @@
+package com.dabsquared.gitlabjenkins.util;
+
+import hudson.model.Cause;
+
+import java.util.List;
+
+/**
+ * @author Sami Makki
+ */
+public class CauseUtil {
+
+    public static <T extends Cause> T findCauseFromUpstreamCauses(List<Cause> causes, Class<T> type) {
+        for (Cause cause : causes) {
+            if (type.isInstance(cause)) {
+                return type.cast(cause);
+            }
+            if (cause instanceof Cause.UpstreamCause) {
+                List<Cause> upCauses = ((Cause.UpstreamCause) cause).getUpstreamCauses();    // Non null, returns empty list when none are set
+                for (Cause upCause : upCauses) {
+                    if (type.isInstance(upCause)) {
+                        return type.cast(upCause);
+                    }
+                }
+                T gitlabCause = findCauseFromUpstreamCauses(upCauses, type);
+                if (gitlabCause != null) {
+                    return gitlabCause;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -3,14 +3,12 @@ package com.dabsquared.gitlabjenkins.util;
 
 import com.dabsquared.gitlabjenkins.cause.CauseData;
 import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
-import com.dabsquared.gitlabjenkins.connection.GitLabConnection;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.BuildState;
 import com.dabsquared.gitlabjenkins.workflow.GitLabBranchBuild;
 import hudson.EnvVars;
 import hudson.model.*;
-import hudson.model.Cause.UpstreamCause;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.util.Build;
 import hudson.plugins.git.util.BuildData;
@@ -246,23 +244,14 @@ public class CommitStatusUpdater {
     }
 
     private static List<GitLabBranchBuild> findBuildsFromUpstreamCauses(List<Cause> causes) {
-        for (Cause cause : causes) {
-            if (cause instanceof UpstreamCause) {
-                List<Cause> upCauses = ((UpstreamCause) cause).getUpstreamCauses();    // Non null, returns empty list when none are set
-                for (Cause upCause : upCauses) {
-                    if (upCause instanceof GitLabWebHookCause) {
-                        GitLabWebHookCause gitlabCause = (GitLabWebHookCause) upCause;
-                        return Collections.singletonList(
-                                new GitLabBranchBuild(gitlabCause.getData().getSourceProjectId().toString(),
-                                        gitlabCause.getData().getLastCommit()));
-                    }
-                }
-                List<GitLabBranchBuild> builds = findBuildsFromUpstreamCauses(upCauses);
-                if (!builds.isEmpty()) {
-                    return builds;
-                }
-            }
+
+        GitLabWebHookCause gitlabCause = CauseUtil.findCauseFromUpstreamCauses(causes, GitLabWebHookCause.class);
+
+        if (gitlabCause != null) {
+            return Collections.singletonList(
+                new GitLabBranchBuild(gitlabCause.getData().getSourceProjectId().toString(), gitlabCause.getData().getLastCommit()));
         }
+
         return Collections.emptyList();
     }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/AcceptGitLabMergeRequestStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/AcceptGitLabMergeRequestStep.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 
+import com.dabsquared.gitlabjenkins.util.CauseUtil;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.*;
 
@@ -85,7 +86,7 @@ public class AcceptGitLabMergeRequestStep extends Step {
         
         @Override
         protected Void run() throws Exception {
-            GitLabWebHookCause cause = run.getCause(GitLabWebHookCause.class);
+            GitLabWebHookCause cause = CauseUtil.findCauseFromUpstreamCauses(run.getCauses(), GitLabWebHookCause.class);
             if (cause != null) {
                 MergeRequest mergeRequest = cause.getData().getMergeRequest();
                 if (mergeRequest != null) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/AddGitLabMergeRequestCommentStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/AddGitLabMergeRequestCommentStep.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 
+import com.dabsquared.gitlabjenkins.util.CauseUtil;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
 import org.jenkinsci.plugins.workflow.steps.Step;
@@ -72,7 +73,7 @@ public class AddGitLabMergeRequestCommentStep extends Step {
         
         @Override
         protected Void run() throws Exception {
-            GitLabWebHookCause cause = run.getCause(GitLabWebHookCause.class);
+            GitLabWebHookCause cause = CauseUtil.findCauseFromUpstreamCauses(run.getCauses(), GitLabWebHookCause.class);
             if (cause != null) {
                 MergeRequest mergeRequest = cause.getData().getMergeRequest();
                 if (mergeRequest != null) {


### PR DESCRIPTION
This patch allows downstream jobs to use the gitlab plugin features, such as accepting a merge request, adding a note, but also populating the environment with the gitlab data.