### PR TITLE
Provide merge request labels as environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ gitlabMergedByUser
 gitlabMergeRequestAssignee
 gitlabMergeRequestLastCommit
 gitlabMergeRequestTargetProjectId
+gitlabMergeRequestLabels
 gitlabTargetBranch
 gitlabTargetRepoName
 gitlabTargetNamespace

--- a/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
@@ -14,6 +14,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 import java.util.*;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Collections.emptyList;
 
 /**
  * @author Robin Müller
@@ -41,6 +42,7 @@ public final class CauseData {
     private final String mergedByUser;
     private final String mergeRequestAssignee;
     private final Integer mergeRequestTargetProjectId;
+    private final List<String> mergeRequestLabels;
     private final String targetBranch;
     private final String targetRepoName;
     private final String targetNamespace;
@@ -66,7 +68,7 @@ public final class CauseData {
     CauseData(ActionType actionType, Integer sourceProjectId, Integer targetProjectId, String branch, String sourceBranch, String userName,
               String userEmail, String sourceRepoHomepage, String sourceRepoName, String sourceNamespace, String sourceRepoUrl,
               String sourceRepoSshUrl, String sourceRepoHttpUrl, String mergeRequestTitle, String mergeRequestDescription, Integer mergeRequestId,
-              Integer mergeRequestIid, Integer mergeRequestTargetProjectId, String targetBranch, String targetRepoName, String targetNamespace, String targetRepoSshUrl,
+              Integer mergeRequestIid, Integer mergeRequestTargetProjectId, List<String> mergeRequestLabels, String targetBranch, String targetRepoName, String targetNamespace, String targetRepoSshUrl,
               String targetRepoHttpUrl, String triggeredByUser, String before, String after, String lastCommit, String targetProjectUrl,
               String triggerPhrase, String mergeRequestState, String mergedByUser, String mergeRequestAssignee, String ref, String isTag,
 	            String sha, String beforeSha, String status, String stages, String createdAt, String finishedAt, String buildDuration) {
@@ -91,6 +93,7 @@ public final class CauseData {
         this.mergedByUser = mergedByUser == null ? "" : mergedByUser;
         this.mergeRequestAssignee = mergeRequestAssignee == null ? "" : mergeRequestAssignee;
         this.mergeRequestTargetProjectId = mergeRequestTargetProjectId;
+        this.mergeRequestLabels = mergeRequestLabels == null ? emptyList() : mergeRequestLabels;
         this.targetBranch = checkNotNull(targetBranch, "targetBranch must not be null.");
         this.targetRepoName = checkNotNull(targetRepoName, "targetRepoName must not be null.");
         this.targetNamespace = checkNotNull(targetNamespace, "targetNamespace must not be null.");
@@ -136,6 +139,7 @@ public final class CauseData {
         variables.putIfNotNull("gitlabMergeRequestState", mergeRequestState);
         variables.putIfNotNull("gitlabMergedByUser", mergedByUser);
         variables.putIfNotNull("gitlabMergeRequestAssignee", mergeRequestAssignee);
+        variables.put("gitlabMergeRequestLabels", mergeRequestLabels == null ? "" : StringUtils.join(mergeRequestLabels, ","));
         variables.put("gitlabTargetBranch", targetBranch);
         variables.put("gitlabTargetRepoName", targetRepoName);
         variables.put("gitlabTargetNamespace", targetNamespace);

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -31,6 +31,7 @@ import java.util.logging.Logger;
 import static com.dabsquared.gitlabjenkins.cause.CauseDataBuilder.causeData;
 import static com.dabsquared.gitlabjenkins.trigger.handler.builder.generated.BuildStatusUpdateBuilder.buildStatusUpdate;
 import static com.dabsquared.gitlabjenkins.util.LoggerUtil.toArray;
+import static java.util.stream.Collectors.toList;
 
 /**
  * @author Robin Müller
@@ -147,6 +148,7 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
                 .withMergedByUser(hook.getUser() == null ? null : hook.getUser().getUsername())
                 .withMergeRequestAssignee(hook.getAssignee() == null ? null : hook.getAssignee().getUsername())
                 .withMergeRequestTargetProjectId(hook.getObjectAttributes().getTargetProjectId())
+                .withMergeRequestLabels(hook.getLabels() == null ? null : hook.getLabels().stream().map(MergeRequestLabel::getTitle).collect(toList()))
                 .withTargetBranch(hook.getObjectAttributes().getTargetBranch())
                 .withTargetRepoName(hook.getObjectAttributes().getTarget().getName())
                 .withTargetNamespace(hook.getObjectAttributes().getTarget().getNamespace())


### PR DESCRIPTION
Closes #900
Also see #646

Example pipeline:
```
pipeline {
    agent any
    triggers {
        gitlab(
            triggerOnPush: true,
            triggerOnMergeRequest: true,
            triggerOpenMergeRequestOnPush: "source",
            triggerOnNoteRequest: true,
            branchFilterType: "All",
            skipWorkInProgressMergeRequest: false)
    }
    stages {
        stage('Prepare') {
            steps {
                echo sh(returnStdout: true, script: 'env')
            }
        }
    }
}
```

Output:
```
[Pipeline] sh
+ env
[Pipeline] echo
gitlabMergeRequestTargetProjectId=1
gitlabSourceRepoURL=ssh://git@localhost:10022/root/anton.git
JENKINS_HOME=/var/jenkins_home
gitlabTargetRepoHttpUrl=http://localhost:10080/root/anton.git
JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
gitlabMergedByUser=root
RUN_CHANGES_DISPLAY_URL=http://localhost:8080/job/anton/5/display/redirect?page=changes
HOSTNAME=4ea3e1ce3cbc
gitlabTargetRepoSshUrl=ssh://git@localhost:10022/root/anton.git
SHLVL=0
NODE_LABELS=master
HUDSON_URL=http://localhost:8080/
HOME=/var/jenkins_home
BUILD_URL=http://localhost:8080/job/anton/5/
HUDSON_COOKIE=85dd3aca-ba51-4ed6-91ce-ffad4cb29895
gitlabTargetBranch=master
JENKINS_SERVER_COOKIE=durable-6b17982e7e0d911a16d9ced57c7aafff
gitlabMergeRequestIid=1
JENKINS_UC=https://updates.jenkins.io
gitlabSourceRepoHttpUrl=http://localhost:10080/root/anton.git
gitlabMergeRequestState=opened
WORKSPACE=/var/jenkins_home/workspace/anton
gitlabMergeRequestTitle=Update README.md
JAVA_VERSION=8u151
gitlabMergeRequestLastCommit=d0b6cdced0adb9808a27787b8cc5d58459170840
NODE_NAME=master
gitlabSourceRepoSshUrl=ssh://git@localhost:10022/root/anton.git
gitlabTargetRepoName=anton
gitlabTargetNamespace=root
gitlabMergeRequestLabels=deploy,bug
STAGE_NAME=Prepare
CA_CERTIFICATES_JAVA_VERSION=20170531+nmu1
gitlabSourceRepoHomepage=http://localhost:10080/root/anton
EXECUTOR_NUMBER=0
gitlabBranch=test
BUILD_DISPLAY_NAME=#5
gitlabSourceBranch=test
gitlabUserEmail=admin@example.com
JENKINS_VERSION=2.89.4
HUDSON_HOME=/var/jenkins_home
JAVA_DEBIAN_VERSION=8u151-b12-1~deb9u1
JOB_BASE_NAME=anton
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
BUILD_ID=5
BUILD_TAG=jenkins-anton-5
gitlabMergeRequestId=1
gitlabActionType=MERGE
JENKINS_URL=http://localhost:8080/
LANG=C.UTF-8
JOB_URL=http://localhost:8080/job/anton/
gitlabSourceRepoName=anton
gitlabSourceNamespace=root
BUILD_NUMBER=5
JENKINS_NODE_COOKIE=63f85221-303e-4906-aca5-59985eb83c63
RUN_DISPLAY_URL=http://localhost:8080/job/anton/5/display/redirect
JENKINS_SLAVE_AGENT_PORT=50000
HUDSON_SERVER_COOKIE=e3dff077c89c3538
JOB_DISPLAY_URL=http://localhost:8080/job/anton/display/redirect
JOB_NAME=anton
COPY_REFERENCE_FILE_LOG=/var/jenkins_home/copy_reference_file.log
PWD=/var/jenkins_home/workspace/anton
JAVA_HOME=/docker-java-home
gitlabUserName=Administrator
```

Limitations:
* Does not work when commenting on the MR, because that GitLab webhook does not include merge request labels.