### PR TITLE
Add possibility to force build with added MR label(s)

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -88,6 +88,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     private String noteRegex = "";
     private boolean ciSkip = true;
     private boolean skipWorkInProgressMergeRequest;
+    private String labelsThatForcesBuildIfAdded = "";
     private boolean setBuildDescription = true;
     private transient boolean addNoteOnMergeRequest;
     private transient boolean addCiMessage;
@@ -119,7 +120,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
     public GitLabPushTrigger(boolean triggerOnPush, boolean triggerOnMergeRequest, boolean triggerOnAcceptedMergeRequest, boolean triggerOnClosedMergeRequest,
     						 TriggerOpenMergeRequest triggerOpenMergeRequestOnPush, boolean triggerOnNoteRequest, String noteRegex,
-    						 boolean skipWorkInProgressMergeRequest, boolean ciSkip,
+                             boolean skipWorkInProgressMergeRequest, boolean ciSkip, String labelsThatForcesBuildIfAdded,
                              boolean setBuildDescription, boolean addNoteOnMergeRequest, boolean addCiMessage, boolean addVoteOnMergeRequest,
                              boolean acceptMergeRequestOnSuccess, BranchFilterType branchFilterType,
                              String includeBranchesSpec, String excludeBranchesSpec, String sourceBranchRegex, String targetBranchRegex,
@@ -135,6 +136,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
         this.triggerOnPipelineEvent = triggerOnPipelineEvent;
         this.ciSkip = ciSkip;
         this.skipWorkInProgressMergeRequest = skipWorkInProgressMergeRequest;
+        this.labelsThatForcesBuildIfAdded = labelsThatForcesBuildIfAdded;
         this.setBuildDescription = setBuildDescription;
         this.addNoteOnMergeRequest = addNoteOnMergeRequest;
         this.addCiMessage = addCiMessage;
@@ -261,6 +263,11 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
         return skipWorkInProgressMergeRequest;
     }
 
+    @Override
+    public String getLabelsThatForcesBuildIfAdded() {
+        return labelsThatForcesBuildIfAdded;
+    }
+
     public BranchFilterType getBranchFilterType() {
         return branchFilterType;
     }
@@ -346,6 +353,11 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     @DataBoundSetter
     public void setSkipWorkInProgressMergeRequest(boolean skipWorkInProgressMergeRequest) {
         this.skipWorkInProgressMergeRequest = skipWorkInProgressMergeRequest;
+    }
+
+    @DataBoundSetter
+    public void setLabelsThatForcesBuildIfAdded(String labelsThatForcesBuildIfAdded) {
+        this.labelsThatForcesBuildIfAdded = labelsThatForcesBuildIfAdded;
     }
 
     @DataBoundSetter

--- a/src/main/java/com/dabsquared/gitlabjenkins/MergeRequestTriggerConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/MergeRequestTriggerConfig.java
@@ -15,5 +15,7 @@ public interface MergeRequestTriggerConfig {
 
     boolean isSkipWorkInProgressMergeRequest();
 
+    String getLabelsThatForcesBuildIfAdded();
+
     boolean getCancelPendingBuildsOnUpdate();
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestChangedLabels.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestChangedLabels.java
@@ -1,0 +1,69 @@
+package com.dabsquared.gitlabjenkins.gitlab.hook.model;
+
+import net.karneim.pojobuilder.GeneratePojoBuilder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+import java.util.List;
+
+/**
+ * @author Anton Johansson
+ */
+@GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
+public class MergeRequestChangedLabels {
+
+    /*
+        "previous": [{...}],
+        "current": [{...}]
+    */
+    private List<MergeRequestLabel> previous;
+    private List<MergeRequestLabel> current;
+
+    public List<MergeRequestLabel> getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(List<MergeRequestLabel> previous) {
+        this.previous = previous;
+    }
+
+    public List<MergeRequestLabel> getCurrent() {
+        return current;
+    }
+
+    public void setCurrent(List<MergeRequestLabel> current) {
+        this.current = current;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MergeRequestChangedLabels that = (MergeRequestChangedLabels) o;
+        return new EqualsBuilder()
+            .append(previous, that.previous)
+            .append(current, that.current)
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+            .append(previous)
+            .append(current)
+            .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("previous", previous)
+            .append("current", current)
+            .toString();
+    }
+}

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestChanges.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestChanges.java
@@ -1,0 +1,54 @@
+package com.dabsquared.gitlabjenkins.gitlab.hook.model;
+
+import net.karneim.pojobuilder.GeneratePojoBuilder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+/**
+ * @author Anton Johansson
+ */
+@GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
+public class MergeRequestChanges {
+
+    /*
+        "labels": {...}
+    */
+    private MergeRequestChangedLabels labels;
+
+    public MergeRequestChangedLabels getLabels() {
+        return labels;
+    }
+
+    public void setLabels(MergeRequestChangedLabels labels) {
+        this.labels = labels;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MergeRequestChanges that = (MergeRequestChanges) o;
+        return new EqualsBuilder()
+            .append(labels, that.labels)
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+            .append(labels)
+            .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("labels", labels)
+            .toString();
+    }
+}

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestHook.java
@@ -14,11 +14,20 @@ import java.util.List;
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
 public class MergeRequestHook extends WebHook {
 
+    /*
+        "user": {...},
+        "assignee": {...},
+        "project": {...},
+        "object_attributes": {...},
+        "labels": [{...}],
+        "changes": {...}
+    */
     private User user;
     private User assignee;
     private Project project;
     private MergeRequestObjectAttributes objectAttributes;
     private List<MergeRequestLabel> labels;
+    private MergeRequestChanges changes;
 
     public User getUser() {
         return user;
@@ -60,6 +69,14 @@ public class MergeRequestHook extends WebHook {
         this.labels = labels;
     }
 
+    public MergeRequestChanges getChanges() {
+        return changes;
+    }
+
+    public void setChanges(MergeRequestChanges changes) {
+        this.changes = changes;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -75,6 +92,7 @@ public class MergeRequestHook extends WebHook {
                 .append(project, that.project)
                 .append(objectAttributes, that.objectAttributes)
                 .append(labels, that.labels)
+                .append(changes, that.changes)
                 .isEquals();
     }
 
@@ -86,6 +104,7 @@ public class MergeRequestHook extends WebHook {
                 .append(project)
                 .append(objectAttributes)
                 .append(labels)
+                .append(changes)
                 .toHashCode();
     }
 
@@ -97,6 +116,7 @@ public class MergeRequestHook extends WebHook {
                 .append("project", project)
                 .append("objectAttributes", objectAttributes)
                 .append("labels", labels)
+                .append("changes", changes)
                 .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
@@ -8,6 +8,14 @@ import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
 import static com.dabsquared.gitlabjenkins.trigger.handler.merge.StateAndActionConfig.notEqual;
 import static com.dabsquared.gitlabjenkins.trigger.handler.merge.StateAndActionConfig.nullOrContains;
 import static java.util.EnumSet.of;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.lang.StringUtils.split;
+import static org.apache.commons.lang.StringUtils.trimToEmpty;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang.StringUtils;
 
 /**
  * @author Robin Müller
@@ -21,6 +29,7 @@ public final class MergeRequestHookTriggerHandlerFactory {
     		                                                                       boolean triggerOnClosedMergeRequest,
                                                                                    TriggerOpenMergeRequest triggerOpenMergeRequest,
                                                                                    boolean skipWorkInProgressMergeRequest,
+                                                                                   String labelsThatForcesBuildIfAdded,
                                                                                    boolean triggerOnApprovedMergeRequest,
                                                                                    boolean cancelPendingBuildsOnUpdate) {
 
@@ -33,7 +42,8 @@ public final class MergeRequestHookTriggerHandlerFactory {
             .acceptIf(triggerOpenMergeRequest != TriggerOpenMergeRequest.never, of(State.updated), null)
         ;
 
-        return new MergeRequestHookTriggerHandlerImpl(chain, skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);
+        Set<String> labelsThatForcesBuildIfAddedSet = Stream.of(split(trimToEmpty(labelsThatForcesBuildIfAdded), ",")).collect(toSet());
+        return new MergeRequestHookTriggerHandlerImpl(chain, skipWorkInProgressMergeRequest, labelsThatForcesBuildIfAddedSet, cancelPendingBuildsOnUpdate);
     }
 
     public static MergeRequestHookTriggerHandler newMergeRequestHookTriggerHandler(MergeRequestTriggerConfig config) {
@@ -42,6 +52,7 @@ public final class MergeRequestHookTriggerHandlerFactory {
             config.isTriggerOnClosedMergeRequest(),
             config.getTriggerOpenMergeRequestOnPush(),
             config.isSkipWorkInProgressMergeRequest(),
+            config.getLabelsThatForcesBuildIfAdded(),
             config.isTriggerOnApprovedMergeRequest(),
             config.getCancelPendingBuildsOnUpdate());
     }
@@ -56,6 +67,7 @@ public final class MergeRequestHookTriggerHandlerFactory {
         private boolean triggerOnClosedMergeRequest = false;
         private TriggerOpenMergeRequest triggerOpenMergeRequest = TriggerOpenMergeRequest.never;
         private boolean skipWorkInProgressMergeRequest = false;
+        private String labelsThatForcesBuildIfAdded;
         private boolean triggerOnApprovedMergeRequest = false;
         private boolean cancelPendingBuildsOnUpdate = false;
 
@@ -90,6 +102,11 @@ public final class MergeRequestHookTriggerHandlerFactory {
         }
 
         @Override
+        public String getLabelsThatForcesBuildIfAdded() {
+            return labelsThatForcesBuildIfAdded;
+        }
+
+        @Override
         public boolean getCancelPendingBuildsOnUpdate() {
             return cancelPendingBuildsOnUpdate;
         }
@@ -116,6 +133,11 @@ public final class MergeRequestHookTriggerHandlerFactory {
 
         public Config setSkipWorkInProgressMergeRequest(boolean skipWorkInProgressMergeRequest) {
             this.skipWorkInProgressMergeRequest = skipWorkInProgressMergeRequest;
+            return this;
+        }
+
+        public Config setLabelsThatForcesBuildIfAdded(String labelsThatForcesBuildIfAdded) {
+            this.labelsThatForcesBuildIfAdded = labelsThatForcesBuildIfAdded;
             return this;
         }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -93,7 +93,7 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
     private boolean isExecutable(Job<?, ?> job, MergeRequestHook hook) {
         MergeRequestObjectAttributes objectAttributes = hook.getObjectAttributes();
         boolean forcedByAddedLabel = isForcedByAddedLabel(hook);
-        return (forcedByAddedLabel || isAllowedByConfig(objectAttributes))
+        return isAllowedByConfig(objectAttributes)
             && (forcedByAddedLabel || isLastCommitNotYetBuild(job, hook))
             && isNotSkipWorkInProgressMergeRequest(objectAttributes);
     }

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -36,6 +36,9 @@
     <f:entry title="${%Ignore WIP Merge Requests}" field="skipWorkInProgressMergeRequest">
       <f:checkbox default="true"/>
     </f:entry>
+    <f:entry title="Labels that forces builds if they are added (comma-separated)">
+      <f:textbox field="labelsThatForcesBuildIfAdded"/>
+    </f:entry>
     <f:entry title="Set build description to build cause (eg. Merge request or Git Push )" field="setBuildDescription">
       <f:checkbox default="true"/>
     </f:entry>


### PR DESCRIPTION
With this functionality (together with #901), I can perform logic using GitLab MR labels. For example, I can have a label titled "Auto-deploy", which I could use to automatically deploy my branch to my Kubernetes cluster.

This PR makes sure I can add the label "Auto-deploy" without having the GitLab Plugin block the webhook due to the fact that the Git SHA has already been built once.

PR #901 makes sure I can actually access the labels in the Jenkins pipeline, using environment variables.