### PR TITLE
Support user regex filter for note trigger

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -86,6 +86,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     private TriggerOpenMergeRequest triggerOpenMergeRequestOnPush;
     private boolean triggerOnNoteRequest = true;
     private String noteRegex = "";
+    private String userRegex = "";
     private boolean ciSkip = true;
     private boolean skipWorkInProgressMergeRequest;
     private boolean setBuildDescription = true;
@@ -118,7 +119,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     @Deprecated
     @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
     public GitLabPushTrigger(boolean triggerOnPush, boolean triggerOnMergeRequest, boolean triggerOnAcceptedMergeRequest, boolean triggerOnClosedMergeRequest,
-    						 TriggerOpenMergeRequest triggerOpenMergeRequestOnPush, boolean triggerOnNoteRequest, String noteRegex,
+    						 TriggerOpenMergeRequest triggerOpenMergeRequestOnPush, boolean triggerOnNoteRequest, String noteRegex, String userRegex,
     						 boolean skipWorkInProgressMergeRequest, boolean ciSkip,
                              boolean setBuildDescription, boolean addNoteOnMergeRequest, boolean addCiMessage, boolean addVoteOnMergeRequest,
                              boolean acceptMergeRequestOnSuccess, BranchFilterType branchFilterType,
@@ -131,6 +132,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
         this.triggerOnClosedMergeRequest = triggerOnClosedMergeRequest;
         this.triggerOnNoteRequest = triggerOnNoteRequest;
         this.noteRegex = noteRegex;
+        this.userRegex = userRegex;
         this.triggerOpenMergeRequestOnPush = triggerOpenMergeRequestOnPush;
         this.triggerOnPipelineEvent = triggerOnPipelineEvent;
         this.ciSkip = ciSkip;
@@ -243,6 +245,10 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
         return this.noteRegex == null ? "" : this.noteRegex;
     }
 
+    public String getUserRegex() {
+        return this.userRegex == null ? "" : this.userRegex;
+    }
+
     @Override
     public TriggerOpenMergeRequest getTriggerOpenMergeRequestOnPush() {
         return triggerOpenMergeRequestOnPush;
@@ -336,6 +342,11 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     @DataBoundSetter
     public void setNoteRegex(String noteRegex) {
         this.noteRegex = noteRegex;
+    }
+
+    @DataBoundSetter
+    public void setUserRegex(String userRegex) {
+        this.userRegex = userRegex;
     }
 
     @DataBoundSetter
@@ -483,7 +494,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
 
     private void initializeTriggerHandler() {
 		mergeRequestHookTriggerHandler = newMergeRequestHookTriggerHandler(this);
-        noteHookTriggerHandler = newNoteHookTriggerHandler(triggerOnNoteRequest, noteRegex);
+        noteHookTriggerHandler = newNoteHookTriggerHandler(triggerOnNoteRequest, noteRegex, userRegex);
         pushHookTriggerHandler = newPushHookTriggerHandler(triggerOnPush, triggerOpenMergeRequestOnPush, skipWorkInProgressMergeRequest);
         pipelineTriggerHandler = newPipelineHookTriggerHandler(triggerOnPipelineEvent);
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerFactory.java
@@ -7,9 +7,9 @@ public final class NoteHookTriggerHandlerFactory {
 
     private NoteHookTriggerHandlerFactory() {}
 
-    public static NoteHookTriggerHandler newNoteHookTriggerHandler(boolean triggerOnNoteRequest, String noteRegex) {
+    public static NoteHookTriggerHandler newNoteHookTriggerHandler(boolean triggerOnNoteRequest, String noteRegex, String userRegex) {
         if (triggerOnNoteRequest) {
-            return new NoteHookTriggerHandlerImpl(noteRegex);
+            return new NoteHookTriggerHandlerImpl(noteRegex, userRegex);
         } else {
             return new NopNoteHookTriggerHandler();
         }

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -27,6 +27,9 @@
       <f:entry title="Comment (regex) for triggering a build" help="/plugin/gitlab-plugin/help/help-noteRegex.html">
         <f:textbox field="noteRegex" default="Jenkins please retry a build"/>
       </f:entry>
+      <f:entry title="User (regex) for triggering a build" help="/plugin/gitlab-plugin/help/help-userRegex.html">
+        <f:textbox field="userRegex" default=""/>
+      </f:entry>
     </table>
   </f:entry>
   <f:advanced>

--- a/src/main/webapp/help/help-userRegex.html
+++ b/src/main/webapp/help/help-userRegex.html
@@ -1,0 +1,5 @@
+<div>
+    <div>
+        <p>When filled, the comment user in the merge request matching this regular expression will trigger a build.</p>
+    </div>
+</div>


### PR DESCRIPTION
Support user regex filter when trigger type is note.If the username who wrote comment like "merge please" not match the user regex configured in job configuration, the note will not trigger build.