### PR TITLE
WIP: Retrieve merge request status for any job

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestStatusStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestStatusStep.java
@@ -1,0 +1,125 @@
+package com.dabsquared.gitlabjenkins.workflow;
+
+import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
+import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
+import com.dabsquared.gitlabjenkins.gitlab.api.model.BuildState;
+import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
+import com.dabsquared.gitlabjenkins.util.CommitStatusUpdater;
+import com.google.common.collect.ImmutableSet;
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.ListBoxModel;
+import org.jenkinsci.plugins.workflow.steps.*;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author <a href="mailto:robin.mueller@1und1.de">Robin Müller</a>
+ */
+@ExportedBean
+public class GitLabMergeRequestStatusStep extends Step {
+
+    private final static Logger LOGGER = Logger.getLogger(GitLabMergeRequestStatusStep.class.getName());
+
+    private String projectName;
+    private String branchName;
+
+    @DataBoundConstructor
+    public GitLabMergeRequestStatusStep(String project_name, String branch_name) {
+        this.projectName = project_name;
+        this.branchName = branch_name;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    @DataBoundSetter
+    public void setProjectName(String project_name) {
+        this.projectName = project_name;
+    }
+
+    public String getBranchName() {
+        return branchName;
+    }
+
+    @DataBoundSetter
+    public void setBranchName(String branch_name) {
+        this.branchName = branch_name;
+    }
+
+	@Override
+	public StepExecution start(StepContext context) throws Exception {
+		return new GitLabMergeRequestStatusStepExecution(context, this);
+	}
+
+    public static class GitLabMergeRequestStatusStepExecution extends SynchronousNonBlockingStepExecution<MergeRequest> {
+        private static final long serialVersionUID = 1;
+
+        private final transient Run<?, ?> run;
+
+        private final transient GitLabMergeRequestStatusStep step;
+
+        GitLabMergeRequestStatusStepExecution(StepContext context, GitLabMergeRequestStatusStep step) throws Exception {
+            super(context);
+            this.step = step;
+            run = context.get(Run.class);
+        }
+
+        @Override
+        protected MergeRequest run() throws Exception {
+            GitLabClient client = GitLabConnectionProperty.getClient(run);
+            if (client == null) {
+                LOGGER.log(Level.WARNING, "Failed to find gitlab connection");
+                return null;
+            }
+
+            Integer page = 1;
+            do {
+                List<MergeRequest> mergeRequests = client.getMergeRequests(step.branchName, State.opened, page, 100);
+                for (MergeRequest mr : mergeRequests) {
+                    if (mr.getSourceBranch().equals(step.branchName)) {
+                        return mr;
+                    }
+                }
+                page = mergeRequests.isEmpty() ? null : page + 1;
+            } while (page != null);
+            return null;
+        }
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends StepDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Return the MergeRequest status for the branch, if it exists.";
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "gitlabMergeRequestStatus";
+        }
+
+        public ListBoxModel doFillStateItems() {
+            ListBoxModel options = new ListBoxModel();
+            for (BuildState buildState : EnumSet.allOf(BuildState.class)) {
+                options.add(buildState.name());
+            }
+            return options;
+        }
+
+		@Override
+		public Set<Class<?>> getRequiredContext() {
+			return ImmutableSet.of(TaskListener.class, Run.class);
+		}
+    }
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestStatusStepTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestStatusStepTest.java
@@ -1,0 +1,27 @@
+package com.dabsquared.gitlabjenkins.workflow;
+
+
+import hudson.model.Run;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class GitLabMergeRequestStatusStepTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void gitlabCommitStatus() throws Exception {
+        WorkflowJob project = j.createProject(WorkflowJob.class);
+        String pipelineText =  IOUtils.toString(getClass().getResourceAsStream(
+            "pipeline/gitlabMergeRequestStatus-pipeline.groovy"));
+        project.setDefinition(new CpsFlowDefinition(pipelineText, false));
+        Run build = j.buildAndAssertSuccess(project);
+        j.assertLogContains("MR1 target = master", build);
+        j.assertLogContains("No MR for feature 2", build);
+    }
+}

--- a/src/test/resources/com/dabsquared/gitlabjenkins/workflow/pipeline/gitlabMergeRequestStatus-pipeline.groovy
+++ b/src/test/resources/com/dabsquared/gitlabjenkins/workflow/pipeline/gitlabMergeRequestStatus-pipeline.groovy
@@ -1,0 +1,8 @@
+package com.dabsquared.gitlabjenkins.workflow.pipeline
+
+def mr1 = gitlabMergeRequestStatus('project', 'feature1')
+echo "MR1 target = ${mr1.targetBranch}"
+
+def mr2 = gitlabMergeRequestStatus('project', 'feature2')
+if (mr2.size() == 0)
+  echo 'No MR for feature 2'

--- a/src/test/resources/com/dabsquared/gitlabjenkins/workflow/pipeline/mr-closed.json
+++ b/src/test/resources/com/dabsquared/gitlabjenkins/workflow/pipeline/mr-closed.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": 10,
+    "iid": 10,
+    "project_id": 10,
+    "title": "MR Feature 2",
+    "description": "This is an MR for feature 2",
+    "state": "merged",
+    "created_at": "2019-06-17T22:54:32.858Z",
+    "updated_at": "2019-06-20T15:27:10.756Z",
+    "merged_by": {
+      "id": 15,
+      "name": "John Doe",
+      "username": "jdoe",
+      "state": "active"
+    },
+    "merged_at": "2019-06-20T15:27:10.828Z",
+    "closed_by": null,
+    "closed_at": null,
+    "target_branch": "master",
+    "source_branch": "feature2",
+    "user_notes_count": 2,
+    "upvotes": 0,
+    "downvotes": 0,
+    "assignee": null,
+    "author": {
+      "id": 11,
+      "name": "Jane Doe",
+      "username": "jdoe",
+      "state": "active"
+    },
+    "assignees": [],
+    "source_project_id": 10,
+    "target_project_id": 10,
+    "labels": [],
+    "work_in_progress": false,
+    "milestone": null,
+    "merge_when_pipeline_succeeds": false,
+    "merge_status": "can_be_merged",
+    "sha": "cf00b438ffa638410dc64b85dac72d49b72e6474",
+    "merge_commit_sha": "51b9249082908db50efde6cd0219e264bff3ac79",
+    "discussion_locked": null,
+    "should_remove_source_branch": null,
+    "force_remove_source_branch": true,
+    "reference": "!46",
+    "web_url": "https://gitlab/project/merge_requests/2",
+    "time_stats": {
+      "time_estimate": 0,
+      "total_time_spent": 0,
+      "human_time_estimate": null,
+      "human_total_time_spent": null
+    },
+    "squash": false,
+    "approvals_before_merge": null
+  }
+]

--- a/src/test/resources/com/dabsquared/gitlabjenkins/workflow/pipeline/mr-open.json
+++ b/src/test/resources/com/dabsquared/gitlabjenkins/workflow/pipeline/mr-open.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": 11,
+    "iid": 35,
+    "project_id": 10,
+    "title": "MR Feature 1",
+    "description": "Mr for Feature 1",
+    "state": "opened",
+    "created_at": "2019-06-11T18:20:14.331Z",
+    "updated_at": "2019-06-11T18:22:03.181Z",
+    "merged_by": null,
+    "merged_at": null,
+    "closed_by": null,
+    "closed_at": null,
+    "target_branch": "master",
+    "source_branch": "feature1",
+    "user_notes_count": 2,
+    "upvotes": 0,
+    "downvotes": 0,
+    "assignee": {
+      "id": 11,
+      "name": "Jane Doe",
+      "username": "jdoe",
+      "state": "active"
+    },
+    "author": {
+      "id": 15,
+      "name": "John Doe",
+      "username": "jdoe",
+      "state": "active"
+    },
+    "assignees": [
+      {
+        "id": 11,
+        "name": "Jane Doe",
+        "username": "jdoe",
+        "state": "active"
+      }
+    ],
+    "source_project_id": 65,
+    "target_project_id": 65,
+    "labels": [],
+    "work_in_progress": false,
+    "milestone": null,
+    "merge_when_pipeline_succeeds": false,
+    "merge_status": "can_be_merged",
+    "sha": "6d3e8611f0a452d7c9d343c6fd734fd47fdfabca",
+    "merge_commit_sha": null,
+    "discussion_locked": null,
+    "should_remove_source_branch": null,
+    "force_remove_source_branch": true,
+    "reference": "!35",
+    "web_url": "https://gitlabee/project/merge_requests/1",
+    "time_stats": {
+      "time_estimate": 0,
+      "total_time_spent": 0,
+      "human_time_estimate": null,
+      "human_total_time_spent": null
+    },
+    "squash": false,
+    "approvals_before_merge": null
+  }
+]


### PR DESCRIPTION
This merge request adds a pipeline function `gitlabMergeRequestStatus(projectId, branchName)` to retrieve merge request information about any given project/branch.

This would be useful in cases where the pipeline needs to behave differently if there is a merge request open, e.g. running long resource intensive tests only for merge requests, or in pipelines that are triggered by other jobs.  This is a partial solution to the fact that Multi-branch pipelines don't get run for merge requests.  These values are retrieved directly since they can't be propagated to the multi-branch build.

Ideally this could be tested by having a mock gitlab instance provide canned JSON responses, but I don't know how to accomplish that within the existing framework.

This is WIP to:
* Gauge interest
* Get code review
* Get advice on how to test