### PR TITLE
noteRegex help: add tips about (?m) and (?s) being useful

### DIFF
--- a/src/main/webapp/help/help-noteRegex.html
+++ b/src/main/webapp/help/help-noteRegex.html
@@ -3,6 +3,6 @@
         <p>When filled, a comment in the merge request completely matching this regular expression will trigger a build.
            Note this uses default <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Java regex syntax</a>.
            Notably <code>^</code> and <code>$</code> only match at the start/end of the whole comment, and <code>.</code> doesn't match newlines.
-           You might want to <a href="https://www.logicbig.com/tutorials/core-java-tutorial/java-regular-expressions/regex-embedded-flags.html">embed syntax modifiers</a> like <code>(?m)</code> <code>(?s)</code> to change these.</p>
+           You might want to <a href="https://docs.oracle.com/javase/tutorial/essential/regex/pattern.html#embedded">embed syntax-modifying flags</a> like <code>(?m)</code> <code>(?s)</code> to change these.</p>
     </div>
 </div>

--- a/src/main/webapp/help/help-noteRegex.html
+++ b/src/main/webapp/help/help-noteRegex.html
@@ -1,7 +1,7 @@
 <div>
     <div>
         <p>When filled, a comment in the merge request completely matching this regular expression will trigger a build.
-           Note this uses default <a href="https://docs.oracle.com/javase/9/docs/api/java/util/regex/Pattern.html">Java regex syntax</a>.
+           Note this uses default <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Java regex syntax</a>.
            Notably <code>^</code> and <code>$</code> only match at the start/end of the whole comment, and <code>.</code> doesn't match newlines.
            You might want to <a href="https://www.logicbig.com/tutorials/core-java-tutorial/java-regular-expressions/regex-embedded-flags.html">embed syntax modifiers</a> like <code>(?m)</code> <code>(?s)</code> to change these.</p>
     </div>

--- a/src/main/webapp/help/help-noteRegex.html
+++ b/src/main/webapp/help/help-noteRegex.html
@@ -1,5 +1,8 @@
 <div>
     <div>
-        <p>When filled, a comment in the merge request matching this regular expression will trigger a build.</p>
+        <p>When filled, a comment in the merge request completely matching this regular expression will trigger a build.
+           Note this uses default <a href="https://docs.oracle.com/javase/9/docs/api/java/util/regex/Pattern.html">Java regex syntax</a>.
+           Notably <code>^</code> and <code>$</code> only match at the start/end of the whole comment, and <code>.</code> doesn't match newlines.
+           You might want to <a href="https://www.logicbig.com/tutorials/core-java-tutorial/java-regular-expressions/regex-embedded-flags.html">embed syntax modifiers</a> like <code>(?m)</code> <code>(?s)</code> to change these.</p>
     </div>
 </div>


### PR DESCRIPTION
Followup to #628.

I'm coming here from a project where we configured noteRegex `^(\[test\]|\/retest)$` and were surprised it only triggers when completely alone in a comment, doesn't trigger for MR comments like:
```markdown
git fetch timed out, retrying.

/retest
```

I see noteRegex is fed to standard Java `.matches()`:
```
    final Pattern pattern = Pattern.compile(this.noteRegex);
    return pattern.matcher(note).matches();
```
There is presently no out-of-band way (and I don't think there should be) to specify options like `Pattern.MULTILINE` or `Pattern.DOTALL`.  
I believe matching multi-line comments is a common use case, so mentioning default `^`, `$`, `.` behavior and the way to sneak modifiers into the string can be helpful?

E.g. in our use case, turns out we want `(?sm).*^(\[test\]|\/retest)$.*`.