### PR TITLE
[Fix] Accepted merge request event can not trigger Jenkins job

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -41,7 +41,7 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
 
     private final boolean skipWorkInProgressMergeRequest;
     private final Predicate<MergeRequestObjectAttributes> triggerConfig;
-    private final EnumSet<Action> skipBuiltYetCheckActions = EnumSet.of(Action.open, Action.approved);
+    private final EnumSet<Action> skipBuiltYetCheckActions = EnumSet.of(Action.open, Action.approved, Action.merge);
     private final EnumSet<Action> skipAllowedStateForActions = EnumSet.of(Action.approved);
     private final boolean cancelPendingBuildsOnUpdate;
 


### PR DESCRIPTION
## Problem Description

While we are using gitlab-plugin as tiggers for Jenkins builds by Merge Request events from gitlab, we hit an issue that the builds can not be fired correctly by `merge` action of any Merge Request.  As I dig the root cause, I think I have some findings and make this change for this issue.

## Scenario and Issue Solution

The CI process of our team based on Jenkins + Gitlab is like this :
- When there is a MR opened, a build should be triggered
- When there is an update of opened MR, a build should be triggered
- When the MR is accepted (merged), a build should be triggered.

So, the cause of the issue we have, it the 3rd scenario of accepted MR. As `gitlab-plugin` has an logic to check if the build should be skipped because it is already done in [this codes](https://github.com/jenkinsci/gitlab-plugin/blob/cb04dad9cb32dd53c2a54083473c9c74f443810b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java#L186), the acceptance event of MR can never trigger the builds due to it skipped.

The fix to this is simple, as `Action.merge` enumeration element is added in `skipBuiltYetCheckActions` set. 

Please kindly review the change and accept it if this makes sense.

Thanks
