### PR TITLE
Make useAuthenticatedEndpoint configurable via CasC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.12.0</version>
+      <version>2.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -201,7 +201,7 @@
     <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>matrix-project</artifactId>
-        <version>1.14</version>
+        <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -341,6 +341,35 @@
       <version>1.27</version>
       <scope>test</scope>
       <classifier>tests</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+      <version>1.54</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.20</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+      <version>2.6.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.20</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <version>2.6</version>
+      <scope>test</scope>
     </dependency>
     <!-- parent pom test dependencies needs overriding-->
 

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>2.4.1</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -201,7 +201,7 @@
     <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>matrix-project</artifactId>
-        <version>1.10</version>
+        <version>1.14</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,12 @@
   <properties>
     <java.level>8</java.level>
     <animal.sniffer.version>1.14</animal.sniffer.version>
-    <jenkins.version>1.609.3</jenkins.version>
+    <jenkins.version>2.150.3</jenkins.version>
     <hpi-plugin.version>1.115</hpi-plugin.version>
     <jenkins-test-harness.version>2.38</jenkins-test-harness.version>
     <findbugs.failOnError>false</findbugs.failOnError>
     <jenkins-war.version>2.60.1</jenkins-war.version>
+    <hpi.compatibleSinceVersion>1.4.0</hpi.compatibleSinceVersion>
   </properties>
 
   <artifactId>gitlab-plugin</artifactId>
@@ -143,9 +144,11 @@
         <plugin>
           <groupId>org.jenkins-ci.tools</groupId>
           <artifactId>maven-hpi-plugin</artifactId>
+          <version>3.8</version>
           <extensions>true</extensions>
           <configuration>
             <compatibleSinceVersion>1.4.0</compatibleSinceVersion>
+            <minimumJavaVersion>1.8</minimumJavaVersion>
           </configuration>
         </plugin>
       </plugins>
@@ -325,6 +328,19 @@
       <artifactId>workflow-basic-steps</artifactId>
       <version>2.2</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>1.27</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>1.27</version>
+      <scope>test</scope>
+      <classifier>tests</classifier>
     </dependency>
     <!-- parent pom test dependencies needs overriding-->
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -516,7 +516,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
         GitLabPushTrigger trigger = null;
         if (job instanceof ParameterizedJobMixIn.ParameterizedJob) {
             ParameterizedJobMixIn.ParameterizedJob p = (ParameterizedJobMixIn.ParameterizedJob) job;
-            for (Trigger t : p.getTriggers().values()) {
+            for (Object t : p.getTriggers().values()) {
                 if (t instanceof GitLabPushTrigger) {
                     trigger = (GitLabPushTrigger) t;
                 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfig.java
@@ -20,6 +20,7 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.eclipse.jgit.util.StringUtils;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -64,7 +65,8 @@ public class GitLabConnectionConfig extends GlobalConfiguration {
         return useAuthenticatedEndpoint;
     }
 
-    void setUseAuthenticatedEndpoint(boolean useAuthenticatedEndpoint) {
+    @DataBoundSetter
+    public void setUseAuthenticatedEndpoint(boolean useAuthenticatedEndpoint) {
         this.useAuthenticatedEndpoint = useAuthenticatedEndpoint;
     }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
@@ -58,7 +58,7 @@ class OpenMergeRequestPushHookTriggerHandler implements PushHookTriggerHandler {
             if (job instanceof ParameterizedJobMixIn.ParameterizedJob) {
                 ParameterizedJob project = (ParameterizedJobMixIn.ParameterizedJob) job;
                 GitLabConnectionProperty property = job.getProperty(GitLabConnectionProperty.class);
-                for (Trigger t : project.getTriggers().values()) {
+                for (Object t : project.getTriggers().values()) {
                 	if (t instanceof GitLabPushTrigger) {
                 		final GitLabPushTrigger trigger = (GitLabPushTrigger) t;
                         Integer projectId = hook.getProjectId();

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
@@ -11,8 +11,6 @@ import hudson.security.ACL;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSCMSource;
-import jenkins.plugins.git.GitSCMSourceContext;
-import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
 import org.apache.commons.lang.StringUtils;
@@ -104,10 +102,7 @@ public class PushBuildAction extends BuildWebHookAction {
                     GitSCMSource gitSCMSource = (GitSCMSource) scmSource;
                     try {
                         if (new URIish(gitSCMSource.getRemote()).equals(new URIish(gitSCMSource.getRemote()))) {
-                            GitSCMSourceContext ctx =
-                                new GitSCMSourceContext<>(null, SCMHeadObserver.none())
-                                    .withTraits(gitSCMSource.getTraits());
-                            if (!ctx.ignoreOnPushNotifications()) {
+                            if (!gitSCMSource.isIgnoreOnPushNotifications()) {
                                 LOGGER.log(Level.FINE, "Notify scmSourceOwner {0} about changes for {1}",
                                            toArray(project.getName(), gitSCMSource.getRemote()));
                                 ((SCMSourceOwner) project).onSCMSourceUpdated(scmSource);

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
@@ -11,6 +11,8 @@ import hudson.security.ACL;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.GitSCMSourceContext;
+import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
 import org.apache.commons.lang.StringUtils;
@@ -102,7 +104,10 @@ public class PushBuildAction extends BuildWebHookAction {
                     GitSCMSource gitSCMSource = (GitSCMSource) scmSource;
                     try {
                         if (new URIish(gitSCMSource.getRemote()).equals(new URIish(gitSCMSource.getRemote()))) {
-                            if (!gitSCMSource.isIgnoreOnPushNotifications()) {
+                            GitSCMSourceContext ctx =
+                                new GitSCMSourceContext<>(null, SCMHeadObserver.none())
+                                    .withTraits(gitSCMSource.getTraits());
+                            if (!ctx.ignoreOnPushNotifications()) {
                                 LOGGER.log(Level.FINE, "Notify scmSourceOwner {0} about changes for {1}",
                                            toArray(project.getName(), gitSCMSource.getRemote()));
                                 ((SCMSourceOwner) project).onSCMSourceUpdated(scmSource);

--- a/src/test/java/com/dabsquared/gitlabjenkins/casc/GitLabConnectionConfigTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/casc/GitLabConnectionConfigTest.java
@@ -1,0 +1,23 @@
+package com.dabsquared.gitlabjenkins.casc;
+
+import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import jenkins.model.GlobalConfiguration;
+import org.junit.Assert;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+public class GitLabConnectionConfigTest extends RoundTripAbstractTest {
+
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+        boolean useAuthenticatedEndpoint = GlobalConfiguration.all()
+            .get(GitLabConnectionConfig.class)
+            .isUseAuthenticatedEndpoint();
+        Assert.assertEquals(false, useAuthenticatedEndpoint);
+    }
+
+    @Override
+    protected String stringInLogExpected() {
+        return "useAuthenticatedEndpoint = false";
+    }
+}

--- a/src/test/resources/com/dabsquared/gitlabjenkins/casc/configuration-as-code.yaml
+++ b/src/test/resources/com/dabsquared/gitlabjenkins/casc/configuration-as-code.yaml
@@ -1,0 +1,3 @@
+unclassified:
+  gitLabConnectionConfig:
+    useAuthenticatedEndpoint: false


### PR DESCRIPTION
To make `useAuthenticatedEndpoint` configurable via YAML and configuration-as-code-plugin it was needed to change the visibility of its setter in `GitLabConnectionConfig`. I also used the recommended technique for `GlobalConfiguration#configure` by calling `StaplerRequest#bindJSON` inside of it.

I added an integration test with CasC, which tests evaluating `useAuthenticatedEndpoint` in YAML. Adding this test required updating Jenkins dependency from 1.609.3 to 2.187 and a little refactoring due to changes in `jenkins.model`.