### PR TITLE
Add the user_username field to the push hook, cause data and env

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ gitlabBranch
 gitlabSourceBranch
 gitlabActionType
 gitlabUserName
+gitlabUserUsername
 gitlabUserEmail
 gitlabSourceRepoHomepage
 gitlabSourceRepoName

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <java.level>8</java.level>
     <animal.sniffer.version>1.14</animal.sniffer.version>
-    <jenkins.version>2.200</jenkins.version>
+    <jenkins.version>2.190.1</jenkins.version>
     <hpi-plugin.version>1.115</hpi-plugin.version>
     <jenkins-test-harness.version>2.38</jenkins-test-harness.version>
     <findbugs.failOnError>false</findbugs.failOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <java.level>8</java.level>
     <animal.sniffer.version>1.14</animal.sniffer.version>
-    <jenkins.version>1.609.3</jenkins.version>
+    <jenkins.version>2.200</jenkins.version>
     <hpi-plugin.version>1.115</hpi-plugin.version>
     <jenkins-test-harness.version>2.38</jenkins-test-harness.version>
     <findbugs.failOnError>false</findbugs.failOnError>
@@ -157,68 +157,109 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>2.4.1</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>1.19.0</version>
+      <version>2.7.7</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.19</version>
+      <version>1.28</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.5</version>
+      <version>1.20</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>1.1</version>
+      <version>2.6.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <version>2.3</version>
+      <version>2.37</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.23</version>
+      <version>1.66</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.16</version>
+      <version>2.20</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <version>2.34</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps-global-lib</artifactId>
+      <version>2.15</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>2.6</version>
+      <version>3.3</version>
+      <exclusions>
+        <!-- -->
+        <exclusion>
+          <groupId>org.jboss.marshalling</groupId>
+          <artifactId>jboss-marshalling</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.marshalling</groupId>
+          <artifactId>jboss-marshalling-river</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.marshalling</groupId>
+      <artifactId>jboss-marshalling</artifactId>
+      <version>1.4.12.jenkins-3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.marshalling</groupId>
+      <artifactId>jboss-marshalling-river</artifactId>
+      <version>1.4.12.jenkins-3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-scm-step</artifactId>
+      <version>2.9</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.6</version>
+      <version>2.35</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.0</version>
+      <version>2.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plain-credentials</artifactId>
-      <version>1.1</version>
+      <version>1.5</version>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-credentials</artifactId>
+      <version>1.18</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>symbol-annotation</artifactId>
-      <version>1.5</version>
+      <version>1.20</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
@@ -228,12 +269,12 @@
     <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>matrix-project</artifactId>
-        <version>1.10</version>
+        <version>1.14</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>display-url-api</artifactId>
-      <version>1.1.1</version>
+      <version>2.1.0</version>
     </dependency>
 
 
@@ -347,7 +388,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.19</version>
+      <version>2.74</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/docker/README.md
+++ b/src/docker/README.md
@@ -21,6 +21,7 @@ For more information on the supported `GitLab` versions and how to configure the
 ## Access Jenkins
 
 To see `Jenkins`, point your browser to `http://localhost:8080`. Jenkins will be able to access GitLab at `http://gitlab`
+Note: you need to change the security settings in `Admin -> Settings -> Network -> Outbound Requests -> Allow requests to the local network from hooks and services` in order for local webhooks to work.
 
 For more information on the supported `Jenkins` tags and how to configure the containers, visit https://hub.docker.com/r/jenkins/jenkins/.
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -60,6 +60,7 @@ import org.kohsuke.stapler.StaplerResponse;
 import java.io.IOException;
 import java.io.ObjectStreamException;
 import java.security.SecureRandom;
+import java.util.Collection;
 
 import static com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterConfig.BranchFilterConfigBuilder.branchFilterConfig;
 import static com.dabsquared.gitlabjenkins.trigger.handler.merge.MergeRequestHookTriggerHandlerFactory.newMergeRequestHookTriggerHandler;
@@ -527,7 +528,8 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
         GitLabPushTrigger trigger = null;
         if (job instanceof ParameterizedJobMixIn.ParameterizedJob) {
             ParameterizedJobMixIn.ParameterizedJob p = (ParameterizedJobMixIn.ParameterizedJob) job;
-            for (Trigger t : p.getTriggers().values()) {
+            Collection<Trigger> triggerList = p.getTriggers().values();
+            for (Trigger t : triggerList) {
                 if (t instanceof GitLabPushTrigger) {
                     trigger = (GitLabPushTrigger) t;
                 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
@@ -26,6 +26,7 @@ public final class CauseData {
     private final String branch;
     private final String sourceBranch;
     private final String userName;
+    private final String userUsername;
     private final String userEmail;
     private final String sourceRepoHomepage;
     private final String sourceRepoName;
@@ -64,7 +65,7 @@ public final class CauseData {
 
     @GeneratePojoBuilder(withFactoryMethod = "*")
     CauseData(ActionType actionType, Integer sourceProjectId, Integer targetProjectId, String branch, String sourceBranch, String userName,
-              String userEmail, String sourceRepoHomepage, String sourceRepoName, String sourceNamespace, String sourceRepoUrl,
+              String userUsername, String userEmail, String sourceRepoHomepage, String sourceRepoName, String sourceNamespace, String sourceRepoUrl,
               String sourceRepoSshUrl, String sourceRepoHttpUrl, String mergeRequestTitle, String mergeRequestDescription, Integer mergeRequestId,
               Integer mergeRequestIid, Integer mergeRequestTargetProjectId, String targetBranch, String targetRepoName, String targetNamespace, String targetRepoSshUrl,
               String targetRepoHttpUrl, String triggeredByUser, String before, String after, String lastCommit, String targetProjectUrl,
@@ -76,6 +77,7 @@ public final class CauseData {
         this.branch = checkNotNull(branch, "branch must not be null.");
         this.sourceBranch = checkNotNull(sourceBranch, "sourceBranch must not be null.");
         this.userName = checkNotNull(userName, "userName must not be null.");
+        this.userUsername = userUsername == null ? "" : userEmail;
         this.userEmail = userEmail == null ? "" : userEmail;
         this.sourceRepoHomepage = sourceRepoHomepage == null ? "" : sourceRepoHomepage;
         this.sourceRepoName = checkNotNull(sourceRepoName, "sourceRepoName must not be null.");
@@ -120,6 +122,7 @@ public final class CauseData {
         variables.put("gitlabSourceBranch", sourceBranch);
         variables.put("gitlabActionType", actionType.name());
         variables.put("gitlabUserName", userName);
+        variables.put("gitlabUserUsername", userUsername == null ? "" : userUsername);
         variables.put("gitlabUserEmail", userEmail);
         variables.put("gitlabSourceRepoHomepage", sourceRepoHomepage);
         variables.put("gitlabSourceRepoName", sourceRepoName);
@@ -184,6 +187,11 @@ public final class CauseData {
     @Exported
     public String getUserName() {
         return userName;
+    }
+
+    @Exported
+    public String getUserUsername() {
+        return userUsername;
     }
 
     @Exported
@@ -369,6 +377,7 @@ public final class CauseData {
             .append(branch, causeData.branch)
             .append(sourceBranch, causeData.sourceBranch)
             .append(userName, causeData.userName)
+            .append(userUsername, causeData.userUsername)
             .append(userEmail, causeData.userEmail)
             .append(sourceRepoHomepage, causeData.sourceRepoHomepage)
             .append(sourceRepoName, causeData.sourceRepoName)
@@ -415,6 +424,7 @@ public final class CauseData {
             .append(branch)
             .append(sourceBranch)
             .append(userName)
+            .append(userUsername)
             .append(userEmail)
             .append(sourceRepoHomepage)
             .append(sourceRepoName)
@@ -461,6 +471,7 @@ public final class CauseData {
             .append("branch", branch)
             .append("sourceBranch", sourceBranch)
             .append("userName", userName)
+            .append("userUsername", userUsername)
             .append("userEmail", userEmail)
             .append("sourceRepoHomepage", sourceRepoHomepage)
             .append("sourceRepoName", sourceRepoName)

--- a/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
@@ -77,7 +77,7 @@ public final class CauseData {
         this.branch = checkNotNull(branch, "branch must not be null.");
         this.sourceBranch = checkNotNull(sourceBranch, "sourceBranch must not be null.");
         this.userName = checkNotNull(userName, "userName must not be null.");
-        this.userUsername = userUsername == null ? "" : userEmail;
+        this.userUsername = userUsername == null ? "" : userUsername;
         this.userEmail = userEmail == null ? "" : userEmail;
         this.sourceRepoHomepage = sourceRepoHomepage == null ? "" : sourceRepoHomepage;
         this.sourceRepoName = checkNotNull(sourceRepoName, "sourceRepoName must not be null.");

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PushHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PushHook.java
@@ -18,6 +18,7 @@ public class PushHook extends WebHook {
     private String ref;
     private Integer userId;
     private String userName;
+    private String userUsername;
     private String userEmail;
     private String userAvatar;
     private Integer projectId;
@@ -63,6 +64,14 @@ public class PushHook extends WebHook {
 
     public void setUserName(String userName) {
         this.userName = userName;
+    }
+
+    public String getUserUsername() {
+        return userUsername;
+    }
+
+    public void setUserUserName(String userUsername) {
+        this.userUsername = userUsername;
     }
 
     public String getUserEmail() {

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
@@ -32,6 +32,7 @@ import javax.ws.rs.WebApplicationException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -58,7 +59,8 @@ class OpenMergeRequestPushHookTriggerHandler implements PushHookTriggerHandler {
             if (job instanceof ParameterizedJobMixIn.ParameterizedJob) {
                 ParameterizedJob project = (ParameterizedJobMixIn.ParameterizedJob) job;
                 GitLabConnectionProperty property = job.getProperty(GitLabConnectionProperty.class);
-                for (Trigger t : project.getTriggers().values()) {
+                Collection<Trigger> triggerList = project.getTriggers().values();
+                for (Trigger t : triggerList) {
                 	if (t instanceof GitLabPushTrigger) {
                 		final GitLabPushTrigger trigger = (GitLabPushTrigger) t;
                         Integer projectId = hook.getProjectId();

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImpl.java
@@ -50,6 +50,7 @@ class PushHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<PushHook>
                 .withBranch(getTargetBranch(hook))
                 .withSourceBranch(getTargetBranch(hook))
                 .withUserName(hook.getUserName())
+                .withUserUsername(hook.getUserUsername())
                 .withUserEmail(hook.getUserEmail())
                 .withSourceRepoHomepage(hook.getRepository().getHomepage())
                 .withSourceRepoName(hook.getRepository().getName())
@@ -108,10 +109,14 @@ class PushHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<PushHook>
     }
 
     private String retrievePushedBy(final PushHook hook) {
-
         final String userName = hook.getUserName();
         if (!StringUtils.isEmptyOrNull(userName)) {
             return userName;
+        }
+
+        final String userUsername = hook.getUserUsername();
+        if (!StringUtils.isEmptyOrNull(userUsername)) {
+            return userUsername;
         }
 
         final List<Commit> commits = hook.getCommits();

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/PendingBuildsHandlerTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/PendingBuildsHandlerTest.java
@@ -78,7 +78,7 @@ public class PendingBuildsHandlerTest {
     public void workflowJobCanConfiguredToSendToPendingBuildStatusWhenTriggered() throws IOException {
         WorkflowJob workflowJob = workflowJob();
 
-        GitLabPushTrigger gitLabPushTrigger = gitLabPushTrigger(workflowJob);
+        GitLabPushTrigger gitLabPushTrigger =  gitLabPushTrigger(workflowJob);
         gitLabPushTrigger.setPendingBuildName(GITLAB_BUILD_NAME);
 
         gitLabPushTrigger.onPost(mergeRequestHook(1, "branch1", "commit1"));
@@ -114,14 +114,14 @@ public class PendingBuildsHandlerTest {
     private GitLabPushTrigger gitLabPushTrigger(Project project) throws IOException {
         GitLabPushTrigger gitLabPushTrigger = gitLabPushTrigger();
         project.addTrigger(gitLabPushTrigger);
-        gitLabPushTrigger.start(project,true);
+        gitLabPushTrigger.start(project, true);
         return gitLabPushTrigger;
     }
 
-    private GitLabPushTrigger gitLabPushTrigger(WorkflowJob workflowJob) {
+    private GitLabPushTrigger gitLabPushTrigger(WorkflowJob workflowJob) throws IOException {
         GitLabPushTrigger gitLabPushTrigger = gitLabPushTrigger();
         workflowJob.addTrigger(gitLabPushTrigger);
-        gitLabPushTrigger.start(workflowJob,true);
+        gitLabPushTrigger.start(workflowJob, true);
         return gitLabPushTrigger;
     }
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdaterTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdaterTest.java
@@ -77,6 +77,7 @@ public class CommitStatusUpdaterTest {
 	    PowerMockito.mockStatic(GitLabConnectionProperty.class);
 	    PowerMockito.mockStatic(Jenkins.class);
 	    when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.getActiveInstance()).thenReturn(jenkins);
 	    when(jenkins.getRootUrl()).thenReturn(JENKINS_URL);
 	    when(jenkins.getDescriptor(GitLabConnectionConfig.class)).thenReturn(gitLabConnectionConfig);
 	    when(GitLabConnectionProperty.getClient(any(Run.class))).thenReturn(client);

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildActionTest.java
@@ -67,6 +67,7 @@ public class PushBuildActionTest {
             verify(trigger).onPost(pushHookArgumentCaptor.capture());
             assertThat(pushHookArgumentCaptor.getValue().getProject(), is(notNullValue()));
             assertThat(pushHookArgumentCaptor.getValue().getProject().getWebUrl(), is(notNullValue()));
+            assertThat(pushHookArgumentCaptor.getValue().getUserUsername(), is(notNullValue()));
         }
     }
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildActionTest.java
@@ -16,6 +16,7 @@ import org.kohsuke.stapler.StaplerResponse;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import static org.hamcrest.CoreMatchers.containsString;
 
 import java.io.IOException;
 
@@ -68,6 +69,7 @@ public class PushBuildActionTest {
             assertThat(pushHookArgumentCaptor.getValue().getProject(), is(notNullValue()));
             assertThat(pushHookArgumentCaptor.getValue().getProject().getWebUrl(), is(notNullValue()));
             assertThat(pushHookArgumentCaptor.getValue().getUserUsername(), is(notNullValue()));
+            assertThat(pushHookArgumentCaptor.getValue().getUserUsername(), containsString("jsmith"));
         }
     }
 

--- a/src/test/resources/com/dabsquared/gitlabjenkins/webhook/build/PushEvent.json
+++ b/src/test/resources/com/dabsquared/gitlabjenkins/webhook/build/PushEvent.json
@@ -5,6 +5,7 @@
   "ref": "refs/heads/master",
   "user_id": 4,
   "user_name": "John Smith",
+  "user_username": "jsmith",
   "user_email": "john@example.com",
   "user_avatar": "https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80",
   "project_id": 15,


### PR DESCRIPTION
The `user_name` field in the GitLab webhook is a field which can be edited by the Gitlab user (in Gitlab it maps to the Full name), while the user_username can only be edited by a Gitlab-admin and therefore provides a much more traceable source.
In this pull request, the field is edited to the CauseData and mapped to the environment variable `gitlabUserUsername`.
A simple but (imho) sufficient test is added.

Please let me know if you have any comments or suggestions for improvements.
