### PR TITLE
Upgrade parent Plugin POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,17 +3,15 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.29</version>
+    <version>2.30</version>
   </parent>
 
   <properties>
     <java.level>8</java.level>
     <animal.sniffer.version>1.14</animal.sniffer.version>
     <jenkins.version>2.190.1</jenkins.version>
-    <hpi-plugin.version>1.115</hpi-plugin.version>
     <jenkins-test-harness.version>2.38</jenkins-test-harness.version>
     <findbugs.failOnError>false</findbugs.failOnError>
-    <jenkins-war.version>2.60.1</jenkins-war.version>
   </properties>
 
   <artifactId>gitlab-plugin</artifactId>


### PR DESCRIPTION
This fixes #996
New Plugin POM version allow us to get rid of separate `jenkins-war-for-test` artifact required for `mvn hpi:run` command to work (there are no new versions anyway https://jenkins.io/changelog-stable/#v2.73.1). With this PR both `mvn hpi:run` and `mvn clean install` work OK