### PR TITLE
Trigger build only when new commits were pushed to MR

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -81,6 +81,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     private boolean triggerOnPush = true;
     private boolean triggerToBranchDeleteRequest = false;
     private boolean triggerOnMergeRequest = true;
+    private boolean triggerOnlyIfNewCommitsPushed = false;
     private boolean triggerOnPipelineEvent = false;
     private boolean triggerOnAcceptedMergeRequest = false;
     private boolean triggerOnClosedMergeRequest = false;
@@ -119,9 +120,9 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
      */
     @Deprecated
     @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-    public GitLabPushTrigger(boolean triggerOnPush, boolean triggerToBranchDeleteRequest, boolean triggerOnMergeRequest, boolean triggerOnAcceptedMergeRequest, boolean triggerOnClosedMergeRequest,
-    						 TriggerOpenMergeRequest triggerOpenMergeRequestOnPush, boolean triggerOnNoteRequest, String noteRegex,
-    						 boolean skipWorkInProgressMergeRequest, boolean ciSkip,
+    public GitLabPushTrigger(boolean triggerOnPush, boolean triggerToBranchDeleteRequest, boolean triggerOnMergeRequest, boolean triggerOnlyIfNewCommitsPushed, boolean triggerOnAcceptedMergeRequest, boolean triggerOnClosedMergeRequest,
+                             TriggerOpenMergeRequest triggerOpenMergeRequestOnPush, boolean triggerOnNoteRequest, String noteRegex,
+                             boolean skipWorkInProgressMergeRequest, boolean ciSkip,
                              boolean setBuildDescription, boolean addNoteOnMergeRequest, boolean addCiMessage, boolean addVoteOnMergeRequest,
                              boolean acceptMergeRequestOnSuccess, BranchFilterType branchFilterType,
                              String includeBranchesSpec, String excludeBranchesSpec, String sourceBranchRegex, String targetBranchRegex,
@@ -130,6 +131,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
         this.triggerOnPush = triggerOnPush;
         this.triggerToBranchDeleteRequest = triggerToBranchDeleteRequest;
         this.triggerOnMergeRequest = triggerOnMergeRequest;
+        this.triggerOnlyIfNewCommitsPushed = triggerOnlyIfNewCommitsPushed;
         this.triggerOnAcceptedMergeRequest = triggerOnAcceptedMergeRequest;
         this.triggerOnClosedMergeRequest = triggerOnClosedMergeRequest;
         this.triggerOnNoteRequest = triggerOnNoteRequest;
@@ -223,6 +225,11 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     @Override
     public boolean getTriggerOnMergeRequest() {
         return triggerOnMergeRequest;
+    }
+
+    @Override
+    public boolean isTriggerOnlyIfNewCommitsPushed() {
+        return triggerOnlyIfNewCommitsPushed;
     }
 
     @Override
@@ -323,6 +330,11 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     @DataBoundSetter
     public void setTriggerOnMergeRequest(boolean triggerOnMergeRequest) {
         this.triggerOnMergeRequest = triggerOnMergeRequest;
+    }
+
+    @DataBoundSetter
+    public void setTriggerOnlyIfNewCommitsPushed(boolean triggerOnlyIfNewCommitsPushed) {
+        this.triggerOnlyIfNewCommitsPushed = triggerOnlyIfNewCommitsPushed;
     }
 
     @DataBoundSetter

--- a/src/main/java/com/dabsquared/gitlabjenkins/MergeRequestTriggerConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/MergeRequestTriggerConfig.java
@@ -5,6 +5,8 @@ import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
 public interface MergeRequestTriggerConfig {
     boolean getTriggerOnMergeRequest();
 
+    boolean isTriggerOnlyIfNewCommitsPushed();
+
     boolean isTriggerOnAcceptedMergeRequest();
 
     boolean isTriggerOnApprovedMergeRequest();

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestChangedTitle.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestChangedTitle.java
@@ -5,35 +5,36 @@ import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
+import java.util.List;
+
 /**
  * @author Anton Johansson
  */
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-public class MergeRequestChanges {
+public class MergeRequestChangedTitle {
 
     /*
-        "labels": {...}
+        "previous": [{...}],
+        "current": [{...}]
     */
-    private MergeRequestChangedLabels labels;
+    private String previous;
+    private String current;
 
-    public MergeRequestChangedLabels getLabels() {
-        return labels;
+    public String getPrevious() {
+        return previous;
     }
 
-    public void setLabels(MergeRequestChangedLabels labels) {
-        this.labels = labels;
+    public void setPrevious(String previous) {
+        this.previous = previous;
     }
 
+    public String getCurrent() {
+        return current;
+    }
 
-
-    /*
-        "title": {...}
-    */
-    private MergeRequestChangedTitle title;
-
-    public MergeRequestChangedTitle getTitle() { return title; }
-
-    public void setTitle(MergeRequestChangedTitle title) { this.title = title; }
+    public void setCurrent(String current) {
+        this.current = current;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -43,23 +44,26 @@ public class MergeRequestChanges {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        MergeRequestChanges that = (MergeRequestChanges) o;
+        MergeRequestChangedTitle that = (MergeRequestChangedTitle) o;
         return new EqualsBuilder()
-            .append(labels, that.labels)
+            .append(previous, that.previous)
+            .append(current, that.current)
             .isEquals();
     }
 
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
-            .append(labels)
+            .append(previous)
+            .append(current)
             .toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .append("labels", labels)
+            .append("previous", previous)
+            .append("current", current)
             .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestObjectAttributes.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestObjectAttributes.java
@@ -30,6 +30,7 @@ public class MergeRequestObjectAttributes {
     private Project source;
     private Project target;
     private Commit lastCommit;
+    private String oldrev;
     private String mergeStatus;
     private String url;
     private Action action;
@@ -162,6 +163,10 @@ public class MergeRequestObjectAttributes {
     public void setLastCommit(Commit lastCommit) {
         this.lastCommit = lastCommit;
     }
+
+    public String getOldrev() { return oldrev; }
+
+    public void setOldrev(String oldrev) { this.oldrev = oldrev; }
 
     public String getMergeStatus() {
         return mergeStatus;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestObjectAttributes.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestObjectAttributes.java
@@ -229,6 +229,7 @@ public class MergeRequestObjectAttributes {
             .append(mergeStatus, that.mergeStatus)
             .append(url, that.url)
             .append(action, that.action)
+            .append(oldrev, that.oldrev)
             .append(workInProgress, that.workInProgress)
             .isEquals();
     }
@@ -281,6 +282,7 @@ public class MergeRequestObjectAttributes {
             .append("mergeStatus", mergeStatus)
             .append("url", url)
             .append("action", action)
+            .append("oldrev", oldrev)
             .append("workInProgress", workInProgress)
             .toString();
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
@@ -5,8 +5,6 @@ import com.dabsquared.gitlabjenkins.gitlab.hook.model.Action;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
 import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
 
-import static com.dabsquared.gitlabjenkins.trigger.handler.merge.StateAndActionConfig.notEqual;
-import static com.dabsquared.gitlabjenkins.trigger.handler.merge.StateAndActionConfig.nullOrContains;
 import static java.util.EnumSet.of;
 
 /**
@@ -17,6 +15,7 @@ public final class MergeRequestHookTriggerHandlerFactory {
     private MergeRequestHookTriggerHandlerFactory() {}
 
     public static MergeRequestHookTriggerHandler newMergeRequestHookTriggerHandler(boolean triggerOnMergeRequest,
+    		                                                                       boolean triggerOnlyWithNewCommitsPushed,
     		                                                                       boolean triggerOnAcceptedMergeRequest,
     		                                                                       boolean triggerOnClosedMergeRequest,
                                                                                    TriggerOpenMergeRequest triggerOpenMergeRequest,
@@ -33,11 +32,12 @@ public final class MergeRequestHookTriggerHandlerFactory {
             .acceptIf(triggerOpenMergeRequest != TriggerOpenMergeRequest.never, of(State.updated), null)
         ;
 
-        return new MergeRequestHookTriggerHandlerImpl(chain, skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);
+        return new MergeRequestHookTriggerHandlerImpl(chain, triggerOnlyWithNewCommitsPushed, skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);
     }
 
     public static MergeRequestHookTriggerHandler newMergeRequestHookTriggerHandler(MergeRequestTriggerConfig config) {
         return newMergeRequestHookTriggerHandler(config.getTriggerOnMergeRequest(),
+            config.isTriggerOnlyIfNewCommitsPushed(),
             config.isTriggerOnAcceptedMergeRequest(),
             config.isTriggerOnClosedMergeRequest(),
             config.getTriggerOpenMergeRequestOnPush(),
@@ -52,6 +52,7 @@ public final class MergeRequestHookTriggerHandlerFactory {
 
     public static class Config implements MergeRequestTriggerConfig {
         private boolean triggerOnMergeRequest = true;
+        private boolean triggerOnlyIfNewCommitsPushed = false;
         private boolean triggerOnAcceptedMergeRequest = false;
         private boolean triggerOnClosedMergeRequest = false;
         private TriggerOpenMergeRequest triggerOpenMergeRequest = TriggerOpenMergeRequest.never;
@@ -62,6 +63,11 @@ public final class MergeRequestHookTriggerHandlerFactory {
         @Override
         public boolean getTriggerOnMergeRequest() {
             return triggerOnMergeRequest;
+        }
+
+        @Override
+        public boolean isTriggerOnlyIfNewCommitsPushed() {
+            return triggerOnlyIfNewCommitsPushed;
         }
 
         @Override
@@ -96,6 +102,11 @@ public final class MergeRequestHookTriggerHandlerFactory {
 
         public Config setTriggerOnMergeRequest(boolean triggerOnMergeRequest) {
             this.triggerOnMergeRequest = triggerOnMergeRequest;
+            return this;
+        }
+
+        public Config setTriggerOnlyIfNewCommitsPushed(boolean triggerOnlyIfNewCommitsPushed) {
+            this.triggerOnlyIfNewCommitsPushed = triggerOnlyIfNewCommitsPushed;
             return this;
         }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -67,7 +67,8 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
         MergeRequestObjectAttributes objectAttributes = hook.getObjectAttributes();
         if (isAllowedByConfig(objectAttributes)
             && isLastCommitNotYetBuild(job, hook)
-            && isNotSkipWorkInProgressMergeRequest(objectAttributes)) {
+            && isNotSkipWorkInProgressMergeRequest(objectAttributes)
+            && isNewCommitPushed(hook)) {
 
             List<String> labelsNames = new ArrayList<>();
             if (hook.getLabels() != null) {
@@ -82,6 +83,15 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
         }
     }
 
+    protected boolean isNewCommitPushed(MergeRequestHook hook) {
+        if (hook.getObjectAttributes().getAction().equals(Action.update)) {
+            if (hook.getObjectAttributes().getOldrev() != null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
     @Override
     protected boolean isCiSkip(MergeRequestHook hook) {
         return hook.getObjectAttributes() != null

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -88,17 +88,10 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
     protected boolean isNewCommitPushed(MergeRequestHook hook) {
         if (this.onlyIfNewCommitsPushed) {
             if (hook.getObjectAttributes().getAction().equals(Action.update)) {
-                if (hook.getObjectAttributes().getOldrev() != null) {
-                    return true;
-                } else {
-                    return false;
-                }
+                return hook.getObjectAttributes().getOldrev() != null;
             }
-        } else {
-            return true;
         }
-
-        return false;
+        return true;
     }
 
     private boolean isExecutable(Job<?, ?> job, MergeRequestHook hook) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -51,14 +51,14 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
     private final boolean cancelPendingBuildsOnUpdate;
 
     MergeRequestHookTriggerHandlerImpl(Collection<State> allowedStates, boolean skipWorkInProgressMergeRequest, boolean cancelPendingBuildsOnUpdate) {
-        this(allowedStates, EnumSet.noneOf(Action.class), skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);
+        this(allowedStates, EnumSet.noneOf(Action.class), false, skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);
     }
 
     // this retains internal API, however, the plugin code no longer instantiates the handler this way.
     // any code using it should test it on higher level
     @Deprecated
-    MergeRequestHookTriggerHandlerImpl(Collection<State> allowedStates, Collection<Action> allowedActions, boolean skipWorkInProgressMergeRequest, boolean cancelPendingBuildsOnUpdate) {
-        this(new TriggerConfigChain().add(allowedStates, null).add(null, allowedActions), false, skipWorkInProgressMergeRequest, emptySet(), cancelPendingBuildsOnUpdate);
+    MergeRequestHookTriggerHandlerImpl(Collection<State> allowedStates, Collection<Action> allowedActions, boolean onlyIfNewCommitsPushed, boolean skipWorkInProgressMergeRequest, boolean cancelPendingBuildsOnUpdate) {
+        this(new TriggerConfigChain().add(allowedStates, null).add(null, allowedActions), onlyIfNewCommitsPushed, skipWorkInProgressMergeRequest, emptySet(), cancelPendingBuildsOnUpdate);
     }
 
     MergeRequestHookTriggerHandlerImpl(Predicate<MergeRequestObjectAttributes> triggerConfig, boolean onlyIfNewCommitsPushed, boolean skipWorkInProgressMergeRequest, Set<String> labelsThatForcesBuildIfAdded, boolean cancelPendingBuildsOnUpdate) {

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -12,7 +12,8 @@
       <f:entry title="Opened Merge Request Events" field="triggerOnMergeRequest">
         <f:checkbox default="true"/>
       </f:entry>
-      <f:entry title="Build only if new commits were pushed to Merge Request" field="triggerOnlyIfNewCommitsPushed">
+      <f:entry title="Build only if new commits were pushed to Merge Request" field="triggerOnlyIfNewCommitsPushed"
+      help="/plugin/gitlab-plugin/help/help-triggerOnlyIfNewCommitsPushed.html">
         <f:checkbox default="false"/>
       </f:entry>
       <f:entry title="Accepted Merge Request Events" field="triggerOnAcceptedMergeRequest">

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -12,6 +12,9 @@
       <f:entry title="Opened Merge Request Events" field="triggerOnMergeRequest">
         <f:checkbox default="true"/>
       </f:entry>
+      <f:entry title="Build only if new commits were pushed to Merge Request" field="triggerOnlyIfNewCommitsPushed">
+        <f:checkbox default="false"/>
+      </f:entry>
       <f:entry title="Accepted Merge Request Events" field="triggerOnAcceptedMergeRequest">
         <f:checkbox default="false"/>
       </f:entry>

--- a/src/main/webapp/help/help-triggerOnlyIfNewCommitsPushed.html
+++ b/src/main/webapp/help/help-triggerOnlyIfNewCommitsPushed.html
@@ -1,0 +1,6 @@
+<p>
+  If checked, a build will be started only if Merge Request was updated with new revisions. Without it, build starts
+  on such changes like title, description, assignee, labels
+  <br>
+  <b>Note:</b> a MR will be started if label from "Labels that forces builds if they are added" list was specified
+</p>

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
@@ -379,7 +379,7 @@ public class MergeRequestHookTriggerHandlerImplTest {
             }
         });
         project.setQuietPeriod(0);
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened, State.reopened), Arrays.asList(Action.approved), false, false);
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened, State.reopened), Arrays.asList(Action.approved), false, false, false);
         mergeRequestHookTriggerHandler.handle(project, mergeRequestHook()
                 .withObjectAttributes(defaultMergeRequestObjectAttributes().withDescription(MRDescription).withLastCommit(commit().withMessage(lastCommitMsg).withAuthor(user().withName("test").build()).withId("testid").build()).build())
                 .build(), true, BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
@@ -284,6 +284,39 @@ public class MergeRequestHookTriggerHandlerImplTest {
     }
 
     @Test
+    public void mergeRequest_build_when_new_commits_were_pushed_state_opened_action_open() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnMergeRequest(true)
+            .setTriggerOnlyIfNewCommitsPushed(true)
+            .build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.opened, Action.open);
+
+        assertThat(buildTriggered.isSignaled(), is(true));
+    }
+
+    @Test
+    public void mergeRequest_build_when_new_commits_were_pushed_state_reopened_action_reopen() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnMergeRequest(true)
+            .setTriggerOnlyIfNewCommitsPushed(true)
+            .build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.reopened, Action.reopen);
+
+        assertThat(buildTriggered.isSignaled(), is(true));
+    }
+
+    @Test
+    public void mergeRequest_build_when_new_commits_were_pushed_do_not_build_without_commits() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+            .setTriggerOnMergeRequest(true)
+            .setTriggerOnlyIfNewCommitsPushed(true)
+            .build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.update);
+
+        assertThat(buildTriggered.isSignaled(), is(false));
+    }
+
+    @Test
     public void mergeRequest_build_only_when_approved_and_not_when_updated() throws IOException, InterruptedException, GitAPIException, ExecutionException {
         mergeRequest_build_only_when_approved(Action.update);
     }


### PR DESCRIPTION
This PR resolves the problem described in #871 and #926 
An option in trigger configuration was added - when set build will be started on MR update only if it has new commits pushed to source branch. However, in current implementation build won't start when work in progress merge request become non-WIP MR.
I can use some help to write tests and fix the issue with WIP merge requests.