### PR TITLE
Add a job-level configuration parameter alwaysForceBuild.

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -85,6 +85,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     private boolean triggerOnAcceptedMergeRequest = false;
     private boolean triggerOnClosedMergeRequest = false;
     private boolean triggerOnApprovedMergeRequest = false;
+    private boolean alwaysForceBuild = false;
     private TriggerOpenMergeRequest triggerOpenMergeRequestOnPush;
     private boolean triggerOnNoteRequest = true;
     private String noteRegex = "";
@@ -126,7 +127,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
                              boolean acceptMergeRequestOnSuccess, BranchFilterType branchFilterType,
                              String includeBranchesSpec, String excludeBranchesSpec, String sourceBranchRegex, String targetBranchRegex,
                              MergeRequestLabelFilterConfig mergeRequestLabelFilterConfig, String secretToken, boolean triggerOnPipelineEvent,
-                             boolean triggerOnApprovedMergeRequest, String pendingBuildName, boolean cancelPendingBuildsOnUpdate) {
+                             boolean triggerOnApprovedMergeRequest, String pendingBuildName, boolean cancelPendingBuildsOnUpdate, boolean alwaysForceBuild) {
         this.triggerOnPush = triggerOnPush;
         this.triggerToBranchDeleteRequest = triggerToBranchDeleteRequest;
         this.triggerOnMergeRequest = triggerOnMergeRequest;
@@ -153,6 +154,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
         this.triggerOnApprovedMergeRequest = triggerOnApprovedMergeRequest;
         this.pendingBuildName = pendingBuildName;
         this.cancelPendingBuildsOnUpdate = cancelPendingBuildsOnUpdate;
+        this.alwaysForceBuild = alwaysForceBuild;
 
         initializeTriggerHandler();
         initializeBranchFilter();
@@ -305,6 +307,8 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
         return this.cancelPendingBuildsOnUpdate;
     }
 
+    public boolean getAlwaysForceBuild() { return this.alwaysForceBuild; }
+
     @DataBoundSetter
     public void setTriggerOnPush(boolean triggerOnPush) {
         this.triggerOnPush = triggerOnPush;
@@ -438,6 +442,11 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     @DataBoundSetter
     public void setCancelPendingBuildsOnUpdate(boolean cancelPendingBuildsOnUpdate) {
         this.cancelPendingBuildsOnUpdate = cancelPendingBuildsOnUpdate;
+    }
+
+    @DataBoundSetter
+    public void setAlwaysForceBuild(boolean alwaysForceBuild) {
+        this.alwaysForceBuild = alwaysForceBuild;
     }
 
     // executes when the Trigger receives a push request

--- a/src/main/java/com/dabsquared/gitlabjenkins/MergeRequestTriggerConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/MergeRequestTriggerConfig.java
@@ -16,4 +16,6 @@ public interface MergeRequestTriggerConfig {
     boolean isSkipWorkInProgressMergeRequest();
 
     boolean getCancelPendingBuildsOnUpdate();
+
+    boolean getAlwaysForceBuild();
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
@@ -22,7 +22,8 @@ public final class MergeRequestHookTriggerHandlerFactory {
                                                                                    TriggerOpenMergeRequest triggerOpenMergeRequest,
                                                                                    boolean skipWorkInProgressMergeRequest,
                                                                                    boolean triggerOnApprovedMergeRequest,
-                                                                                   boolean cancelPendingBuildsOnUpdate) {
+                                                                                   boolean cancelPendingBuildsOnUpdate,
+                                                                                   boolean alwaysForceBuild) {
 
         TriggerConfigChain chain = new TriggerConfigChain();
         chain
@@ -33,7 +34,7 @@ public final class MergeRequestHookTriggerHandlerFactory {
             .acceptIf(triggerOpenMergeRequest != TriggerOpenMergeRequest.never, of(State.updated), null)
         ;
 
-        return new MergeRequestHookTriggerHandlerImpl(chain, skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);
+        return new MergeRequestHookTriggerHandlerImpl(chain, skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate, alwaysForceBuild);
     }
 
     public static MergeRequestHookTriggerHandler newMergeRequestHookTriggerHandler(MergeRequestTriggerConfig config) {
@@ -43,7 +44,8 @@ public final class MergeRequestHookTriggerHandlerFactory {
             config.getTriggerOpenMergeRequestOnPush(),
             config.isSkipWorkInProgressMergeRequest(),
             config.isTriggerOnApprovedMergeRequest(),
-            config.getCancelPendingBuildsOnUpdate());
+            config.getCancelPendingBuildsOnUpdate(),
+            config.getAlwaysForceBuild());
     }
 
     public static Config withConfig() {
@@ -58,6 +60,7 @@ public final class MergeRequestHookTriggerHandlerFactory {
         private boolean skipWorkInProgressMergeRequest = false;
         private boolean triggerOnApprovedMergeRequest = false;
         private boolean cancelPendingBuildsOnUpdate = false;
+        private boolean alwaysForceBuild = false;
 
         @Override
         public boolean getTriggerOnMergeRequest() {
@@ -94,6 +97,9 @@ public final class MergeRequestHookTriggerHandlerFactory {
             return cancelPendingBuildsOnUpdate;
         }
 
+        @Override
+        public boolean getAlwaysForceBuild() { return alwaysForceBuild; }
+
         public Config setTriggerOnMergeRequest(boolean triggerOnMergeRequest) {
             this.triggerOnMergeRequest = triggerOnMergeRequest;
             return this;
@@ -126,6 +132,11 @@ public final class MergeRequestHookTriggerHandlerFactory {
 
         public Config setCancelPendingBuildsOnUpdate(boolean cancelPendingBuildsOnUpdate) {
             this.cancelPendingBuildsOnUpdate = cancelPendingBuildsOnUpdate;
+            return this;
+        }
+
+        public Config setAlwaysForceBuild(boolean alwaysForceBuild) {
+            this.alwaysForceBuild = alwaysForceBuild;
             return this;
         }
 

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -33,6 +33,9 @@
     </table>
   </f:entry>
   <f:advanced>
+    <f:entry title="Always force build, even if the latest commit already has been built" field="alwaysForceBuild">
+      <f:checkbox default="false"/>
+    </f:entry>
     <f:entry title="Enable [ci-skip]" field="ciSkip">
       <f:checkbox default="true"/>
     </f:entry>


### PR DESCRIPTION
This parameter allows overriding the check isLastCommitNotYetBuild in MergeRequestHookTriggerHandlerImpl.

This commit fixes issue #636 and #734, probably also #958.

Notice: I am not a Java expert, especially not in writing test code, so I would be happy if someone could please add a test for the new feature. Existing tests do not break and regular operations in our Jenkins also work so I am at least confident that no regressions have been introduced.