### PR TITLE
Check project item permission and not only global permission

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/BuildWebHookAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/BuildWebHookAction.java
@@ -47,7 +47,7 @@ abstract class BuildWebHookAction implements WebHookAction {
             GitLabPushTrigger trigger = GitLabPushTrigger.getFromJob((Job<?, ?>) project);
             if (trigger != null) {
                 if (StringUtils.isEmpty(trigger.getSecretToken())) {
-                    checkPermission(Item.BUILD);
+                    checkPermission(Item.BUILD, project);
                 } else if (!StringUtils.equals(trigger.getSecretToken(), secretToken)) {
                     throw HttpResponses.errorWithoutStack(401, "Invalid token");
                 }
@@ -55,9 +55,9 @@ abstract class BuildWebHookAction implements WebHookAction {
             }
         }
 
-        private void checkPermission(Permission permission) {
-            if (((GitLabConnectionConfig) Jenkins.getInstance().getDescriptor(GitLabConnectionConfig.class)).isUseAuthenticatedEndpoint()) {
-                if (!Jenkins.getActiveInstance().getACL().hasPermission(authentication, permission)) {
+        private void checkPermission(Permission permission, Item project) {
+            if (((GitLabConnectionConfig) Jenkins.get().getDescriptor(GitLabConnectionConfig.class)).isUseAuthenticatedEndpoint()) {
+                if (!project.getACL().hasPermission(authentication, permission)) {
                     String message = Messages.AccessDeniedException2_MissingPermission(authentication.getName(), permission.group.title+"/"+permission.name);
                     LOGGER.finest("Unauthorized (Did you forget to add API Token to the web hook ?)");
                     throw HttpResponses.errorWithoutStack(403, message);


### PR DESCRIPTION
The plugin checked only the global permissions.
But often people configure only folder or project permissions to have a more specific access control.
These were ignored.

This works also if a Jenkins instance uses only the global permissions because the project item inherits the permissions.

This commit fixes issue #950 