### PR TITLE
Don't raise NPE if revision is null

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -183,6 +183,10 @@ public class CommitStatusUpdater {
 
             String scmRevisionHash = null;
             if (scmRevision instanceof AbstractGitSCMSource.SCMRevisionImpl) {
+                if (scmRevision == null) {
+                    LOGGER.log(Level.INFO, "Build does not contain SCM revision object.");
+                    return result;
+                }
                 scmRevisionHash = ((AbstractGitSCMSource.SCMRevisionImpl) scmRevision).getHash();
             }
 


### PR DESCRIPTION
Gitlab branch source plugin uses another class to track headHash and baseHash values for MRs that leads to NPE error.
mitigates: https://issues.jenkins-ci.org/browse/JENKINS-60309