### PR TITLE
Fix another NPE with gitlab branch source plugin  in MR tab

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -188,12 +188,12 @@ public class CommitStatusUpdater {
                     return result;
                 }
                 scmRevisionHash = ((AbstractGitSCMSource.SCMRevisionImpl) scmRevision).getHash();
-            }
 
-            for (final BuildData buildData : buildDatas) {
-                for (final Entry<String, Build> buildByBranchName : buildData.getBuildsByBranchName().entrySet()) {
-                    if (buildByBranchName.getValue().getSHA1().equals(ObjectId.fromString(scmRevisionHash))) {
-                        addGitLabBranchBuild(result, scmRevisionHash, buildData.getRemoteUrls(), environment, gitLabClient);
+                for (final BuildData buildData : buildDatas) {
+                    for (final Entry<String, Build> buildByBranchName : buildData.getBuildsByBranchName().entrySet()) {
+                        if (buildByBranchName.getValue().getSHA1().equals(ObjectId.fromString(scmRevisionHash))) {
+                            addGitLabBranchBuild(result, scmRevisionHash, buildData.getRemoteUrls(), environment, gitLabClient);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixing one more NPE when used with GitlabBranch source plugin.
if scmRevision isn't a  AbstractGitSCMSource.SCMRevisionImpl  we can't call getSHA1(), otherwise NPE. related to #1012 