### PR TITLE
Update BuildState enum to include skipped status, this was previous i…

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/BuildState.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/BuildState.java
@@ -4,5 +4,5 @@ package com.dabsquared.gitlabjenkins.gitlab.api.model;
  * @author Robin Müller
  */
 public enum BuildState {
-    pending, running, canceled, success, failed
+    pending, running, canceled, success, failed, skipped
 }


### PR DESCRIPTION
Update BuildState enum to include skipped status, this was previous included in 1.5.7 and regressed in 1.5.10
