### PR TITLE
[WIP] (TBT) Fix pipeline GitLab connection 

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
@@ -27,6 +27,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -41,12 +42,6 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
 	private boolean useAlternativeCredential = false;
 
     @DataBoundConstructor
-    public GitLabConnectionProperty(String gitLabConnection, boolean useAlternativeCredential, String jobCredentialId) {
-        this.gitLabConnection = gitLabConnection;
-        this.useAlternativeCredential = useAlternativeCredential;
-        this.jobCredentialId = jobCredentialId;
-    }
-    
     public GitLabConnectionProperty(String gitLabConnection) {
         this.gitLabConnection = gitLabConnection;
     }
@@ -61,6 +56,16 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
 
     public boolean isUseAlternativeCredential() {
         return useAlternativeCredential;
+    }
+
+    @DataBoundSetter
+    public void setJobCredentialId(String jobCredentialId) {
+        this.jobCredentialId = jobCredentialId;
+    }
+
+    @DataBoundSetter
+    public void setUseAlternativeCredential(boolean useAlternativeCredential) {
+        this.useAlternativeCredential = useAlternativeCredential;
     }
 
     public GitLabClient getClient() {


### PR DESCRIPTION
After #916 , you must add 2 more parameters to gitLabConnection method call in a pipeline.
This fix is to allow the single parameter call like before.

See #1016 
