### PR TITLE
[JENKINS-62767] Rely on git-client to provide jgit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,21 +189,6 @@
       <version>1.20</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jgit</groupId>
-      <artifactId>org.eclipse.jgit</artifactId>
-      <version>4.5.5.201812240535-r</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.jcraft</groupId>
-          <artifactId>jsch</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>matrix-project</artifactId>
         <version>1.14</version>


### PR DESCRIPTION
## [JENKINS-62767](https://issues.jenkins-ci.org/browse/JENKINS-62767) Rely on git-client to provide jgit

The git client plugin is intended to be the only plugin in the Jenkins project that delivers JGit.  Other plugins rely on the version of JGit inside the git client plugin.  The gitlab-plugin 1.5.13 bundles JGit 3.5.2.  That is a 6 year old version of JGit that has not been used by the git client plugin for a very long time.  The git client plugin is currently delivering JGit 5.8.0.

This removes the declared dependency on JGit and relies instead on the JGit version that is provided by the already declared dependency on git-client.

## Submitter checklist

* [ ] your changes work with the oldest and latest supported GitLab version
* [x] new features are provided with tests (not applicable, no new features)
* [x] refactored code is provided with regression tests (not applicable, no new features)
* [x] the code formatting follows the plugin standard (code deletion only, no new code to check formatting)
* [x] imports are organised (no new imports)
* [x] you updated the help docs (no change to help docs)
* [x] you updated the README (no change to README)
* [ ] you have used spotbugs to see if you haven't introduced any new warnings