### PR TITLE
Fix dependencies and tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>24.1.1</version>
+      <version>24.1.1-jre</version>
     </dependency>
     <dependency>
       <groupId>net.karneim</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,11 @@
       <artifactId>display-url-api</artifactId>
       <version>2.1.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>2.3.3</version>
+    </dependency>
 
 
     <!-- REST client dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -217,9 +217,6 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.7</version>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
       <version>${jackson.version}</version>

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabAcceptMergeRequestPublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabAcceptMergeRequestPublisherTest.java
@@ -54,7 +54,7 @@ public class GitLabAcceptMergeRequestPublisherTest {
 
     @Test
     public void matrixAggregatable() throws InterruptedException, IOException {
-        verifyMatrixAggregatable(GitLabAcceptMergeRequestPublisher.class, listener);
+        verifyMatrixAggregatable(new GitLabAcceptMergeRequestPublisher(), listener);
     }
 
     @Test

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
@@ -94,7 +94,7 @@ public class GitLabCommitStatusPublisherTest {
 
     @Test
     public void matrixAggregatable() throws InterruptedException, IOException {
-        verifyMatrixAggregatable(GitLabCommitStatusPublisher.class, listener);
+        verifyMatrixAggregatable(new GitLabCommitStatusPublisher("", false), listener);
     }
 
     @Test
@@ -333,6 +333,7 @@ public class GitLabCommitStatusPublisherTest {
         List<BuildData> buildDatas = new ArrayList<>();
         BuildData buildData = mock(BuildData.class);
         Revision revision = mock(Revision.class);
+        when(revision.getSha1()).thenReturn(ObjectId.fromString(SHA1));
         when(revision.getSha1String()).thenReturn(SHA1);
         when(buildData.getLastBuiltRevision()).thenReturn(revision);
         when(buildData.getRemoteUrls()).thenReturn(new HashSet<>(Arrays.asList(remoteUrls)));

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisherTest.java
@@ -68,7 +68,7 @@ public class GitLabMessagePublisherTest {
 
     @Test
     public void matrixAggregatable() throws InterruptedException, IOException {
-        verifyMatrixAggregatable(GitLabMessagePublisher.class, listener);
+        verifyMatrixAggregatable(new GitLabMessagePublisher(), listener);
     }
 
     @Test

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabVotePublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabVotePublisherTest.java
@@ -54,7 +54,7 @@ public class GitLabVotePublisherTest {
 
     @Test
     public void matrixAggregatable() throws InterruptedException, IOException {
-        verifyMatrixAggregatable(GitLabVotePublisher.class, listener);
+        verifyMatrixAggregatable(new GitLabVotePublisher(), listener);
     }
 
     @Test

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/TestUtility.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/TestUtility.java
@@ -65,17 +65,14 @@ final class TestUtility {
 
     }
 
-    static <T  extends Notifier & MatrixAggregatable> void verifyMatrixAggregatable(Class<T> publisherClass, BuildListener listener) throws InterruptedException, IOException {
+    static <T  extends Notifier & MatrixAggregatable> void verifyMatrixAggregatable(T publisherS, BuildListener listener) throws InterruptedException, IOException {
         AbstractBuild build = mock(AbstractBuild.class);
         AbstractProject project = mock(MatrixConfiguration.class);
-        Notifier publisher = mock(publisherClass);
         MatrixBuild parentBuild = mock(MatrixBuild.class);
-
+        T publisher = spy(publisherS);
         when(build.getParent()).thenReturn(project);
-        when(((MatrixAggregatable) publisher).createAggregator(any(MatrixBuild.class), any(Launcher.class), any(BuildListener.class))).thenCallRealMethod();
-        when(publisher.perform(any(AbstractBuild.class), any(Launcher.class), any(BuildListener.class))).thenReturn(true);
-
-        MatrixAggregator aggregator = ((MatrixAggregatable) publisher).createAggregator(parentBuild, null, listener);
+        doReturn(true).when(publisher).perform(any(AbstractBuild.class), any(Launcher.class), any(BuildListener.class));
+        MatrixAggregator aggregator = publisher.createAggregator(parentBuild, null, listener);
         aggregator.startBuild();
         aggregator.endBuild();
         verify(publisher).perform(parentBuild, null, listener);


### PR DESCRIPTION
Since the Jackson plugin imports Jackson 2 databind, it shouldn't be added directly.