### PR TITLE
Fix dependencies and mock to make unit test Success

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>gitlab-plugin</artifactId>
   <version>${revision}${changelist}</version>
   <name>GitLab Plugin</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/GitLab+Plugin</url>
+  <url>https://github.com/jenkinsci/gitlab-plugin/</url>
   <packaging>hpi</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,23 +3,27 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.2</version>
+    <version>4.16</version>
+    <relativePath/>
   </parent>
-
-  <properties>
-    <java.level>8</java.level>
-    <jenkins.version>2.190.1</jenkins.version>
-    <spotbugs.failOnError >false</spotbugs.failOnError>
-    <configuration-as-code-plugin.version>1.36</configuration-as-code-plugin.version>
-    <hpi.compatibleSinceVersion>1.4.0</hpi.compatibleSinceVersion>
-    <jackson.version>2.11.0</jackson.version>
-  </properties>
-
   <artifactId>gitlab-plugin</artifactId>
-  <version>1.5.17-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <name>GitLab Plugin</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/GitLab+Plugin</url>
   <packaging>hpi</packaging>
+
+  <properties>
+    <revision>1.5.18</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <java.level>8</java.level>
+    <jenkins.version>2.222.4</jenkins.version>
+    <spotbugs.failOnError >false</spotbugs.failOnError>
+    <configuration-as-code-plugin.version>1.46</configuration-as-code-plugin.version>
+    <hpi.compatibleSinceVersion>1.4.0</hpi.compatibleSinceVersion>
+    <jackson.version>2.12.1</jackson.version>
+    <jenkins-test-harness.version>2.71</jenkins-test-harness.version>
+  </properties>
+
 
   <licenses>
     <license>
@@ -77,6 +81,10 @@
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org-r</id>
+      <url>https://repo.jenkins-ci.org/releases/</url>
+    </pluginRepository>
   </pluginRepositories>
 
   <dependencies>
@@ -84,119 +92,80 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>2.7.7</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.28</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.20</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.6.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <version>2.37</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.66</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.22</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.34</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps-global-lib</artifactId>
-      <version>2.15</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>3.3</version>
-      <exclusions>
-        <!-- -->
-        <exclusion>
-          <groupId>org.jboss.marshalling</groupId>
-          <artifactId>jboss-marshalling</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jboss.marshalling</groupId>
-          <artifactId>jboss-marshalling-river</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.marshalling</groupId>
-      <artifactId>jboss-marshalling</artifactId>
-      <version>1.4.12.jenkins-3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.marshalling</groupId>
-      <artifactId>jboss-marshalling-river</artifactId>
-      <version>1.4.12.jenkins-3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
-      <version>2.9</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.35</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plain-credentials</artifactId>
-      <version>1.5</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.18</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>symbol-annotation</artifactId>
-      <version>1.20</version>
     </dependency>
     <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>matrix-project</artifactId>
-        <version>1.14</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>display-url-api</artifactId>
-      <version>2.1.0</version>
     </dependency>
 
 
@@ -204,62 +173,49 @@
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
       <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
-      <version>1.0.0.Final</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
-      <version>3.0.16.Final</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.7</version>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.10-2.0</version>
     </dependency>
 
     <!-- util dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>24.1.1</version>
     </dependency>
     <dependency>
       <groupId>net.karneim</groupId>
       <artifactId>pojobuilder</artifactId>
-      <version>3.4.0</version>
       <scope>provided</scope>
     </dependency>
 
     <!-- test dependencies -->
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${configuration-as-code-plugin.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
-      <version>${configuration-as-code-plugin.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -280,7 +236,6 @@
     <dependency>
       <groupId>org.mock-server</groupId>
       <artifactId>mockserver-netty</artifactId>
-      <version>3.10.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -304,40 +259,115 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>9.4.1208</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-auth</artifactId>
-      <version>2.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.74</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.2</version>
       <scope>test</scope>
     </dependency>
-    <!-- parent pom test dependencies needs overriding-->
 
   </dependencies>
 
   <dependencyManagement>
     <dependencies>
+
+
+      <dependency>
+        <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.277.x</artifactId>
+        <version>23</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+<!--Jenkins Plugins-->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>git</artifactId>
+        <version>4.5.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>git-client</artifactId>
+        <version>3.6.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>2.3.14</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-durable-task-step</artifactId>
+        <version>2.35</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-basic-steps</artifactId>
+        <scope>test</scope>
+        <version>2.21</version>
+      </dependency>
+<!--3rd party-->
+      <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>9.4.1208</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-netty</artifactId>
+      <version>3.10.2</version>
+      <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.spec.javax.ws.rs</groupId>
+        <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+        <version>1.0.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-client</artifactId>
+        <version>3.0.16.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>18.0</version>
+      </dependency>
+      <dependency>
+        <groupId>net.karneim</groupId>
+        <artifactId>pojobuilder</artifactId>
+        <version>3.4.0</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.9</version>
+        <version>3.11</version>
       </dependency>
     </dependencies>
+
   </dependencyManagement>
+
 
   <profiles>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -286,39 +286,13 @@
       <dependency>
         <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.277.x</artifactId>
+        <artifactId>bom-2.222.x</artifactId>
         <version>23</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-<!--Jenkins Plugins-->
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>git</artifactId>
-        <version>4.5.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>git-client</artifactId>
-        <version>3.6.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>credentials</artifactId>
-        <version>2.3.14</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-durable-task-step</artifactId>
-        <version>2.35</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-basic-steps</artifactId>
-        <scope>test</scope>
-        <version>2.21</version>
-      </dependency>
-<!--3rd party-->
+
+      <!--3rd party-->
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
@@ -11,8 +11,10 @@ import hudson.security.ACL;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.traits.IgnoreOnPushNotificationTrait;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
+import jenkins.scm.api.trait.SCMTrait;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.transport.URIish;
 
@@ -102,7 +104,7 @@ public class PushBuildAction extends BuildWebHookAction {
                     GitSCMSource gitSCMSource = (GitSCMSource) scmSource;
                     try {
                         if (new URIish(gitSCMSource.getRemote()).equals(new URIish(gitSCMSource.getRemote()))) {
-                            if (!gitSCMSource.isIgnoreOnPushNotifications()) {
+                            if (SCMTrait.find(gitSCMSource.getTraits(), IgnoreOnPushNotificationTrait.class) != null) {
                                 LOGGER.log(Level.FINE, "Notify scmSourceOwner {0} about changes for {1}",
                                            toArray(project.getName(), gitSCMSource.getRemote()));
                                 ((SCMSourceOwner) project).onSCMSourceUpdated(scmSource);

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
@@ -333,6 +333,7 @@ public class GitLabCommitStatusPublisherTest {
         List<BuildData> buildDatas = new ArrayList<>();
         BuildData buildData = mock(BuildData.class);
         Revision revision = mock(Revision.class);
+        when(revision.getSha1()).thenReturn(ObjectId.fromString(SHA1));
         when(revision.getSha1String()).thenReturn(SHA1);
         when(buildData.getLastBuiltRevision()).thenReturn(revision);
         when(buildData.getRemoteUrls()).thenReturn(new HashSet<>(Arrays.asList(remoteUrls)));

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/TestUtility.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/TestUtility.java
@@ -65,14 +65,14 @@ final class TestUtility {
 
     }
 
-    static <T  extends Notifier & MatrixAggregatable> void verifyMatrixAggregatable(Class<T> publisherClass, BuildListener listener) throws InterruptedException, IOException {
+    static <T extends Notifier & MatrixAggregatable> void verifyMatrixAggregatable(Class<T> publisherClass, BuildListener listener) throws InterruptedException, IOException {
         AbstractBuild build = mock(AbstractBuild.class);
         AbstractProject project = mock(MatrixConfiguration.class);
         Notifier publisher = mock(publisherClass);
         MatrixBuild parentBuild = mock(MatrixBuild.class);
 
         when(build.getParent()).thenReturn(project);
-        when(((MatrixAggregatable) publisher).createAggregator(any(MatrixBuild.class), any(Launcher.class), any(BuildListener.class))).thenCallRealMethod();
+        when(((MatrixAggregatable) publisher).createAggregator(any(MatrixBuild.class), any(), any(BuildListener.class))).thenCallRealMethod();
         when(publisher.perform(any(AbstractBuild.class), any(Launcher.class), any(BuildListener.class))).thenReturn(true);
 
         MatrixAggregator aggregator = ((MatrixAggregatable) publisher).createAggregator(parentBuild, null, listener);

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImplTest.java
@@ -14,10 +14,7 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
@@ -132,9 +129,17 @@ public class PipelineHookTriggerHandlerImplTest {
         project.setQuietPeriod(0);
 
         pipelineHookTriggerHandler.handle(project, pipelineHook, false, newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-                                      newMergeRequestLabelFilter(null));
+            newMergeRequestLabelFilter(null));
 
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(true));
+    }
+    @After
+    public void after()    {
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException ignored) {
+
+        }
     }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImplTest.java
@@ -13,10 +13,7 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
@@ -68,9 +65,9 @@ public class PushHookTriggerHandlerImplTest {
         project.setQuietPeriod(0);
         pushHookTriggerHandler.handle(project, pushHook()
                 .withCommits(Arrays.asList(commit().withMessage("some message").build(),
-                                           commit().withMessage("[ci-skip]").build()))
+                    commit().withMessage("[ci-skip]").build()))
                 .build(), true, newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-                                      newMergeRequestLabelFilter(null));
+            newMergeRequestLabelFilter(null));
 
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(false));
@@ -103,20 +100,20 @@ public class PushHookTriggerHandlerImplTest {
                 .withUserName("test")
                 .withObjectKind("tag_push")
                 .withRepository(repository()
-                        .withName("test")
-                        .withHomepage("https://gitlab.org/test")
-                        .withUrl("git@gitlab.org:test.git")
-                        .withGitSshUrl("git@gitlab.org:test.git")
-                        .withGitHttpUrl("https://gitlab.org/test.git")
-                        .build())
+                    .withName("test")
+                    .withHomepage("https://gitlab.org/test")
+                    .withUrl("git@gitlab.org:test.git")
+                    .withGitSshUrl("git@gitlab.org:test.git")
+                    .withGitHttpUrl("https://gitlab.org/test.git")
+                    .build())
                 .withProject(project()
-                        .withNamespace("test-namespace")
-                        .withWebUrl("https://gitlab.org/test")
-                        .build())
+                    .withNamespace("test-namespace")
+                    .withWebUrl("https://gitlab.org/test")
+                    .build())
                 .withAfter(commit.name())
                 .withRef("refs/heads/" + git.nameRev().add(head).call().get(head))
                 .build(), true, newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-                                      newMergeRequestLabelFilter(null));
+            newMergeRequestLabelFilter(null));
 
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(true));
@@ -154,25 +151,35 @@ public class PushHookTriggerHandlerImplTest {
             .withUserName("test")
             .withObjectKind("push")
             .withRepository(repository()
-                                .withName("test")
-                                .withHomepage("https://gitlab.org/test")
-                                .withUrl("git@gitlab.org:test.git")
-                                .withGitSshUrl("git@gitlab.org:test.git")
-                                .withGitHttpUrl("https://gitlab.org/test.git")
-                                .build())
+                .withName("test")
+                .withHomepage("https://gitlab.org/test")
+                .withUrl("git@gitlab.org:test.git")
+                .withGitSshUrl("git@gitlab.org:test.git")
+                .withGitHttpUrl("https://gitlab.org/test.git")
+                .build())
             .withProject(project()
-                             .withNamespace("test-namespace")
-                             .withWebUrl("https://gitlab.org/test")
-                             .build())
+                .withNamespace("test-namespace")
+                .withWebUrl("https://gitlab.org/test")
+                .build())
             .withAfter(commit.name())
             .withRef("refs/heads/" + git.nameRev().add(head).call().get(head));
         pushHookTriggerHandler.handle(project, pushHookBuilder.build(), true, newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-                                      newMergeRequestLabelFilter(null));
+            newMergeRequestLabelFilter(null));
         pushHookTriggerHandler.handle(project, pushHookBuilder
-                                          .but().withRef("refs/heads/" + git.nameRev().add(head).call().get(head) + "-2").build(), true,
-                                      newBranchFilter(branchFilterConfig().build(BranchFilterType.All)), newMergeRequestLabelFilter(null));
+                .but().withRef("refs/heads/" + git.nameRev().add(head).call().get(head) + "-2").build(), true,
+            newBranchFilter(branchFilterConfig().build(BranchFilterType.All)), newMergeRequestLabelFilter(null));
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(true));
         assertThat(buildCount.intValue(), is(2));
     }
+
+    @After
+    public void after()    {
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException ignored) {
+
+        }
+    }
+
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdaterTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdaterTest.java
@@ -1,10 +1,9 @@
 package com.dabsquared.gitlabjenkins.util;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import static com.dabsquared.gitlabjenkins.cause.CauseDataBuilder.causeData;
+import static org.mockito.Mockito.*;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -13,6 +12,7 @@ import java.util.Collections;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
 import com.dabsquared.gitlabjenkins.workflow.GitLabBranchBuild;
 import hudson.Functions;
+import hudson.Util;
 import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.junit.Before;
@@ -46,7 +46,7 @@ import jenkins.model.Jenkins;
  * @author Daumantas Stulgis
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({GitLabConnectionProperty.class, Jenkins.class})
+@PrepareForTest({GitLabConnectionProperty.class, Jenkins.class, DisplayURLProvider.class})
 public class CommitStatusUpdaterTest {
 
 	private static final int PROJECT_ID = 1;
@@ -99,6 +99,11 @@ public class CommitStatusUpdaterTest {
 	    } else {
 	        when(taskListener.getLogger()).thenReturn(new PrintStream("/dev/null"));
 	    }
+	    PowerMockito.mockStatic(DisplayURLProvider.class);
+	    DisplayURLProvider urlProvider = mock(DisplayURLProvider.class);
+	    when(DisplayURLProvider.get()).thenReturn(urlProvider);
+	    String url = JENKINS_URL+ Util.encode(build.getUrl());
+	    when(urlProvider.getRunURL(any())).thenReturn(url);
 
 
 	    causeData = causeData()


### PR DESCRIPTION
Fix dependencies and mock to make unit test Success

Changes were made:
1. Fix pom.xml to make pom.xml valid
2. Downgrade guava to 18.0 as it managed by Jenkins Core
3. Add mock in GitLabCommitStatusPublisherTest to avoid NPE
4. Bump jenkins-test-harness
5. Add timeout to avoid Temp Directory dispose error
6. Bump Jackson to Modern version with ordering bugfix 2.12.1
7. Update parent.pom to 4.16
8. Switch version management to DependenciesManagement using Jenkins BOM
9. Align all depends according to bom-2.222.x version 23
10. Minimal required version of Jenkins 2.224.4
11. Use README from repo as a plugin documentation on plugins.jenkins.io (Thanks to @MarkEWaite )