### PR TITLE
Fix master branch compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,9 +217,6 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.7</version>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
       <version>${jackson.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>24.1.1</version>
+      <version>18.0</version>
     </dependency>
     <dependency>
       <groupId>net.karneim</groupId>


### PR DESCRIPTION
## Fix compile on master branch

- Apply pom.xml from develop to master to fix duplicate groupId
- Revert "Update pom.xml" to undo guava upgrade (guava is provided by Jenkins core, can't be upgraded)
