### PR TITLE
Remove git submodule config pipeline settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,7 @@ In the *Source Code Management* section:
 checkout changelog: true, poll: true, scm: [
     $class: 'GitSCM',
     branches: [[name: "origin/${env.gitlabSourceBranch}"]],
-    doGenerateSubmoduleConfigurations: false,
     extensions: [[$class: 'PreBuildMerge', options: [fastForwardMode: 'FF', mergeRemote: 'origin', mergeStrategy: 'DEFAULT', mergeTarget: "${env.gitlabTargetBranch}"]]],
-    submoduleCfg: [],
     userRemoteConfigs: [[name: 'origin', url: 'git@gitlab.example.com:foo/testrepo.git']]
     ]
 ```


### PR DESCRIPTION
### Remove git submodule settings from pipeline example

The values are the defaults in all plugin releases.

Values are not needed and are no longer shown to users with [git plugin 4.6.0](https://github.com/jenkinsci/git-plugin/releases/tag/git-4.6.0) and later.
