### PR TITLE
Make field name match getter/setter

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PushHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PushHook.java
@@ -18,7 +18,7 @@ public class PushHook extends WebHook {
     private String ref;
     private Integer userId;
     private String userName;
-    private String userUsername;
+    private String userUserName;
     private String userEmail;
     private String userAvatar;
     private Integer projectId;
@@ -67,11 +67,11 @@ public class PushHook extends WebHook {
     }
 
     public String getUserUsername() {
-        return userUsername;
+        return userUserName;
     }
 
     public void setUserUserName(String userUsername) {
-        this.userUsername = userUsername;
+        this.userUserName = userUsername;
     }
 
     public String getUserEmail() {


### PR DESCRIPTION
This fixes a Javadoc error by making field and getter/setter names match.

Unsure what the side effects are, might be better for now to ignore Javadoc failures.