### PR TITLE
Update README with a corrected groovy job script

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,22 +171,23 @@ In your job configuration, click 'This build is parameterized' and add any param
 In the Groovy Script field insert something similar to:
 
 ```
-import hudson.model.*
-def env = Thread.currentThread()?.executable.parent.builds[0].properties.get('envVars')
+def env = currentBuild.getEnvironment(currentListener)
 def map = [:]
 
-if (env['gitlabSourceBranch'] != null) { 
-  map['sourceBranch'] = env['gitlabSourceBranch'] 
+if (env.gitlabSourceBranch != null) {
+  map['sourceBranch'] = env.gitlabSourceBranch
 }
-if (env['gitlabTargetBranch'] != null) { 
-  map['targetBranch'] = env['gitlabTargetBranch'] 
+
+if (env.gitlabTargetBranch != null) {
+  map['targetBranch'] = env.gitlabTargetBranch
 }
-// Add additional entries for any other parameters you have created
 
 return map
 ```
 
 You can then reference these variables in your job config, e.g. as `${sourceBranch}`. You will need to update this code anytime you add or remove parameters.
+
+Note: If you use the Groovy Sandbox, you might need to approve the script yourself or let an administrator approve the script in the Jenkins configuration.
 
 ## Git configuration 
 ### Freestyle jobs


### PR DESCRIPTION
### Test environment

Jenkins version: 2.280
Gitlab version: 13.8.4 (9fb9cbf50c3) CE
Gitlab plugin version: 1.5.13
Job type: Matrix job in a Multi-configuration project
Groovy sandbox in the project was disabled, the script was written in the textbox the current Readme file is referring to.

### Current state

The groovy script currently proposed by the README file for a [parametrized build with parameter configuration](https://github.com/jenkinsci/gitlab-plugin/blob/master/README.md#parameter-configuration) doesn't seem to be working correctly anymore.

The only issue I could find referencing something similar was #1073, where just a warning about a method deprecation was thrown.

In my Jenkins instance, however, it results in an error:
```
21:57:31 ERROR: SEVERE ERROR occurs
21:57:31 org.jenkinsci.lib.envinject.EnvInjectException: Failed to evaluate the script
21:57:31 	at org.jenkinsci.plugins.envinject.service.EnvInjectEnvVars.executeGroovyScript(EnvInjectEnvVars.java:227)
21:57:31 	at org.jenkinsci.plugins.envinject.EnvInjectListener.setUpEnvironmentJobPropertyObject(EnvInjectListener.java:185)
21:57:31 	at org.jenkinsci.plugins.envinject.EnvInjectListener.setUpEnvironment(EnvInjectListener.java:47)
[...]
21:57:31 Caused by: groovy.lang.MissingPropertyException: No such property: executable for class: hudson.model.OneOffExecutor
21:57:31 	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:53)
21:57:31 	at org.codehaus.groovy.runtime.callsite.GetEffectivePojoPropertySite.getProperty(GetEffectivePojoPropertySite.java:66)
[...]
21:57:31 	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript.evaluate(SecureGroovyScript.java:377)
21:57:31 	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript.evaluate(SecureGroovyScript.java:314)
21:57:31 	at org.jenkinsci.plugins.envinject.service.EnvInjectEnvVars.executeGroovyScript(EnvInjectEnvVars.java:225)
21:57:31 	... 8 more
```

I've traced this back to the usage of the property Thread.executable, which doesn't seem to be available in this context.
Furthermore, the [Jenkins help of the EnvInject plugin](https://github.com/jenkinsci/envinject-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobPropertyInfo/help-secureGroovyScript.html) provides/proposes variables that seem to do a much better job of getting environment variables here.

### Proposal

The updated script uses the variables actually made available by EnvInject now like proposed by the commit attached to this PR.
Since I'm not very experienced with groovy scripts, I'm not sure if the code could be written more elegantly, but if tested with debug content, it correctly prints the branch sent by the webhook test push feature of Gitlab.

Test code used:
```groovy
def env = currentBuild.getEnvironment(currentListener)
def map = [:] 

if (env.gitlabSourceBranch != null) { 
  println "Got gitlab source branch: "
  println env.gitlabSourceBranch
  map['sourceBranch'] = env.gitlabSourceBranch
}

return map
```