### PR TITLE
Fix logic error blocking Multibranch Pipeline projects from being triggered

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
@@ -104,7 +104,7 @@ public class PushBuildAction extends BuildWebHookAction {
                     GitSCMSource gitSCMSource = (GitSCMSource) scmSource;
                     try {
                         if (new URIish(gitSCMSource.getRemote()).equals(new URIish(gitSCMSource.getRemote()))) {
-                            if (SCMTrait.find(gitSCMSource.getTraits(), IgnoreOnPushNotificationTrait.class) != null) {
+                            if (SCMTrait.find(gitSCMSource.getTraits(), IgnoreOnPushNotificationTrait.class) == null) {
                                 LOGGER.log(Level.FINE, "Notify scmSourceOwner {0} about changes for {1}",
                                            toArray(project.getName(), gitSCMSource.getRemote()));
                                 ((SCMSourceOwner) project).onSCMSourceUpdated(scmSource);


### PR DESCRIPTION
The bug was introduced in commit 4eb27b477fd0c5fa7c809b268e1d2d0b635c0f35.
It prevented Multibranch Pipeline projects from being triggered by webhooks *unless* `Ignore on push notifications` had been set on the Git (branch) source.

Fixes #1116