### PR TITLE
Fix problem with lookup for credentials (No credentials found for credentialsId)

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnection.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnection.java
@@ -136,7 +136,7 @@ public class GitLabConnection extends AbstractDescribableImpl<GitLabConnection> 
 
     public GitLabClient getClient(Item item, String jobCredentialId) {
         if (apiCache == null) {
-            apiCache = clientBuilder.buildClient(url, null == jobCredentialId ? getApiToken(apiTokenId, null) : getApiToken(jobCredentialId, item), ignoreCertificateErrors,
+            apiCache = clientBuilder.buildClient(url, jobCredentialId == null ? getApiToken(apiTokenId, null) : getApiToken(jobCredentialId, item), ignoreCertificateErrors,
                     connectionTimeout, readTimeout);
         }
         return apiCache;
@@ -144,7 +144,7 @@ public class GitLabConnection extends AbstractDescribableImpl<GitLabConnection> 
 
     @Restricted(NoExternalUse.class)
     private String getApiToken(String apiTokenId, Item item) {
-        ItemGroup<?> context = null != item ? item.getParent() : Jenkins.get();
+        ItemGroup<?> context = item != null ? item.getParent() : Jenkins.get();
         StandardCredentials credentials = CredentialsMatchers.firstOrNull(
             lookupCredentials(
                     StandardCredentials.class,

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
@@ -39,7 +39,7 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
 
     private String gitLabConnection;
     private String jobCredentialId;
-	private boolean useAlternativeCredential = false;
+    private boolean useAlternativeCredential = false;
 
     @DataBoundConstructor
     public GitLabConnectionProperty(String gitLabConnection) {
@@ -72,20 +72,19 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
         if (StringUtils.isNotEmpty(gitLabConnection)) {
             GitLabConnectionConfig connectionConfig = (GitLabConnectionConfig) Jenkins.getActiveInstance().getDescriptor(GitLabConnectionConfig.class);
             return connectionConfig != null ? connectionConfig.getClient(gitLabConnection, this.owner, jobCredentialId)
-                   : null;
+                    : null;
         }
         return null;
     }
 
     public static GitLabClient getClient(@NotNull Run<?, ?> build) {
         Job<?, ?> job = build.getParent();
-        if(job != null) {
+        if (job != null) {
             final GitLabConnectionProperty connectionProperty = job.getProperty(GitLabConnectionProperty.class);
             if (connectionProperty != null) {
                 return connectionProperty.getClient();
             }
         }
-        
         return null;
     }
 
@@ -118,7 +117,7 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
         }
         
         public ListBoxModel doFillJobCredentialIdItems(@AncestorInPath Item item, @QueryParameter String url,
-               @QueryParameter String jobCredentialId) {
+                @QueryParameter String jobCredentialId) {
             StandardListBoxModel result = new StandardListBoxModel();
             return result.includeEmptyValue()
                     .includeMatchingAs(ACL.SYSTEM, item, StandardCredentials.class,
@@ -131,13 +130,13 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
         public FormValidation doTestConnection(@QueryParameter String jobCredentialId,
                 @QueryParameter String gitLabConnection, @AncestorInPath Item item) {
         	Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER);
-             try {
+            try {
                 GitLabConnection gitLabConnectionTested = null;
                 GitLabConnectionConfig descriptor = (GitLabConnectionConfig) Jenkins.getInstance()
                         .getDescriptor(GitLabConnectionConfig.class);
                 for (GitLabConnection connection : descriptor.getConnections()) {
                     if (gitLabConnection.equals(connection.getName())) {
-                         gitLabConnectionTested = connection;
+                        gitLabConnectionTested = connection;
                     }
                 }
                 if (gitLabConnectionTested == null) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
@@ -71,8 +71,14 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
     public GitLabClient getClient() {
         if (StringUtils.isNotEmpty(gitLabConnection)) {
             GitLabConnectionConfig connectionConfig = (GitLabConnectionConfig) Jenkins.getActiveInstance().getDescriptor(GitLabConnectionConfig.class);
-            return connectionConfig != null ? connectionConfig.getClient(gitLabConnection, this.owner, jobCredentialId)
-                    : null;
+            if (connectionConfig != null) {
+                if (useAlternativeCredential) {
+                    return connectionConfig.getClient(gitLabConnection, this.owner, jobCredentialId);
+                } else {
+                    return connectionConfig.getClient(gitLabConnection, null, null);
+                }
+            }
+            return null;
         }
         return null;
     }


### PR DESCRIPTION
It seems that in some cases (described in these issues: #1117 #1119) credentials cannot be found for configured GitLab connection after changes made in PR #916.

I'm not fully sure if the proposed change will solve every case of this problem, because it seems that there are various scenarios, but I think that anyway, it shouldn't look up for credentials in context of a specific job if it's not indicated to "use alternative credentials".
