### PR TITLE
fixes #856 - use red cross icon for build failure

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisher.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisher.java
@@ -187,7 +187,7 @@ public class GitLabMessagePublisher extends MergeRequestNotifier {
         } else if (result == Result.UNSTABLE) {
             return ":warning:";
         } else {
-            return ":negative_squared_cross_mark:";
+            return ":x:";
         }
     }
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisherTest.java
@@ -123,7 +123,7 @@ public class GitLabMessagePublisherTest {
     @Test
     public void failed_v3() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V3, Result.FAILURE);
-        String defaultNote = formatNote(build, ":negative_squared_cross_mark: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
+        String defaultNote = formatNote(build, ":x: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
 
         performAndVerify(
             build, defaultNote, false, false, false, false, false,
@@ -133,7 +133,7 @@ public class GitLabMessagePublisherTest {
     @Test
     public void failed_v4() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, Result.FAILURE);
-        String defaultNote = formatNote(build, ":negative_squared_cross_mark: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
+        String defaultNote = formatNote(build, ":x: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
 
         performAndVerify(
             build, defaultNote, false, false, false, false, false,
@@ -144,7 +144,7 @@ public class GitLabMessagePublisherTest {
     @Test
     public void failed_withOnlyForFailed() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, Result.FAILURE);
-        String defaultNote = formatNote(build, ":negative_squared_cross_mark: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
+        String defaultNote = formatNote(build, ":x: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
 
         performAndVerify(
             build, defaultNote, true, false, false, false, false,


### PR DESCRIPTION
This is a simple change that fixes #856

Looks like this change almost made it in with https://github.com/jenkinsci/gitlab-plugin/pull/582
But was closed due to a disagreement about the icon to use for aborted builds.

I thought I'd give it another shot. :crossed_fingers: 
