### PR TITLE
prevent a NPE when calling 'ObjectId.fromString(scmRevisionHash)'

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -188,6 +188,10 @@ public class CommitStatusUpdater {
                     return result;
                 }
                 scmRevisionHash = ((AbstractGitSCMSource.SCMRevisionImpl) scmRevision).getHash();
+                if (scmRevisionHash == null) {
+                    LOGGER.log(Level.INFO, "Build does not contain SCM revision hash.");
+                    return result;
+                }
 
                 for (final BuildData buildData : buildDatas) {
                     for (final Entry<String, Build> buildByBranchName : buildData.getBuildsByBranchName().entrySet()) {


### PR DESCRIPTION
This MR avoid the following NPE:
```
18:13:18  [Pipeline] updateGitlabCommitStatus
18:13:18  Error when executing success post condition:
18:13:18  java.lang.NullPointerException
18:13:18  	at org.eclipse.jgit.lib.ObjectId.fromString(ObjectId.java:202)
18:13:18  	at com.dabsquared.gitlabjenkins.util.CommitStatusUpdater.retrieveGitlabProjectIds(CommitStatusUpdater.java:191)
18:13:18  	at com.dabsquared.gitlabjenkins.util.CommitStatusUpdater.updateCommitStatus(CommitStatusUpdater.java:61)
18:13:18  	at com.dabsquared.gitlabjenkins.util.CommitStatusUpdater.updateCommitStatus(CommitStatusUpdater.java:97)
18:13:18  	at com.dabsquared.gitlabjenkins.workflow.UpdateGitLabCommitStatusStep$UpdateGitLabCommitStatusStepExecution.run(UpdateGitLabCommitStatusStep.java:79)
18:13:18  	at com.dabsquared.gitlabjenkins.workflow.UpdateGitLabCommitStatusStep$UpdateGitLabCommitStatusStepExecution.run(UpdateGitLabCommitStatusStep.java:63)
18:13:18  	at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution.start(AbstractSynchronousStepExecution.java:42)
18:13:18  	at org.jenkinsci.plugins.workflow.cps.DSL.invokeStep(DSL.java:319)
18:13:18  	at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:193)
18:13:18  	at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:122)
18:13:18  	at sun.reflect.GeneratedMethodAccessor5043.invoke(Unknown Source)
18:13:18  	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
18:13:18  	at java.lang.reflect.Method.invoke(Method.java:498)
18:13:18  	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
18:13:18  	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
18:13:18  	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1213)
18:13:18  	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1022)
18:13:18  	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:42)
18:13:18  	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
18:13:18  	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
18:13:18  	at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:163)
18:13:18  	at org.kohsuke.groovy.sandbox.GroovyInterceptor.onMethodCall(GroovyInterceptor.java:23)
18:13:18  	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onMethodCall(SandboxInterceptor.java:157)
18:13:18  	at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:161)
18:13:18  	at org.kohsuke.groovy.sandbox.impl.Checker.checkedCall(Checker.java:165)
18:13:18  	at org.kohsuke.groovy.sandbox.impl.Checker.checkedCall(Checker.java:135)
18:13:18  	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.methodCall(SandboxInvoker.java:17)
18:13:18  	at WorkflowScript.run(WorkflowScript:61)
18:13:18  	at org.jenkinsci.plugins.pipeline.modeldefinition.ModelInterpreter.delegateAndExecute(ModelInterpreter.groovy:137)
18:13:18  	at org.jenkinsci.plugins.pipeline.modeldefinition.ModelInterpreter.runPostConditions(ModelInterpreter.groovy:756)
18:13:18  	at org.jenkinsci.plugins.pipeline.modeldefinition.ModelInterpreter.catchRequiredContextForNode(ModelInterpreter.groovy:395)
18:13:18  	at org.jenkinsci.plugins.pipeline.modeldefinition.ModelInterpreter.catchRequiredContextForNode(ModelInterpreter.groovy:393)
18:13:18  	at org.jenkinsci.plugins.pipeline.modeldefinition.ModelInterpreter.runPostConditions(ModelInterpreter.groovy:755)
18:13:18  	at com.cloudbees.groovy.cps.CpsDefaultGroovyMethods.each(CpsDefaultGroovyMethods:2030)
18:13:18  	at com.cloudbees.groovy.cps.CpsDefaultGroovyMethods.each(CpsDefaultGroovyMethods:2015)
18:13:18  	at com.cloudbees.groovy.cps.CpsDefaultGroovyMethods.each(CpsDefaultGroovyMethods:2056)
18:13:18  	at org.jenkinsci.plugins.pipeline.modeldefinition.ModelInterpreter.runPostConditions(ModelInterpreter.groovy:745)
18:13:18  	at org.jenkinsci.plugins.pipeline.modeldefinition.ModelInterpreter.runPostConditions(ModelInterpreter.groovy)
18:13:18  	at org.jenkinsci.plugins.pipeline.modeldefinition.ModelInterpreter.executePostBuild(ModelInterpreter.groovy:723)
18:13:18  	at ___cps.transform___(Native Method)
18:13:18  	at com.cloudbees.groovy.cps.impl.ContinuationGroup.methodCall(ContinuationGroup.java:86)
18:13:18  	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.dispatchOrArg(FunctionCallBlock.java:113)
18:13:18  	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.fixArg(FunctionCallBlock.java:83)
18:13:18  	at sun.reflect.GeneratedMethodAccessor448.invoke(Unknown Source)
18:13:18  	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
18:13:18  	at java.lang.reflect.Method.invoke(Method.java:498)
18:13:18  	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)
18:13:18  	at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.dispatch(CollectionLiteralBlock.java:55)
18:13:18  	at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.item(CollectionLiteralBlock.java:45)
18:13:18  	at sun.reflect.GeneratedMethodAccessor451.invoke(Unknown Source)
18:13:18  	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
18:13:18  	at java.lang.reflect.Method.invoke(Method.java:498)
18:13:18  	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)
18:13:18  	at com.cloudbees.groovy.cps.impl.ConstantBlock.eval(ConstantBlock.java:21)
18:13:18  	at com.cloudbees.groovy.cps.Next.step(Next.java:83)
18:13:18  	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:174)
18:13:18  	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:163)
18:13:18  	at org.codehaus.groovy.runtime.GroovyCategorySupport$ThreadCategoryInfo.use(GroovyCategorySupport.java:129)
18:13:18  	at org.codehaus.groovy.runtime.GroovyCategorySupport.use(GroovyCategorySupport.java:268)
18:13:18  	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:163)
18:13:18  	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$001(SandboxContinuable.java:18)
18:13:18  	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:51)
18:13:18  	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:185)
18:13:18  	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:400)
18:13:18  	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$400(CpsThreadGroup.java:96)
18:13:18  	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:312)
18:13:18  	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:276)
18:13:18  	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:67)
18:13:18  	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
18:13:18  	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:136)
18:13:18  	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
18:13:18  	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:59)
18:13:18  	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
18:13:18  	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
18:13:18  	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
18:13:18  	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
18:13:18  	at java.lang.Thread.run(Thread.java:748)
```
Unclear where it comes from, but it makes the plugin pretty much unusable since every MR dies with a failure.