### PR TITLE
[JENKINS-66304] Prepare GitLab for core Guava upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
   <dependencies>
     <!-- Jenkins dependencies -->
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>caffeine-api</artifactId>
+      <version>2.9.1-23.v51c4e2c879c8</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
     </dependency>

--- a/src/main/java/com/dabsquared/gitlabjenkins/service/GitLabProjectLabelsService.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/service/GitLabProjectLabelsService.java
@@ -5,14 +5,13 @@ import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.Label;
 import com.dabsquared.gitlabjenkins.util.LoggerUtil;
 import com.dabsquared.gitlabjenkins.util.ProjectIdUtil;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -25,7 +24,7 @@ public class GitLabProjectLabelsService {
     private final Cache<String, List<String>> projectLabelsCache;
 
     GitLabProjectLabelsService() {
-        this.projectLabelsCache = CacheBuilder.<String, String>newBuilder()
+        this.projectLabelsCache = Caffeine.<String, String>newBuilder()
                 .maximumSize(1000)
                 .expireAfterWrite(5, TimeUnit.SECONDS)
                 .build();
@@ -40,11 +39,7 @@ public class GitLabProjectLabelsService {
 
     public List<String> getLabels(GitLabClient client, String sourceRepositoryString) {
         synchronized (projectLabelsCache) {
-            try {
-                return projectLabelsCache.get(sourceRepositoryString, new LabelNamesLoader(client, sourceRepositoryString));
-            } catch (ExecutionException e) {
-                throw new LabelLoadingException(e);
-            }
+            return projectLabelsCache.get(sourceRepositoryString, new LabelNamesLoader(client));
         }
     }
 
@@ -54,19 +49,22 @@ public class GitLabProjectLabelsService {
         }
     }
 
-    private static class LabelNamesLoader implements Callable<List<String>> {
+    private static class LabelNamesLoader implements Function<String, List<String>> {
         private final GitLabClient client;
-        private final String sourceRepository;
 
-        private LabelNamesLoader(GitLabClient client, String sourceRepository) {
+        private LabelNamesLoader(GitLabClient client) {
             this.client = client;
-            this.sourceRepository = sourceRepository;
         }
 
         @Override
-        public List<String> call() throws Exception {
+        public List<String> apply(String sourceRepository) {
             List<String> result = new ArrayList<>();
-            String projectId = ProjectIdUtil.retrieveProjectId(client, sourceRepository);
+            String projectId;
+            try {
+                projectId = ProjectIdUtil.retrieveProjectId(client, sourceRepository);
+            } catch (ProjectIdUtil.ProjectIdResolutionException e) {
+                throw new LabelLoadingException(e);
+            }
             for (Label label : client.getLabels(projectId)) {
                 result.add(label.getName());
             }


### PR DESCRIPTION
See [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988) and [JENKINS-66304](https://issues.jenkins.io/browse/JENKINS-66304). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.cache.Cache#get(K key)` API, which has been removed between Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/cache/Cache.html) and [latest](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/cache/Cache.html). The removal took place in Guava 12.0.

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. The recommendation is for plugins to migrate from Guava's cache to [Caffeine](https://github.com/ben-manes/caffeine) via the Jenkins [Caffeine API](https://plugins.jenkins.io/caffeine-api/) plugin.

For the most part, the migration is a trivial matter of replacing imports of `com.google.common.cache.Cache` with imports of `com.github.benmanes.caffeine.cache.Cache` and imports of `com.google.common.cache.CacheBuilder` with imports of `com.github.benmanes.caffeine.cache.Caffeine`.