### PR TITLE
old buildata hash can be null - fix NPE

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -191,8 +191,10 @@ public class CommitStatusUpdater {
 
                 for (final BuildData buildData : buildDatas) {
                     for (final Entry<String, Build> buildByBranchName : buildData.getBuildsByBranchName().entrySet()) {
-                        if (buildByBranchName.getValue().getSHA1().equals(ObjectId.fromString(scmRevisionHash))) {
-                            addGitLabBranchBuild(result, scmRevisionHash, buildData.getRemoteUrls(), environment, gitLabClient);
+                        if (buildByBranchName.getValue().getSHA1() != null){
+                            if (buildByBranchName.getValue().getSHA1().equals(ObjectId.fromString(scmRevisionHash))) {
+                                addGitLabBranchBuild(result, scmRevisionHash, buildData.getRemoteUrls(), environment, gitLabClient);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Like #1146 it looks like that in some cases the scm build data can also return a NPE which failed all of our builds.
