### PR TITLE
Fix access denied on test connection of a job for non admin users

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
@@ -135,7 +135,7 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
         @Restricted(DoNotUse.class)
         public FormValidation doTestConnection(@QueryParameter String jobCredentialId,
                 @QueryParameter String gitLabConnection, @AncestorInPath Item item) {
-        	Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER);
+            item.checkPermission(Jenkins.READ);
             try {
                 GitLabConnection gitLabConnectionTested = null;
                 GitLabConnectionConfig descriptor = (GitLabConnectionConfig) Jenkins.getInstance()


### PR DESCRIPTION
Fix "Access Denied" error message when non admin user click on "Test Connection" button for the Gitlab connection on a Job.
