### PR TITLE
Respect GitLab's delete source branch checkbox

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClient.java
@@ -26,7 +26,7 @@ public interface GitLabClient {
 
     void getCommit(String projectId, String sha);
 
-    void acceptMergeRequest(MergeRequest mr, String mergeCommitMessage, boolean shouldRemoveSourceBranch);
+    void acceptMergeRequest(MergeRequest mr, String mergeCommitMessage, Boolean shouldRemoveSourceBranch);
 
     void createMergeRequestNote(MergeRequest mr, String body);
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
@@ -140,7 +140,7 @@ final class AutodetectingGitLabClient implements GitLabClient {
     }
 
     @Override
-    public void acceptMergeRequest(final MergeRequest mr, final String mergeCommitMessage, final boolean shouldRemoveSourceBranch) {
+    public void acceptMergeRequest(final MergeRequest mr, final String mergeCommitMessage, final Boolean shouldRemoveSourceBranch) {
         execute(
             new GitLabOperation<Void>() {
                 @Override

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/GitLabApiProxy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/GitLabApiProxy.java
@@ -26,7 +26,7 @@ interface GitLabApiProxy {
 
     void getCommit(String projectId, String sha);
 
-    void acceptMergeRequest(Integer projectId, Integer mergeRequestId, String mergeCommitMessage, boolean shouldRemoveSourceBranch);
+    void acceptMergeRequest(Integer projectId, Integer mergeRequestId, String mergeCommitMessage, Boolean shouldRemoveSourceBranch);
 
     void createMergeRequestNote(Integer projectId, Integer mergeRequestId, String body);
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClient.java
@@ -71,7 +71,7 @@ final class ResteasyGitLabClient implements GitLabClient {
     }
 
     @Override
-    public void acceptMergeRequest(MergeRequest mr, String mergeCommitMessage, boolean shouldRemoveSourceBranch) {
+    public void acceptMergeRequest(MergeRequest mr, String mergeCommitMessage, Boolean shouldRemoveSourceBranch) {
         api.acceptMergeRequest(mr.getProjectId(), mergeRequestIdProvider.apply(mr), mergeCommitMessage, shouldRemoveSourceBranch);
     }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V3GitLabApiProxy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V3GitLabApiProxy.java
@@ -119,7 +119,7 @@ interface V3GitLabApiProxy extends GitLabApiProxy {
     void acceptMergeRequest(@PathParam("projectId") @Encoded Integer projectId,
                             @PathParam("mergeRequestId") @Encoded Integer mergeRequestId,
                             @FormParam("merge_commit_message") String mergeCommitMessage,
-                            @FormParam("should_remove_source_branch") boolean shouldRemoveSourceBranch);
+                            @FormParam("should_remove_source_branch") Boolean shouldRemoveSourceBranch);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V4GitLabApiProxy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V4GitLabApiProxy.java
@@ -119,7 +119,7 @@ interface V4GitLabApiProxy extends GitLabApiProxy {
     void acceptMergeRequest(@PathParam("projectId") @Encoded Integer projectId,
                             @PathParam("mergeRequestIid") @Encoded Integer mergeRequestIid,
                             @FormParam("merge_commit_message") String mergeCommitMessage,
-                            @FormParam("should_remove_source_branch") boolean shouldRemoveSourceBranch);
+                            @FormParam("should_remove_source_branch") Boolean shouldRemoveSourceBranch);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabAcceptMergeRequestPublisher.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabAcceptMergeRequestPublisher.java
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
 public class GitLabAcceptMergeRequestPublisher extends MergeRequestNotifier {
     private static final Logger LOGGER = Logger.getLogger(GitLabAcceptMergeRequestPublisher.class.getName());
 
-    private boolean deleteSourceBranch = false;
+    private Boolean deleteSourceBranch;
 
     @DataBoundConstructor
     public GitLabAcceptMergeRequestPublisher() {

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/AcceptGitLabMergeRequestStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/AcceptGitLabMergeRequestStep.java
@@ -38,14 +38,17 @@ public class AcceptGitLabMergeRequestStep extends Step {
 
 	private boolean useMRDescription;
 
-	private boolean removeSourceBranch;
+	private Boolean removeSourceBranch;
 
-    @DataBoundConstructor
+    @Deprecated
     public AcceptGitLabMergeRequestStep(String mergeCommitMessage,boolean useMRDescription, boolean removeSourceBranch) {
 		this.mergeCommitMessage = StringUtils.isEmpty(mergeCommitMessage) ? null : mergeCommitMessage;
         this.useMRDescription = useMRDescription;
         this.removeSourceBranch = removeSourceBranch;
     }
+
+    @DataBoundConstructor
+    public AcceptGitLabMergeRequestStep() {}
 
 	@Override
 	public StepExecution start(StepContext context) throws Exception {

--- a/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabClientStub.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabClientStub.java
@@ -123,7 +123,7 @@ class GitLabClientStub implements GitLabClient {
     }
 
     @Override
-    public void acceptMergeRequest(MergeRequest mr, String mergeCommitMessage, boolean shouldRemoveSourceBranch) {
+    public void acceptMergeRequest(MergeRequest mr, String mergeCommitMessage, Boolean shouldRemoveSourceBranch) {
 
     }
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/util/GitLabClientStub.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/util/GitLabClientStub.java
@@ -70,7 +70,7 @@ class GitLabClientStub implements GitLabClient {
     }
 
     @Override
-    public void acceptMergeRequest(MergeRequest mr, String mergeCommitMessage, boolean shouldRemoveSourceBranch) {
+    public void acceptMergeRequest(MergeRequest mr, String mergeCommitMessage, Boolean shouldRemoveSourceBranch) {
 
     }
 


### PR DESCRIPTION
Currently, `acceptGitLabMR` passes `false` to GitLab's API for `should_remove_source_branch` unless otherwise specified. This change makes it specify `null` instead, which means that unless it is specified, it will respect the checkbox in the GitLab UI for removing the source branch after merge.