### PR TITLE
Upgrade Docker in GitLab

### DIFF
--- a/src/docker/README.md
+++ b/src/docker/README.md
@@ -14,13 +14,13 @@ To start the containers, run `docker-compose up -d` from the `docker` folder. If
 
 ## Access GitLab
 
-To access `GitLab`, point your browser to `http://localhost:10080` and set a password for the `root` user account. Then create a user for Jenkins, impersonate that user, get its API key, set up test repos, etc. When creating webhooks to trigger Jenkins jobs, use `http://jenkins:8080` as the base URL.
+To access `GitLab`, point your browser to `http://localhost:10080` and log in with `root` as the username and `password` as the password. Then create a user for Jenkins, impersonate that user, get its API key, set up test repos, etc. When creating webhooks to trigger Jenkins jobs, use `http://jenkins:8080` as the base URL.
 
-For more information on the supported `GitLab` versions and how to configure the containers, visit Sameer Naik's github page at https://github.com/sameersbn/docker-gitlab.
+If you have trouble cloning a GitLab repository, it may be because you have a leftover host key from an SSH connection to a previous installation of GitLab in Docker. To troubleshoot, run `ssh -vT git@localhost -p 10022`.
 
 ## Access Jenkins
 
-To see `Jenkins`, point your browser to `http://localhost:8080`. Jenkins will be able to access GitLab at `http://gitlab`
+To see `Jenkins`, point your browser to `http://localhost:8080`. Jenkins will be able to access GitLab at `http://gitlab`.
 Note: you need to change the security settings in `Admin -> Settings -> Network -> Outbound Requests -> Allow requests to the local network from hooks and services` in order for local webhooks to work.
 
 For more information on the supported `Jenkins` tags and how to configure the containers, visit https://hub.docker.com/r/jenkins/jenkins/.

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -1,92 +1,22 @@
-version: '2'
+version: '3'
 
 services:
-  postgresql:
-    restart: "no"
-    image: sameersbn/postgresql:9.6-2
-    ports:
-      - "5432:5432"
-    environment:
-      - DB_USER=gitlab
-      - DB_PASS=password
-      - DB_NAME=gitlabhq_production
-      - DB_EXTENSION=pg_trgm
-    volumes:
-      - /srv/docker/gitlab/postgresql:/var/lib/postgresql
-
   gitlab:
+    image: 'gitlab/gitlab-ce:14.7.0-ce.0'
     restart: "no"
-    image: sameersbn/gitlab:11.0.3
-    depends_on:
-      - redis
-      - postgresql
+    hostname: 'localhost'
     ports:
-      - "10080:80"
-      - "10022:22"
+      - '10080:80'
+      - '10022:22'
+    volumes:
+      - '/srv/docker/gitlab/config:/etc/gitlab'
+      - '/srv/docker/gitlab/logs:/var/log/gitlab'
+      - '/srv/docker/gitlab/data:/var/opt/gitlab'
     environment:
-      - DEBUG=false
-
-      - DB_ADAPTER=postgresql
-      - DB_HOST=postgresql
-      - DB_PORT=5432
-      - DB_USER=gitlab
-      - DB_PASS=password
-      - DB_NAME=gitlabhq_production
-
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-
-      - TZ=Asia/Kolkata
-      - GITLAB_TIMEZONE=Kolkata
-
-      - GITLAB_HTTPS=false
-      - SSL_SELF_SIGNED=false
-
-      - GITLAB_HOST=localhost
-      - GITLAB_PORT=10080
-      - GITLAB_SSH_PORT=10022
-      - GITLAB_RELATIVE_URL_ROOT=
-      - GITLAB_SECRETS_DB_KEY_BASE=long-and-random-alpha-numeric-string
-      - GITLAB_SECRETS_SECRET_KEY_BASE=long-and-random-alphanumeric-string
-      - GITLAB_SECRETS_OTP_KEY_BASE=long-and-random-alpha-numeric-string
-
-      - GITLAB_ROOT_PASSWORD=
-      - GITLAB_ROOT_EMAIL=
-
-      - GITLAB_NOTIFY_ON_BROKEN_BUILDS=true
-      - GITLAB_NOTIFY_PUSHER=false
-
-      - GITLAB_EMAIL=notifications@example.com
-      - GITLAB_EMAIL_REPLY_TO=noreply@example.com
-      - GITLAB_INCOMING_EMAIL_ADDRESS=reply@example.com
-
-      - GITLAB_BACKUP_SCHEDULE=daily
-      - GITLAB_BACKUP_TIME=01:00
-
-      - SMTP_ENABLED=false
-      - SMTP_DOMAIN=www.example.com
-      - SMTP_HOST=smtp.gmail.com
-      - SMTP_PORT=587
-      - SMTP_USER=mailer@example.com
-      - SMTP_PASS=password
-      - SMTP_STARTTLS=true
-      - SMTP_AUTHENTICATION=login
-
-      - IMAP_ENABLED=false
-      - IMAP_HOST=imap.gmail.com
-      - IMAP_PORT=993
-      - IMAP_USER=mailer@example.com
-      - IMAP_PASS=password
-      - IMAP_SSL=true
-      - IMAP_STARTTLS=false
-    volumes:
-      - /srv/docker/gitlab/gitlab:/home/git/data
-
-  redis:
-    restart: "no"
-    image: sameersbn/redis:latest
-    volumes:
-      - /srv/docker/gitlab/redis:/var/lib/redis
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url 'http://localhost'
+        gitlab_rails['gitlab_shell_ssh_port'] = 10022
+        gitlab_rails['initial_root_password'] = 'password'
 
   jenkins:
     restart: "no"


### PR DESCRIPTION
Closes #1232 

Upgrade to the latest GitLab Omnibus Docker. This ensures that we can test the plugin against a modern version of GitLab, and also substantially simplifies the docker-compose setup.