### PR TITLE
Merge back SECURITY-2753 security fix into default branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
     <relativePath />
   </parent>
   <artifactId>gitlab-plugin</artifactId>
-  <version>1.5.32</version>
+  <version>${revision}${changelist}</version>
   <name>GitLab Plugin</name>
   <url>https://github.com/jenkinsci/${project.artifactId}</url>
   <packaging>hpi</packaging>
 
   <properties>
-    <revision>1.5.32</revision>
+    <revision>1.5.33</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.289.3</jenkins.version>
     <spotbugs.failOnError>false</spotbugs.failOnError>
@@ -56,7 +56,7 @@
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
-    <tag>gitlab-plugin-1.5.32</tag>
+    <tag>${scmTag}</tag>
   </scm>
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <relativePath />
   </parent>
   <artifactId>gitlab-plugin</artifactId>
-  <version>${revision}${changelist}</version>
+  <version>1.5.32</version>
   <name>GitLab Plugin</name>
   <url>https://github.com/jenkinsci/${project.artifactId}</url>
   <packaging>hpi</packaging>
@@ -56,7 +56,7 @@
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
-    <tag>${scmTag}</tag>
+    <tag>gitlab-plugin-1.5.32</tag>
   </scm>
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
   <repositories>

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
@@ -1,6 +1,7 @@
 package com.dabsquared.gitlabjenkins.connection;
 
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
@@ -125,6 +126,15 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
         public ListBoxModel doFillJobCredentialIdItems(@AncestorInPath Item item, @QueryParameter String url,
                 @QueryParameter String jobCredentialId) {
             StandardListBoxModel result = new StandardListBoxModel();
+            if (item == null) {
+                if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                  return result.includeCurrentValue(jobCredentialId);
+                }
+            } else {
+                if (!item.hasPermission(Item.EXTENDED_READ) && !item.hasPermission(CredentialsProvider.USE_ITEM)) {
+                    return result.includeCurrentValue(jobCredentialId);
+                }
+            }
             return result.includeEmptyValue()
                     .includeMatchingAs(ACL.SYSTEM, item, StandardCredentials.class,
                             URIRequirementBuilder.fromUri(url).build(), new GitLabCredentialMatcher())


### PR DESCRIPTION
https://www.jenkins.io/security/advisory/2022-05-17/#SECURITY-2753

I recommend merging this PR using merge commit, so that the 1.5.32 release commits are on the default branch's history.