### PR TITLE
Remove JSR-305 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,11 +153,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>display-url-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-    </dependency>
 
 
     <!-- REST client dependencies -->


### PR DESCRIPTION
## Remove JSR-305 dependency

Jenkins 2.231 removed JSR-305 from the core so that it could be removed from use in Jenkins.

https://issues.jenkins.io/browse/JENKINS-55973 provides history of the change and the transition to use the spotbugs annotations instead of the JSR-305 annotations.  Since this plugin requires Jenkins 2.289.3 or newer, it can rely on the spotbugs annotations being available.
