### PR TITLE
Require Jenkins 2.346.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,6 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.11.0</version>
       </dependency>
       <dependency>
         <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->

--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,6 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.36</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -141,11 +141,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>display-url-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-    </dependency>
 
 
     <!-- REST client dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,6 @@
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
-        <version>9.3</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
         <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.346.x</artifactId>
-        <version>1670.v7f165fc7a_079</version>
+        <version>1678.vc1feb_6a_3c0f1</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
@@ -21,7 +21,7 @@ import net.sf.json.JSONObject;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 
-import org.antlr.v4.runtime.misc.NotNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -84,7 +84,7 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
         return null;
     }
 
-    public static GitLabClient getClient(@NotNull Run<?, ?> build) {
+    public static GitLabClient getClient(@NonNull Run<?, ?> build) {
         Job<?, ?> job = build.getParent();
         if (job != null) {
             final GitLabConnectionProperty connectionProperty = job.getProperty(GitLabConnectionProperty.class);


### PR DESCRIPTION
## Require Jenkins 2.346.3 or newer

85% of users running one of the last two versions are using Jenkins 2.346.1 or newer.  Require Jenkins 2.346.3 or newer to reduce the maintenance load and narrow the testing.

- Remove jsr305 unnecessary dependency
- Get commons-io version from plugin bom
- Get asm version from plugin bom
- Get slf4j-api version from plugin bom
- Use latest bom release
