### PR TITLE
Fix compilation against 2.372+

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -551,9 +551,9 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     public static GitLabPushTrigger getFromJob(Job<?, ?> job) {
         GitLabPushTrigger trigger = null;
         if (job instanceof ParameterizedJobMixIn.ParameterizedJob) {
-            ParameterizedJobMixIn.ParameterizedJob p = (ParameterizedJobMixIn.ParameterizedJob) job;
-            Collection<Trigger> triggerList = p.getTriggers().values();
-            for (Trigger t : triggerList) {
+            ParameterizedJobMixIn.ParameterizedJob<?, ?> p = (ParameterizedJobMixIn.ParameterizedJob) job;
+            Collection<Trigger<?>> triggerList = p.getTriggers().values();
+            for (Trigger<?> t : triggerList) {
                 if (t instanceof GitLabPushTrigger) {
                     trigger = (GitLabPushTrigger) t;
                 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
@@ -57,10 +57,10 @@ class OpenMergeRequestPushHookTriggerHandler implements PushHookTriggerHandler {
     public void handle(Job<?, ?> job, PushHook hook, boolean ciSkip, BranchFilter branchFilter, MergeRequestLabelFilter mergeRequestLabelFilter) {
     	try {
             if (job instanceof ParameterizedJobMixIn.ParameterizedJob) {
-                ParameterizedJob project = (ParameterizedJobMixIn.ParameterizedJob) job;
+                ParameterizedJob<?, ?> project = (ParameterizedJobMixIn.ParameterizedJob) job;
                 GitLabConnectionProperty property = job.getProperty(GitLabConnectionProperty.class);
-                Collection<Trigger> triggerList = project.getTriggers().values();
-                for (Trigger t : triggerList) {
+                Collection<Trigger<?>> triggerList = project.getTriggers().values();
+                for (Trigger<?> t : triggerList) {
                 	if (t instanceof GitLabPushTrigger) {
                 		final GitLabPushTrigger trigger = (GitLabPushTrigger) t;
                         Integer projectId = hook.getProjectId();


### PR DESCRIPTION
https://github.com/jenkinsci/bom/pull/1479#issuecomment-1311694971 https://github.com/jenkinsci/jenkins/pull/7131 somehow causes what was previously some `unchecked` & `rawtypes` warnings to be fatal