### PR TITLE
Test more versions of Jenkins core

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,11 @@
  * See the documentation for more options:
  * https://github.com/jenkins-infra/pipeline-library/
  */
-buildPlugin(useContainerAgent: true)
+buildPlugin(useContainerAgent: true,
+            configurations: [
+                [platform: 'linux',   jdk: '17', jenkins: '2.375'],
+                [platform: 'linux',   jdk: '11', jenkins: '2.361.3'],
+                [platform: 'windows', jdk:  '8']
+            ]
+
+)

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <revision>1.5.37</revision>
+    <revision>1.6.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.346.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>


### PR DESCRIPTION
## Test more versions of Jenkins core

- Test with Jenkins 2.361.3 (Java 11) and 2.375 (Java 17)
- Fix Jenkins 2.375 compile failure
