### PR TITLE
Remove unneeded spotbugs exclusions

### DIFF
--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -109,12 +109,6 @@
     <Field name="builds"/>
   </Match>
   <Match>
-    <Bug pattern="EI_EXPOSE_REP"/>
-  </Match>
-  <Match>
-    <Bug pattern="EI_EXPOSE_REP2"/>
-  </Match>
-  <Match>
     <Bug pattern="NM_CONFUSING"/>
   </Match>
   <Match>


### PR DESCRIPTION
## Remove unused spotbugs exclusions

Spotbugs has improved their detectors in the last two months.  These are no longer raised as warnings.
