### PR TITLE
Enable Java cache in security scan

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -2,13 +2,12 @@
 # For more information, see: https://www.jenkins.io/doc/developer/security/scan/
 
 name: Jenkins Security Scan
-
 on:
   push:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
   workflow_dispatch:
 
 permissions:
@@ -20,5 +19,5 @@ jobs:
   security-scan:
     uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
-      java-cache: 'maven'
-      java-version: 11
+      java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
+      java-version: 11 # What version of Java to set up for the build.


### PR DESCRIPTION
## Enable Java cache in security scan

Reduce load on repo.jenkins-ci.org.  Also adds consistent comments and content formatting with other plugins that I maintain.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
