### PR TITLE
Fix NullPointerException in GitLabCommitStatusStep Bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
     <mockserver.version>5.15.0</mockserver.version>
   </properties>
 
-
   <licenses>
     <license>
       <name>GPL v2.0 License</name>

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep.java
@@ -100,21 +100,23 @@ public class GitLabCommitStatusStep extends Step {
 
                     @Override
                     public void onSuccess(StepContext context, Object result) {
-                        CommitStatusUpdater.updateCommitStatus(run, getTaskListener(context), BuildState.success, name,  step.builds, step.connection);
+                        CommitStatusUpdater.updateCommitStatus(run, getTaskListener(context), BuildState.success, name, step.builds, step.connection);
                         context.onSuccess(result);
                     }
 
                     @Override
                     public void onFailure(StepContext context, Throwable t) {
                         BuildState state = BuildState.failed;
-                        if (t instanceof FlowInterruptedException) {
-                            FlowInterruptedException ex = (FlowInterruptedException) t;
-                            if (ex.isActualInterruption()) {
-                                state = BuildState.canceled;
+                        if (!t.getMessage().isBlank()) {
+                            if (t instanceof FlowInterruptedException) {
+                                FlowInterruptedException ex = (FlowInterruptedException) t;
+                                if (ex.isActualInterruption()) {
+                                    state = BuildState.canceled;
+                                }
                             }
                         }
 
-                        CommitStatusUpdater.updateCommitStatus(run, getTaskListener(context), state, name,  step.builds, step.connection);
+                        CommitStatusUpdater.updateCommitStatus(run, getTaskListener(context), state, name, step.builds, step.connection);
                         context.onFailure(t);
                     }
                 })


### PR DESCRIPTION
<!--### Before submitting a pull request, please make sure you read the instructions in the ["Contribution to the Plugin"](https://github.com/jenkinsci/gitlab-plugin/tree/master#contributing-to-the-plugin) section in the README.

*(if you read the above instructions, remove the paragraph and start describing the pull request)*-->

Fixes #1030. 

## Description
Use an if statement to make sure the outcome of `t instanceof FlowInterruptedException` is not null at https://github.com/jenkinsci/gitlab-plugin/blob/4edb6c1a15897be9a737f127a570a051a2ee56cd/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep.java#L110
