### PR TITLE
Rely on artifact caching proxy default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,9 +6,6 @@ buildPlugin(
   useContainerAgent: true,
   // Show failures on all configurations
   failFast: false,
-  // Opt-in to the Artifact Caching Proxy, to be removed when it will be in opt-out.
-  // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
-  artifactCachingProxyEnabled: true,
   // Test Java 11 with a recent LTS, Java 17 on Windows (not ready to test newer LTS versions)
   configurations: [
     [platform: 'linux',   jdk: '11'], // Linux first for coverage report on ci.jenkins.io


### PR DESCRIPTION
## Rely on artifact caching proxy default

Artifact caching proxy is now enabled by default.
