### PR TITLE
Revert changes to Jenkins version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <revision>1.7.2</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.375.2</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
@@ -141,7 +141,6 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
     </dependency>
-
 
     <!-- REST client dependencies -->
     <dependency>


### PR DESCRIPTION
<!--### Before submitting a pull request, please make sure you read the instructions in the ["Contribution to the Plugin"](https://github.com/jenkinsci/gitlab-plugin/tree/master#contributing-to-the-plugin) section in the README.

*(if you read the above instructions, remove the paragraph and start describing the pull request)*-->

## Description
Reverse unintended Jenkins version change to LTS `2.375.2`. 
