### PR TITLE
3rd attempt at patching NullPointerException bug in GitLabCommitStatusStep

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -56,7 +56,9 @@ public class CommitStatusUpdater {
 
         if (gitLabBranchBuilds == null || gitLabBranchBuilds.isEmpty()) {
             try {
-                gitLabBranchBuilds = retrieveGitlabProjectIds(build, build.getEnvironment(listener));
+                if (!build.getEnvironment(listener).isEmpty()) {
+                    gitLabBranchBuilds = retrieveGitlabProjectIds(build, build.getEnvironment(listener));
+                }
             } catch (IOException | InterruptedException e) {
                 printf(listener, "Failed to get Gitlab Build list to update status: %s%n", e.getMessage());
             }

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep.java
@@ -100,8 +100,10 @@ public class GitLabCommitStatusStep extends Step {
 
                     @Override
                     public void onSuccess(StepContext context, Object result) {
-                        CommitStatusUpdater.updateCommitStatus(run, getTaskListener(context), BuildState.success, name, step.builds, step.connection);
-                        context.onSuccess(result);
+                        if (context.hasBody()) {
+                            CommitStatusUpdater.updateCommitStatus(run, getTaskListener(context), BuildState.success, name, step.builds, step.connection);
+                            context.onSuccess(result);
+                        }
                     }
 
                     @Override


### PR DESCRIPTION
<!--### Before submitting a pull request, please make sure you read the instructions in the ["Contribution to the Plugin"](https://github.com/jenkinsci/gitlab-plugin/tree/master#contributing-to-the-plugin) section in the README.

*(if you read the above instructions, remove the paragraph and start describing the pull request)*-->
Fixes #1030.

## Description
To add conditional checking to `src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java` and `src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStep.java` to try and see if Null Pointer Exception bugs go away at least for `onSuccess()`.
