### PR TITLE
Added quick test environment setup instructions for macos.

### DIFF
--- a/src/docker/README.md
+++ b/src/docker/README.md
@@ -1,8 +1,7 @@
-# Quick test environment setup using Docker
-
 In order to test the plugin on different versions of `GitLab` and `Jenkins` you may want to use `Docker` containers.
+# Quick test environment setup using Docker for Linux/amd64
 
-A example docker-compose file is available at `gitlab-plugin/src/docker` which allows to set up instances of the latest `GitLab` and `Jenkins` versions.
+An example docker-compose file is available at `gitlab-plugin/src/docker` which allows to set up instances of the latest `GitLab` and `Jenkins` versions for linux/amd64. 
 
 If they don't already exist, create the following directories and make sure the user that Docker is running as owns them:
 * /srv/docker/gitlab/postgresql
@@ -10,17 +9,46 @@ If they don't already exist, create the following directories and make sure the 
 * /srv/docker/gitlab/redis
 * /srv/docker/jenkins
 
-To start the containers, run `docker-compose up -d` from the `docker` folder. If you have problems accessing the services in the containers, run `docker-compose up` by itself to see output from the services as they start.
+## Quick test environment setup using Docker for MacOS/arm64
+
+You need to modify the example docker-compose file available at `gitlab-plugin/src/docker` to set up instances of the latest `GitLab` and `Jenkins` versions for MacOS/arm64. 
+
+Due to Apple's System Integrity Protection, you need to use the home directory as a root for the new directories to be created.
+
+In the `docker-compose.yml` file :
+    1. Change the ports to 
+      - '55580:80'
+      - '55522:22'
+      - '55443:443'
+      as the browser may block the ports in original docker-compose file.
+    2. Change the gitlab volumes to 
+        `/Users/yourusername/srv/docker/gitlab/config:/etc/gitlab`
+        `/Users/yourusername/srv/docker/gitlab/logs:/var/log/gitlab`
+        `/Users/yourusername/srv/docker/gitlab/data:/var/opt/gitlab`
+    3. Change the jenkins volumes to 
+        `/Users/yourusername/srv/docker/jenkins:/var/jenkins_home`
+    4. In your Docker-Desktop go to `Settings > General > Choose file sharing   implementation for your containers` and switch to osxfs(Legacy). osxfs(Legacy) utilizes more resources of the system so make sure that the assigned resources are sufficient by going to `Settings > Resources` otherwise Docker-Desktop may go to forever start mode on Restarting.
+    5. Add `shm_size: '5gb'`under gitlab services.
+
+Now for both Linux/MacOS users to start the containers, run `docker-compose up -d` from the `docker` folder. If you have problems accessing the services in the containers, run `docker-compose up` by itself to see output from the services as they start.
 
 ## Access GitLab
 
-To access `GitLab`, point your browser to `http://localhost:10080` and log in with `root` as the username and `password` as the password. Then create a user for Jenkins, impersonate that user, get its API key, set up test repos, etc. When creating webhooks to trigger Jenkins jobs, use `http://jenkins:8080` as the base URL.
+To access `GitLab`, you first need to create a user - `root` with some password. To do so, follow the following steps :
+    1. In the Gitlab containers terminal inside Docker Desktop, type `gitlab-rails console` and wait for atleast 5 minutes for the console to start. 
+    2. Once the console is started successfully, type the following commands:
+        a. `user = User.new(username: 'root', email: 'root@root.com', name: 'root', password: 'setyourown', password_confirmation: 'setyourown')`
+        b. `user.skip_confirmation!` 
+        c. `user.save!`
+    3. Now, point your browser to `http://localhost:port` and log in with `root` as the username and `setyourown` as the password. Then create a user for Jenkins, impersonate that user, get its API key, set up test repos, etc. When creating webhooks to trigger Jenkins jobs, use `http://jenkins:8080` as the base URL.
 
-If you have trouble cloning a GitLab repository, it may be because you have a leftover host key from an SSH connection to a previous installation of GitLab in Docker. To troubleshoot, run `ssh -vT git@localhost -p 10022`.
+
+If you have trouble cloning a GitLab repository, it may be because you have a leftover host key from an SSH connection to a previous installation of GitLab in Docker. To troubleshoot, run `ssh -vT git@localhost -p port`.
 
 ## Access Jenkins
 
 To see `Jenkins`, point your browser to `http://localhost:8080`. Jenkins will be able to access GitLab at `http://gitlab`.
+
 Note: you need to change the security settings in `Admin -> Settings -> Network -> Outbound Requests -> Allow requests to the local network from hooks and services` in order for local webhooks to work.
 
 For more information on the supported `Jenkins` tags and how to configure the containers, visit https://hub.docker.com/r/jenkins/jenkins/.


### PR DESCRIPTION
There was not much macOS-based content in the documentation for the Quick test environment setup using Docker. Thus, modified the README.md file, added the instructions.