### PR TITLE
Fix NPE bug in AbstractWebHookTriggerHandler for webhooks

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/AbstractWebHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/AbstractWebHookTriggerHandler.java
@@ -81,7 +81,7 @@ public abstract class AbstractWebHookTriggerHandler<H extends WebHook> implement
                 }
             }
         } catch (NullPointerException e) {
-            e.getMessage();
+            LOGGER.log(Level.WARNING, e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
Fixes #1088 by handling possible Null Pointer Exceptions due to a bug found in [src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/AbstractWebHookTriggerHandler.java](https://github.com/jenkinsci/gitlab-plugin/blob/2dadca288356162d95e4899edcfa6deaa2c2e3a2/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/AbstractWebHookTriggerHandler.java). 
