### PR TITLE
Bug fix: Remove non-functional "Use custom workspace" field from Freestyle project configuration form

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
   - [Cancel pending builds on merge request update](#cancel-pending-builds-on-merge-request-update)
 - [Compatibility](#compatibility)
 - [Contributing to the Plugin](#contributing-to-the-plugin)
-- [Testing With Docker](#testing-with-docker)
-- [Release Workflow](#release-workflow)
+- [Testing With Docker](src/docker/README.md#quick-test-environment-setup-using-docker-for-linuxamd64)
+- [Release Workflow](CONTRIBUTING.md#release-workflow)
 - [Changelog](#changelog)
 
 ## Introduction

--- a/src/docker/README.md
+++ b/src/docker/README.md
@@ -9,19 +9,19 @@ If they don't already exist, create the following directories and make sure the 
 * /srv/docker/gitlab/gitlab
 * /srv/docker/gitlab/redis
 * /srv/docker/jenkins
-To start the containers for Linux, run `docker-compose up -d` from the `docker` folder. If you have problems accessing the services in the containers, run `docker-compose up` by itself to see output from the services as they start, and the latter command is the verbose version of the former.
+To start the containers for Linux, run `docker-compose up -d` from the `src/docker` folder. If you have problems accessing the services in the containers, run `docker-compose up` by itself to see output from the services as they start, and the latter command is the verbose version of the former.
 
 ## Quick test environment setup using Docker for MacOS/arm64
 
-You need to modify the example docker-compose file available at `gitlab-plugin/src/docker` to set up instances of the latest `GitLab` and `Jenkins` versions for MacOS/arm64. 
+You need to modify the example docker-compose file available at `src/docker` to set up instances of the latest `GitLab` and `Jenkins` versions for MacOS/arm64. 
 
 Due to Apple's System Integrity Protection (SIP), the suggested paths cannot be simply created and accessed, so you may need to use the home directory (~) as a root for the new directories to be created.
 
 In the `docker-compose.yml` file:
+
 1. Change the ports to 
     - '55580:80'
     - '55522:22'
-    - '55443:443'
 as the browser may block the ports in original docker-compose file.
 2. Change the gitlab volumes to 
     `/Users/yourusername/srv/docker/gitlab/config:/etc/gitlab`
@@ -29,21 +29,15 @@ as the browser may block the ports in original docker-compose file.
     `/Users/yourusername/srv/docker/gitlab/data:/var/opt/gitlab`
 3. Change the jenkins volumes to 
     `/Users/yourusername/srv/docker/jenkins:/var/jenkins_home`
-4. In your Docker-Desktop go to `Settings > General > Choose file sharing implementation for your containers` and switch to osxfs (Legacy). As `osxfs (Legacy)` utilizes more resources of the system, make sure the assigned resources are sufficient by going to `Settings > Resources` and make suitable adjustments where necessary, otherwise Docker Desktop may go on start mode forever on restarting.
-5. Add `shm_size: '5gb'`under gitlab services.
+4. In your Docker-Desktop go to `Settings > General > Choose file sharing implementation for your containers` and switch to `osxfs (Legacy)`. As `osxfs (Legacy)` utilizes more resources of the system, make sure the assigned resources are sufficient by going to `Settings > Resources` and make suitable adjustments where necessary, otherwise Docker Desktop may go on start mode forever on restarting.
 
 Like the instructions for Linux, for macOS users to start the containers, run `docker-compose up -d` from the `docker` folder. If you have any problems accessing the services in the containers, run `docker-compose up` by itself to see output from the services as they start.
 
 ## Access GitLab
 
-To access `GitLab`, you first need to create a user - `root` with some password. To do so, follow the following steps :
-1. In the GitLab containers terminal inside Docker Desktop, type `gitlab-rails console` and wait for at least a few minutes for the console to start.
-2. Once the console is started successfully, run the following commands in sequence at the console, noting that there are certain security rules to the password choice:
-    a. `user = User.new(username: 'root', email: 'root@root.com', name: 'root', password: 'setyourown', password_confirmation: 'setyourown')`
-        b. `user.skip_confirmation!` 
-    c. `user.save!`
-3. Now, point your browser to `http://localhost:55580` and log in with `root` as the username and `setyourown` as the password. Then create a user for Jenkins, impersonate that user, get its API key, set up test repos, etc. When creating webhooks to trigger Jenkins jobs, use `http://jenkins:8080` as the base URL.
-
+To access `GitLab`, you first need to create a user - `root` with some password. To do so, follow the following steps:
+1. Point your browser to `http://localhost:55580` and log in with `root` as the username and `p@ssw0rd` as the password. 
+2. Then create a user for Jenkins, impersonate that user, get its API key, set up test repos, etc. When creating webhooks to trigger Jenkins jobs, use `http://jenkins:8080` as the base URL.
 
 If you have trouble cloning a GitLab repository, it may be because you have a leftover host key from an SSH connection to a previous installation of GitLab in Docker. To troubleshoot, run `ssh -vT git@localhost -p 55522`.
 

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -28,3 +28,4 @@ services:
       - "50000:50000"
     volumes:
       - '/srv/docker/jenkins:/var/jenkins_home'
+    shm_size: '5gb'

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -18,6 +18,7 @@ services:
         external_url 'http://localhost'
         gitlab_rails['gitlab_shell_ssh_port'] = 55522
         gitlab_rails['initial_root_password'] = 'p@ssw0rd'
+    shm_size: '5gb'
 
   jenkins:
     restart: "no"

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -5,10 +5,10 @@ services:
     image: 'gitlab/gitlab-ce:latest'
     restart: "no"
     hostname: 'localhost'
+    platform: 'linux/amd64'
     ports:
       - '55580:80'
       - '55522:22'
-      - '55443:443'
     volumes:
       - '/srv/docker/gitlab/config:/etc/gitlab'
       - '/srv/docker/gitlab/logs:/var/log/gitlab'
@@ -17,8 +17,7 @@ services:
       GITLAB_OMNIBUS_CONFIG: |
         external_url 'http://localhost'
         gitlab_rails['gitlab_shell_ssh_port'] = 55522
-        gitlab_rails['initial_root_password'] = 'password'
-    shm_size: '5gb'
+        gitlab_rails['initial_root_password'] = 'p@ssw0rd'
 
   jenkins:
     restart: "no"
@@ -27,4 +26,4 @@ services:
       - "8080:8080"
       - "50000:50000"
     volumes:
-      - /srv/docker/jenkins:/var/jenkins_home
+      - '/srv/docker/jenkins:/var/jenkins_home'

--- a/src/main/resources/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty/config.jelly
@@ -1,7 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form"
 	xmlns:c="/lib/credentials" xmlns:st="jelly:stapler">
-	<st:include page="configure-advanced.jelly" optional="true" />
 	<f:entry title="${%GitLab Connection}" field="gitLabConnection">
 		<f:select />
 	</f:entry>


### PR DESCRIPTION
<!--### Before submitting a pull request, please make sure you read the instructions in the ["Contribution to the Plugin"](https://github.com/jenkinsci/gitlab-plugin/tree/master#contributing-to-the-plugin) section in the README.

*(if you read the above instructions, remove the paragraph and start describing the pull request)*-->
Closes #1171. 

It was discovered that there is an extra "Use custom workspace" field introduced to the Freestyle projects configuration form by the GitLab plugin, and that only the "Use custom workspace" field wrapped by the ["Advanced" button](https://github.com/jenkinsci/jenkins/blob/677fbb2a81fa8e9a0bc37ad5eca56565612e1f2e/core/src/main/resources/hudson/model/AbstractProject/configure-common.jelly#L56) is functional. To fix this the non-functional "Use custom workspace" field is removed in this pull request. 


