### PR TITLE
Fix permission denied on test connection for non admin

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
@@ -145,7 +145,7 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
         @Restricted(DoNotUse.class)
         public FormValidation doTestConnection(@QueryParameter String jobCredentialId,
                 @QueryParameter String gitLabConnection, @AncestorInPath Item item) {
-        	Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER);
+            item.checkPermission(Jenkins.READ);
             try {
                 GitLabConnection gitLabConnectionTested = null;
                 GitLabConnectionConfig descriptor = (GitLabConnectionConfig) Jenkins.getInstance()


### PR DESCRIPTION
See #1198 
Fix "Access Denied" error message when non admin user click on "Test Connection" button for the Gitlab connection on a Job.