### PR TITLE
Notify the discreprency in the jenkins.io documentation and the information provided in plugin README

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ pipeline {
    [...]
 }
 ```
-
+Although it is mentioned on the documentation page of jenkins under section "updateGitlabCommitStatus" that the supported values by GitLab are ( pending, running, canceled, success, failed ) only. Using skipped as commit status will return HTTP 400 Bad Request because it is not supported by GitLab.
 If:
 1. You use the *"Merge When Pipeline Succeeds"* option for Merge Requests in GitLab, and
 2. Your Declarative Pipeline jobs have more than one stage, and


### PR DESCRIPTION
There was wrong information on the jenkins.io infra page so I have mentioned here that this should be considered as the source of truth for the commit status values.

Fixes #1411