### PR TITLE
Use upstream Spotless configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <version>4.59</version>
     <relativePath />
   </parent>
+
   <artifactId>gitlab-plugin</artifactId>
   <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
@@ -69,11 +70,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- depdendencies added to satisfy new requirements from enforcer plugin in plugin pom 4.55 -->
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-      </dependency>
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
@@ -83,7 +79,6 @@
   </dependencyManagement>
 
   <dependencies>
-    <!-- Jenkins dependencies -->
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>caffeine-api</artifactId>
@@ -99,6 +94,47 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jersey2-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <version>3.15.6.Final</version>
+      <exclusions>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>com.github.stephenc.jcip</groupId>
+          <artifactId>jcip-annotations</artifactId>
+        </exclusion>
+        <!-- Provided by javax-activation-api plugin -->
+        <exclusion>
+          <groupId>com.sun.activation</groupId>
+          <artifactId>jakarta.activation</artifactId>
+        </exclusion>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+        <!-- Provided by javax-activation-api plugin -->
+        <exclusion>
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
+        </exclusion>
+        <!-- Provided by jaxb plugin -->
+        <exclusion>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+        </exclusion>
+        <!-- Provided by apache-httpcomponents-client-4-api plugin -->
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -150,51 +186,6 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
     </dependency>
-
-    <!-- REST client dependencies -->
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-client</artifactId>
-      <version>3.15.6.Final</version>
-      <exclusions>
-        <!-- Provided by Jenkins core -->
-        <exclusion>
-          <groupId>com.github.stephenc.jcip</groupId>
-          <artifactId>jcip-annotations</artifactId>
-        </exclusion>
-        <!-- Provided by javax-activation-api plugin -->
-        <exclusion>
-          <groupId>com.sun.activation</groupId>
-          <artifactId>jakarta.activation</artifactId>
-        </exclusion>
-        <!-- Provided by Jenkins core -->
-        <exclusion>
-          <groupId>commons-codec</groupId>
-          <artifactId>commons-codec</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-        </exclusion>
-        <!-- Provided by javax-activation-api plugin -->
-        <exclusion>
-          <groupId>jakarta.activation</groupId>
-          <artifactId>jakarta.activation-api</artifactId>
-        </exclusion>
-        <!-- Provided by jaxb plugin -->
-        <exclusion>
-          <groupId>jakarta.xml.bind</groupId>
-          <artifactId>jakarta.xml.bind-api</artifactId>
-        </exclusion>
-        <!-- Provided by apache-httpcomponents-client-4-api plugin -->
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <!-- util dependencies -->
     <dependency>
       <groupId>net.karneim</groupId>
       <artifactId>pojobuilder</artifactId>
@@ -202,8 +193,6 @@
       <!-- 'provided' scope because this is only needed during compilation -->
       <scope>provided</scope>
     </dependency>
-
-    <!-- test dependencies -->
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
@@ -314,6 +303,7 @@
       </exclusions>
     </dependency>
   </dependencies>
+
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
   <repositories>
     <repository>
@@ -331,36 +321,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.36.0</version>
-        <configuration>
-          <!-- define a language-specific format -->
-          <java>
-            <!-- no need to specify files, inferred automatically -->
-            <endWithNewline />
-            <removeUnusedImports />
-          </java>
-          <pom>
-            <sortPom>
-              <encoding>${project.build.sourceEncoding}</encoding>
-              <lineSeparator>\n</lineSeparator>
-              <expandEmptyElements>false</expandEmptyElements>
-              <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
-            </sortPom>
-          </pom>
-        </configuration>
-        <executions>
-          <execution>
-            <!-- Runs in verify phase by default -->
-            <goals>
-              <!-- Can be disabled using -Dspotless.check.skip -->
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -1,5 +1,10 @@
 package com.dabsquared.gitlabjenkins;
 
+import static com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterConfig.BranchFilterConfigBuilder.branchFilterConfig;
+import static com.dabsquared.gitlabjenkins.trigger.handler.merge.MergeRequestHookTriggerHandlerFactory.newMergeRequestHookTriggerHandler;
+import static com.dabsquared.gitlabjenkins.trigger.handler.note.NoteHookTriggerHandlerFactory.newNoteHookTriggerHandler;
+import static com.dabsquared.gitlabjenkins.trigger.handler.pipeline.PipelineHookTriggerHandlerFactory.newPipelineHookTriggerHandler;
+import static com.dabsquared.gitlabjenkins.trigger.handler.push.PushHookTriggerHandlerFactory.newPushHookTriggerHandler;
 
 import com.dabsquared.gitlabjenkins.connection.GitLabConnection;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
@@ -41,6 +46,10 @@ import hudson.util.ListBoxModel;
 import hudson.util.ListBoxModel.Option;
 import hudson.util.Secret;
 import hudson.util.SequentialExecutionQueue;
+import java.io.IOException;
+import java.io.ObjectStreamException;
+import java.security.SecureRandom;
+import java.util.Collection;
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.triggers.SCMTriggerItem.SCMTriggerItems;
@@ -56,18 +65,6 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
-
-import java.io.IOException;
-import java.io.ObjectStreamException;
-import java.security.SecureRandom;
-import java.util.Collection;
-
-import static com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterConfig.BranchFilterConfigBuilder.branchFilterConfig;
-import static com.dabsquared.gitlabjenkins.trigger.handler.merge.MergeRequestHookTriggerHandlerFactory.newMergeRequestHookTriggerHandler;
-import static com.dabsquared.gitlabjenkins.trigger.handler.note.NoteHookTriggerHandlerFactory.newNoteHookTriggerHandler;
-import static com.dabsquared.gitlabjenkins.trigger.handler.pipeline.PipelineHookTriggerHandlerFactory.newPipelineHookTriggerHandler;
-import static com.dabsquared.gitlabjenkins.trigger.handler.push.PushHookTriggerHandlerFactory.newPushHookTriggerHandler;
-
 
 /**
  * Triggers a build when we receive a GitLab WebHook.
@@ -121,14 +118,35 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
      */
     @Deprecated
     @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-    public GitLabPushTrigger(boolean triggerOnPush, boolean triggerToBranchDeleteRequest, boolean triggerOnMergeRequest, boolean triggerOnlyIfNewCommitsPushed, boolean triggerOnAcceptedMergeRequest, boolean triggerOnClosedMergeRequest,
-    						 TriggerOpenMergeRequest triggerOpenMergeRequestOnPush, boolean triggerOnNoteRequest, String noteRegex,
-                             boolean skipWorkInProgressMergeRequest, boolean ciSkip, String labelsThatForcesBuildIfAdded,
-                             boolean setBuildDescription, boolean addNoteOnMergeRequest, boolean addCiMessage, boolean addVoteOnMergeRequest,
-                             boolean acceptMergeRequestOnSuccess, BranchFilterType branchFilterType,
-                             String includeBranchesSpec, String excludeBranchesSpec, String sourceBranchRegex, String targetBranchRegex,
-                             MergeRequestLabelFilterConfig mergeRequestLabelFilterConfig, String secretToken, boolean triggerOnPipelineEvent,
-                             boolean triggerOnApprovedMergeRequest, String pendingBuildName, boolean cancelPendingBuildsOnUpdate) {
+    public GitLabPushTrigger(
+            boolean triggerOnPush,
+            boolean triggerToBranchDeleteRequest,
+            boolean triggerOnMergeRequest,
+            boolean triggerOnlyIfNewCommitsPushed,
+            boolean triggerOnAcceptedMergeRequest,
+            boolean triggerOnClosedMergeRequest,
+            TriggerOpenMergeRequest triggerOpenMergeRequestOnPush,
+            boolean triggerOnNoteRequest,
+            String noteRegex,
+            boolean skipWorkInProgressMergeRequest,
+            boolean ciSkip,
+            String labelsThatForcesBuildIfAdded,
+            boolean setBuildDescription,
+            boolean addNoteOnMergeRequest,
+            boolean addCiMessage,
+            boolean addVoteOnMergeRequest,
+            boolean acceptMergeRequestOnSuccess,
+            BranchFilterType branchFilterType,
+            String includeBranchesSpec,
+            String excludeBranchesSpec,
+            String sourceBranchRegex,
+            String targetBranchRegex,
+            MergeRequestLabelFilterConfig mergeRequestLabelFilterConfig,
+            String secretToken,
+            boolean triggerOnPipelineEvent,
+            boolean triggerOnApprovedMergeRequest,
+            String pendingBuildName,
+            boolean cancelPendingBuildsOnUpdate) {
         this.triggerOnPush = triggerOnPush;
         this.triggerToBranchDeleteRequest = triggerToBranchDeleteRequest;
         this.triggerOnMergeRequest = triggerOnMergeRequest;
@@ -164,21 +182,24 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     }
 
     @DataBoundConstructor
-    public GitLabPushTrigger() { }
+    public GitLabPushTrigger() {}
 
     @Initializer(after = InitMilestone.JOB_LOADED)
     public static void migrateJobs() throws IOException {
         GitLabPushTrigger.DescriptorImpl oldConfig = Trigger.all().get(GitLabPushTrigger.DescriptorImpl.class);
         if (!oldConfig.jobsMigrated) {
-            GitLabConnectionConfig gitLabConfig = (GitLabConnectionConfig) Jenkins.getInstance().getDescriptor(GitLabConnectionConfig.class);
-            gitLabConfig.getConnections().add(new GitLabConnection(
-                oldConfig.gitlabHostUrl,
-                    oldConfig.gitlabHostUrl,
-                    oldConfig.gitlabApiToken,
-                "autodetect",
-                    oldConfig.ignoreCertificateErrors,
-                    10,
-                    10));
+            GitLabConnectionConfig gitLabConfig =
+                    (GitLabConnectionConfig) Jenkins.getInstance().getDescriptor(GitLabConnectionConfig.class);
+            gitLabConfig
+                    .getConnections()
+                    .add(new GitLabConnection(
+                            oldConfig.gitlabHostUrl,
+                            oldConfig.gitlabHostUrl,
+                            oldConfig.gitlabApiToken,
+                            "autodetect",
+                            oldConfig.ignoreCertificateErrors,
+                            10,
+                            10));
 
             String defaultConnectionName = gitLabConfig.getConnections().get(0).getName();
             for (AbstractProject<?, ?> project : Jenkins.getInstance().getAllItems(AbstractProject.class)) {
@@ -241,9 +262,9 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
 
     @Override
     public boolean isTriggerOnApprovedMergeRequest() {
-		return triggerOnApprovedMergeRequest;
-	}    
-    
+        return triggerOnApprovedMergeRequest;
+    }
+
     @Override
     public boolean isTriggerOnClosedMergeRequest() {
         return triggerOnClosedMergeRequest;
@@ -253,7 +274,9 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
         return triggerOnNoteRequest;
     }
 
-    public boolean getTriggerOnPipelineEvent() { return triggerOnPipelineEvent; }
+    public boolean getTriggerOnPipelineEvent() {
+        return triggerOnPipelineEvent;
+    }
 
     public String getNoteRegex() {
         return this.noteRegex == null ? "" : this.noteRegex;
@@ -328,7 +351,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     public void setTriggerToBranchDeleteRequest(boolean triggerToBranchDeleteRequest) {
         this.triggerToBranchDeleteRequest = triggerToBranchDeleteRequest;
     }
-    
+
     @DataBoundSetter
     public void setTriggerOnApprovedMergeRequest(boolean triggerOnApprovedMergeRequest) {
         this.triggerOnApprovedMergeRequest = triggerOnApprovedMergeRequest;
@@ -518,9 +541,13 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     }
 
     private void initializeTriggerHandler() {
-		mergeRequestHookTriggerHandler = newMergeRequestHookTriggerHandler(this);
+        mergeRequestHookTriggerHandler = newMergeRequestHookTriggerHandler(this);
         noteHookTriggerHandler = newNoteHookTriggerHandler(triggerOnNoteRequest, noteRegex);
-        pushHookTriggerHandler = newPushHookTriggerHandler(triggerOnPush,triggerToBranchDeleteRequest, triggerOpenMergeRequestOnPush, skipWorkInProgressMergeRequest);
+        pushHookTriggerHandler = newPushHookTriggerHandler(
+                triggerOnPush,
+                triggerToBranchDeleteRequest,
+                triggerOpenMergeRequestOnPush,
+                skipWorkInProgressMergeRequest);
         pipelineTriggerHandler = newPipelineHookTriggerHandler(triggerOnPipelineEvent);
     }
 
@@ -534,13 +561,16 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     }
 
     private void initializeMergeRequestLabelFilter() {
-        mergeRequestLabelFilter = MergeRequestLabelFilterFactory.newMergeRequestLabelFilter(mergeRequestLabelFilterConfig);
+        mergeRequestLabelFilter =
+                MergeRequestLabelFilterFactory.newMergeRequestLabelFilter(mergeRequestLabelFilterConfig);
     }
 
     @Override
     protected Object readResolve() throws ObjectStreamException {
         if (branchFilterType == null) {
-            branchFilterType = StringUtils.isNotBlank(branchFilterName) ? BranchFilterType.valueOf(branchFilterName) : BranchFilterType.All;
+            branchFilterType = StringUtils.isNotBlank(branchFilterName)
+                    ? BranchFilterType.valueOf(branchFilterName)
+                    : BranchFilterType.All;
         }
         initializeTriggerHandler();
         initializeBranchFilter();
@@ -566,7 +596,8 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     @Symbol("gitlab")
     public static class DescriptorImpl extends TriggerDescriptor {
 
-        private transient final SequentialExecutionQueue queue = new SequentialExecutionQueue(Jenkins.MasterComputer.threadPoolForRemoting);
+        private final transient SequentialExecutionQueue queue =
+                new SequentialExecutionQueue(Jenkins.MasterComputer.threadPoolForRemoting);
         private boolean jobsMigrated = false;
         private boolean jobsMigrated2 = false;
         private String gitlabApiToken;
@@ -589,7 +620,8 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
             Job<?, ?> project = retrieveCurrentJob();
             if (project != null) {
                 try {
-                    return "Build when a change is pushed to GitLab. GitLab webhook URL: " + retrieveProjectUrl(project);
+                    return "Build when a change is pushed to GitLab. GitLab webhook URL: "
+                            + retrieveProjectUrl(project);
                 } catch (IllegalStateException e) {
                     // nothing to do
                 }
@@ -602,7 +634,8 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
                     .append(Jenkins.getInstance().getRootUrl())
                     .append(GitLabWebHook.WEBHOOK_URL)
                     .append(retrieveParentUrl(project))
-                    .append('/').append(Util.rawEncode(project.getName()));
+                    .append('/')
+                    .append(Util.rawEncode(project.getName()));
         }
 
         private StringBuilder retrieveParentUrl(Item item) {
@@ -629,52 +662,66 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
             return super.configure(req, formData);
         }
 
-        public ListBoxModel doFillTriggerOpenMergeRequestOnPushItems(@QueryParameter String triggerOpenMergeRequestOnPush) {
-            return new ListBoxModel(new Option("Never", "never", triggerOpenMergeRequestOnPush.matches("never")),
+        public ListBoxModel doFillTriggerOpenMergeRequestOnPushItems(
+                @QueryParameter String triggerOpenMergeRequestOnPush) {
+            return new ListBoxModel(
+                    new Option("Never", "never", triggerOpenMergeRequestOnPush.matches("never")),
                     new Option("On push to source branch", "source", triggerOpenMergeRequestOnPush.matches("source")),
-                    new Option("On push to source or target branch", "both", triggerOpenMergeRequestOnPush.matches("both")));
+                    new Option(
+                            "On push to source or target branch",
+                            "both",
+                            triggerOpenMergeRequestOnPush.matches("both")));
         }
 
-        public AutoCompletionCandidates doAutoCompleteIncludeBranchesSpec(@AncestorInPath final Job<?, ?> job, @QueryParameter final String value) {
+        public AutoCompletionCandidates doAutoCompleteIncludeBranchesSpec(
+                @AncestorInPath final Job<?, ?> job, @QueryParameter final String value) {
             return ProjectBranchesProvider.instance().doAutoCompleteBranchesSpec(job, value);
         }
 
-        public AutoCompletionCandidates doAutoCompleteExcludeBranchesSpec(@AncestorInPath final Job<?, ?> job, @QueryParameter final String value) {
+        public AutoCompletionCandidates doAutoCompleteExcludeBranchesSpec(
+                @AncestorInPath final Job<?, ?> job, @QueryParameter final String value) {
             return ProjectBranchesProvider.instance().doAutoCompleteBranchesSpec(job, value);
         }
 
-        public FormValidation doCheckIncludeBranchesSpec(@AncestorInPath final Job<?, ?> project, @QueryParameter final String value) {
+        public FormValidation doCheckIncludeBranchesSpec(
+                @AncestorInPath final Job<?, ?> project, @QueryParameter final String value) {
             return ProjectBranchesProvider.instance().doCheckBranchesSpec(project, value);
         }
 
-        public FormValidation doCheckExcludeBranchesSpec(@AncestorInPath final Job<?, ?> project, @QueryParameter final String value) {
+        public FormValidation doCheckExcludeBranchesSpec(
+                @AncestorInPath final Job<?, ?> project, @QueryParameter final String value) {
             return ProjectBranchesProvider.instance().doCheckBranchesSpec(project, value);
         }
 
-        public AutoCompletionCandidates doAutoCompleteIncludeMergeRequestLabels(@AncestorInPath final Job<?, ?> job, @QueryParameter final String value) {
+        public AutoCompletionCandidates doAutoCompleteIncludeMergeRequestLabels(
+                @AncestorInPath final Job<?, ?> job, @QueryParameter final String value) {
             return ProjectLabelsProvider.instance().doAutoCompleteLabels(job, value);
         }
 
-        public AutoCompletionCandidates doAutoCompleteExcludeMergeRequestLabels(@AncestorInPath final Job<?, ?> job, @QueryParameter final String value) {
+        public AutoCompletionCandidates doAutoCompleteExcludeMergeRequestLabels(
+                @AncestorInPath final Job<?, ?> job, @QueryParameter final String value) {
             return ProjectLabelsProvider.instance().doAutoCompleteLabels(job, value);
         }
 
-        public FormValidation doCheckIncludeMergeRequestLabels(@AncestorInPath final Job<?, ?> project, @QueryParameter final String value) {
+        public FormValidation doCheckIncludeMergeRequestLabels(
+                @AncestorInPath final Job<?, ?> project, @QueryParameter final String value) {
             return ProjectLabelsProvider.instance().doCheckLabels(project, value);
         }
 
-        public FormValidation doCheckExcludeMergeRequestLabels(@AncestorInPath final Job<?, ?> project, @QueryParameter final String value) {
+        public FormValidation doCheckExcludeMergeRequestLabels(
+                @AncestorInPath final Job<?, ?> project, @QueryParameter final String value) {
             return ProjectLabelsProvider.instance().doCheckLabels(project, value);
         }
 
         public void doGenerateSecretToken(@AncestorInPath final Job<?, ?> project, StaplerResponse response) {
-            byte[] random = new byte[16];   // 16x8=128bit worth of randomness, since we use md5 digest as the API token
+            byte[] random = new byte[16]; // 16x8=128bit worth of randomness, since we use md5 digest as the API token
             RANDOM.nextBytes(random);
             String secretToken = Util.toHexString(random);
             response.setHeader("script", "document.getElementById('secretToken').value='" + secretToken + "'");
         }
 
-        public void doClearSecretToken(@AncestorInPath final Job<?, ?> project, StaplerResponse response) {;
+        public void doClearSecretToken(@AncestorInPath final Job<?, ?> project, StaplerResponse response) {
+            ;
             response.setHeader("script", "document.getElementById('secretToken').value=''");
         }
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
@@ -2,6 +2,7 @@ package com.dabsquared.gitlabjenkins.cause;
 
 import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
 import hudson.markup.EscapedMarkupFormatter;
+import java.util.*;
 import jenkins.model.Jenkins;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.StringUtils;
@@ -10,8 +11,6 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
-
-import java.util.*;
 
 /**
  * @author Robin Müller
@@ -63,13 +62,50 @@ public final class CauseData {
     private final String commentAuthor;
 
     @GeneratePojoBuilder(withFactoryMethod = "*")
-    CauseData(ActionType actionType, Integer sourceProjectId, Integer targetProjectId, String branch, String sourceBranch, String userName,
-              String userUsername, String userEmail, String sourceRepoHomepage, String sourceRepoName, String sourceNamespace, String sourceRepoUrl,
-              String sourceRepoSshUrl, String sourceRepoHttpUrl, String mergeRequestTitle, String mergeRequestDescription, Integer mergeRequestId,
-              Integer mergeRequestIid, Integer mergeRequestTargetProjectId, String targetBranch, String targetRepoName, String targetNamespace, String targetRepoSshUrl,
-              String targetRepoHttpUrl, String triggeredByUser, String before, String after, String lastCommit, String targetProjectUrl,
-              String triggerPhrase, String mergeRequestState, String mergedByUser, String mergeRequestAssignee, String ref, String isTag,
-	            String sha, String beforeSha, String status, String stages, String createdAt, String finishedAt, String buildDuration, String commentAuthor) {
+    CauseData(
+            ActionType actionType,
+            Integer sourceProjectId,
+            Integer targetProjectId,
+            String branch,
+            String sourceBranch,
+            String userName,
+            String userUsername,
+            String userEmail,
+            String sourceRepoHomepage,
+            String sourceRepoName,
+            String sourceNamespace,
+            String sourceRepoUrl,
+            String sourceRepoSshUrl,
+            String sourceRepoHttpUrl,
+            String mergeRequestTitle,
+            String mergeRequestDescription,
+            Integer mergeRequestId,
+            Integer mergeRequestIid,
+            Integer mergeRequestTargetProjectId,
+            String targetBranch,
+            String targetRepoName,
+            String targetNamespace,
+            String targetRepoSshUrl,
+            String targetRepoHttpUrl,
+            String triggeredByUser,
+            String before,
+            String after,
+            String lastCommit,
+            String targetProjectUrl,
+            String triggerPhrase,
+            String mergeRequestState,
+            String mergedByUser,
+            String mergeRequestAssignee,
+            String ref,
+            String isTag,
+            String sha,
+            String beforeSha,
+            String status,
+            String stages,
+            String createdAt,
+            String finishedAt,
+            String buildDuration,
+            String commentAuthor) {
         this.actionType = Objects.requireNonNull(actionType, "actionType must not be null.");
         this.sourceProjectId = Objects.requireNonNull(sourceProjectId, "sourceProjectId must not be null.");
         this.targetProjectId = Objects.requireNonNull(targetProjectId, "targetProjectId must not be null.");
@@ -134,7 +170,9 @@ public final class CauseData {
         variables.put("gitlabMergeRequestDescription", mergeRequestDescription);
         variables.put("gitlabMergeRequestId", mergeRequestId == null ? "" : mergeRequestId.toString());
         variables.put("gitlabMergeRequestIid", mergeRequestIid == null ? "" : mergeRequestIid.toString());
-        variables.put("gitlabMergeRequestTargetProjectId", mergeRequestTargetProjectId == null ? "" : mergeRequestTargetProjectId.toString());
+        variables.put(
+                "gitlabMergeRequestTargetProjectId",
+                mergeRequestTargetProjectId == null ? "" : mergeRequestTargetProjectId.toString());
         variables.put("gitlabMergeRequestLastCommit", lastCommit);
         variables.putIfNotNull("gitlabMergeRequestState", mergeRequestState);
         variables.putIfNotNull("gitlabMergedByUser", mergedByUser);
@@ -306,35 +344,54 @@ public final class CauseData {
     }
 
     @Exported
-    public String getRef() { return ref; }
+    public String getRef() {
+        return ref;
+    }
 
     @Exported
-    public String getIsTag() { return isTag; }
+    public String getIsTag() {
+        return isTag;
+    }
 
     @Exported
-    public String getSha() { return sha; }
+    public String getSha() {
+        return sha;
+    }
 
     @Exported
-    public String getBeforeSha() {return beforeSha; }
+    public String getBeforeSha() {
+        return beforeSha;
+    }
 
     @Exported
-    public String getStatus() { return status; }
+    public String getStatus() {
+        return status;
+    }
 
     @Exported
-    public String getStages() { return stages; }
+    public String getStages() {
+        return stages;
+    }
 
     @Exported
-    public String getCreatedAt() { return createdAt; }
+    public String getCreatedAt() {
+        return createdAt;
+    }
 
     @Exported
-    public String getFinishedAt() { return finishedAt; }
+    public String getFinishedAt() {
+        return finishedAt;
+    }
 
     @Exported
-    public String getBuildDuration() { return buildDuration; }
+    public String getBuildDuration() {
+        return buildDuration;
+    }
 
     @Exported
-    public String getCommentAuthor() { return commentAuthor; }
-
+    public String getCommentAuthor() {
+        return commentAuthor;
+    }
 
     String getShortDescription() {
         return actionType.getShortDescription(this);
@@ -342,27 +399,35 @@ public final class CauseData {
 
     @Exported
     public String getMergeRequestState() {
-		return mergeRequestState;
-	}
+        return mergeRequestState;
+    }
 
     @Exported
-	public String getMergedByUser() {
-		return mergedByUser;
-	}
+    public String getMergedByUser() {
+        return mergedByUser;
+    }
 
     @Exported
-	public String getMergeRequestAssignee() {
-		return mergeRequestAssignee;
-	}
+    public String getMergeRequestAssignee() {
+        return mergeRequestAssignee;
+    }
 
     @Exported
-	public MergeRequest getMergeRequest() {
+    public MergeRequest getMergeRequest() {
         if (mergeRequestId == null) {
             return null;
         }
 
-        return new MergeRequest(mergeRequestId, mergeRequestIid, sourceBranch, targetBranch, mergeRequestTitle,
-            sourceProjectId, targetProjectId, mergeRequestDescription, mergeRequestState);
+        return new MergeRequest(
+                mergeRequestId,
+                mergeRequestIid,
+                sourceBranch,
+                targetBranch,
+                mergeRequestTitle,
+                sourceProjectId,
+                targetProjectId,
+                mergeRequestDescription,
+                mergeRequestState);
     }
 
     @Override
@@ -375,145 +440,145 @@ public final class CauseData {
         }
         CauseData causeData = (CauseData) o;
         return new EqualsBuilder()
-            .append(actionType, causeData.actionType)
-            .append(sourceProjectId, causeData.sourceProjectId)
-            .append(targetProjectId, causeData.targetProjectId)
-            .append(branch, causeData.branch)
-            .append(sourceBranch, causeData.sourceBranch)
-            .append(userName, causeData.userName)
-            .append(userUsername, causeData.userUsername)
-            .append(userEmail, causeData.userEmail)
-            .append(sourceRepoHomepage, causeData.sourceRepoHomepage)
-            .append(sourceRepoName, causeData.sourceRepoName)
-            .append(sourceNamespace, causeData.sourceNamespace)
-            .append(sourceRepoUrl, causeData.sourceRepoUrl)
-            .append(sourceRepoSshUrl, causeData.sourceRepoSshUrl)
-            .append(sourceRepoHttpUrl, causeData.sourceRepoHttpUrl)
-            .append(mergeRequestTitle, causeData.mergeRequestTitle)
-            .append(mergeRequestDescription, causeData.mergeRequestDescription)
-            .append(mergeRequestId, causeData.mergeRequestId)
-            .append(mergeRequestIid, causeData.mergeRequestIid)
-            .append(mergeRequestState, causeData.mergeRequestState)
-            .append(mergedByUser, causeData.mergedByUser)
-            .append(mergeRequestAssignee, causeData.mergeRequestAssignee)
-            .append(mergeRequestTargetProjectId, causeData.mergeRequestTargetProjectId)
-            .append(targetBranch, causeData.targetBranch)
-            .append(targetRepoName, causeData.targetRepoName)
-            .append(targetNamespace, causeData.targetNamespace)
-            .append(targetRepoSshUrl, causeData.targetRepoSshUrl)
-            .append(targetRepoHttpUrl, causeData.targetRepoHttpUrl)
-            .append(triggeredByUser, causeData.triggeredByUser)
-            .append(before, causeData.before)
-            .append(after, causeData.after)
-            .append(lastCommit, causeData.lastCommit)
-            .append(targetProjectUrl, causeData.targetProjectUrl)
-            .append(ref, causeData.getRef())
-            .append(isTag, causeData.getIsTag())
-            .append(sha, causeData.getSha())
-            .append(beforeSha, causeData.getBeforeSha())
-            .append(status, causeData.getStatus())
-            .append(stages, causeData.getStages())
-            .append(createdAt, causeData.getCreatedAt())
-            .append(finishedAt, causeData.getFinishedAt())
-            .append(buildDuration, causeData.getBuildDuration())
-            .append(commentAuthor, causeData.getCommentAuthor())
-            .isEquals();
+                .append(actionType, causeData.actionType)
+                .append(sourceProjectId, causeData.sourceProjectId)
+                .append(targetProjectId, causeData.targetProjectId)
+                .append(branch, causeData.branch)
+                .append(sourceBranch, causeData.sourceBranch)
+                .append(userName, causeData.userName)
+                .append(userUsername, causeData.userUsername)
+                .append(userEmail, causeData.userEmail)
+                .append(sourceRepoHomepage, causeData.sourceRepoHomepage)
+                .append(sourceRepoName, causeData.sourceRepoName)
+                .append(sourceNamespace, causeData.sourceNamespace)
+                .append(sourceRepoUrl, causeData.sourceRepoUrl)
+                .append(sourceRepoSshUrl, causeData.sourceRepoSshUrl)
+                .append(sourceRepoHttpUrl, causeData.sourceRepoHttpUrl)
+                .append(mergeRequestTitle, causeData.mergeRequestTitle)
+                .append(mergeRequestDescription, causeData.mergeRequestDescription)
+                .append(mergeRequestId, causeData.mergeRequestId)
+                .append(mergeRequestIid, causeData.mergeRequestIid)
+                .append(mergeRequestState, causeData.mergeRequestState)
+                .append(mergedByUser, causeData.mergedByUser)
+                .append(mergeRequestAssignee, causeData.mergeRequestAssignee)
+                .append(mergeRequestTargetProjectId, causeData.mergeRequestTargetProjectId)
+                .append(targetBranch, causeData.targetBranch)
+                .append(targetRepoName, causeData.targetRepoName)
+                .append(targetNamespace, causeData.targetNamespace)
+                .append(targetRepoSshUrl, causeData.targetRepoSshUrl)
+                .append(targetRepoHttpUrl, causeData.targetRepoHttpUrl)
+                .append(triggeredByUser, causeData.triggeredByUser)
+                .append(before, causeData.before)
+                .append(after, causeData.after)
+                .append(lastCommit, causeData.lastCommit)
+                .append(targetProjectUrl, causeData.targetProjectUrl)
+                .append(ref, causeData.getRef())
+                .append(isTag, causeData.getIsTag())
+                .append(sha, causeData.getSha())
+                .append(beforeSha, causeData.getBeforeSha())
+                .append(status, causeData.getStatus())
+                .append(stages, causeData.getStages())
+                .append(createdAt, causeData.getCreatedAt())
+                .append(finishedAt, causeData.getFinishedAt())
+                .append(buildDuration, causeData.getBuildDuration())
+                .append(commentAuthor, causeData.getCommentAuthor())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
-            .append(actionType)
-            .append(sourceProjectId)
-            .append(targetProjectId)
-            .append(branch)
-            .append(sourceBranch)
-            .append(userName)
-            .append(userUsername)
-            .append(userEmail)
-            .append(sourceRepoHomepage)
-            .append(sourceRepoName)
-            .append(sourceNamespace)
-            .append(sourceRepoUrl)
-            .append(sourceRepoSshUrl)
-            .append(sourceRepoHttpUrl)
-            .append(mergeRequestTitle)
-            .append(mergeRequestDescription)
-            .append(mergeRequestId)
-            .append(mergeRequestIid)
-            .append(mergeRequestState)
-            .append(mergedByUser)
-            .append(mergeRequestAssignee)
-            .append(mergeRequestTargetProjectId)
-            .append(targetBranch)
-            .append(targetRepoName)
-            .append(targetNamespace)
-            .append(targetRepoSshUrl)
-            .append(targetRepoHttpUrl)
-            .append(triggeredByUser)
-            .append(before)
-            .append(after)
-            .append(lastCommit)
-            .append(targetProjectUrl)
-            .append(ref)
-            .append(isTag)
-            .append(sha)
-            .append(beforeSha)
-            .append(status)
-            .append(stages)
-            .append(createdAt)
-            .append(finishedAt)
-            .append(buildDuration)
-            .append(commentAuthor)
-            .toHashCode();
+                .append(actionType)
+                .append(sourceProjectId)
+                .append(targetProjectId)
+                .append(branch)
+                .append(sourceBranch)
+                .append(userName)
+                .append(userUsername)
+                .append(userEmail)
+                .append(sourceRepoHomepage)
+                .append(sourceRepoName)
+                .append(sourceNamespace)
+                .append(sourceRepoUrl)
+                .append(sourceRepoSshUrl)
+                .append(sourceRepoHttpUrl)
+                .append(mergeRequestTitle)
+                .append(mergeRequestDescription)
+                .append(mergeRequestId)
+                .append(mergeRequestIid)
+                .append(mergeRequestState)
+                .append(mergedByUser)
+                .append(mergeRequestAssignee)
+                .append(mergeRequestTargetProjectId)
+                .append(targetBranch)
+                .append(targetRepoName)
+                .append(targetNamespace)
+                .append(targetRepoSshUrl)
+                .append(targetRepoHttpUrl)
+                .append(triggeredByUser)
+                .append(before)
+                .append(after)
+                .append(lastCommit)
+                .append(targetProjectUrl)
+                .append(ref)
+                .append(isTag)
+                .append(sha)
+                .append(beforeSha)
+                .append(status)
+                .append(stages)
+                .append(createdAt)
+                .append(finishedAt)
+                .append(buildDuration)
+                .append(commentAuthor)
+                .toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .append("actionType", actionType)
-            .append("sourceProjectId", sourceProjectId)
-            .append("targetProjectId", targetProjectId)
-            .append("branch", branch)
-            .append("sourceBranch", sourceBranch)
-            .append("userName", userName)
-            .append("userUsername", userUsername)
-            .append("userEmail", userEmail)
-            .append("sourceRepoHomepage", sourceRepoHomepage)
-            .append("sourceRepoName", sourceRepoName)
-            .append("sourceNamespace", sourceNamespace)
-            .append("sourceRepoUrl", sourceRepoUrl)
-            .append("sourceRepoSshUrl", sourceRepoSshUrl)
-            .append("sourceRepoHttpUrl", sourceRepoHttpUrl)
-            .append("mergeRequestTitle", mergeRequestTitle)
-            .append("mergeRequestDescription", mergeRequestDescription)
-            .append("mergeRequestId", mergeRequestId)
-            .append("mergeRequestIid", mergeRequestIid)
-            .append("mergeRequestState", mergeRequestState)
-            .append("mergedByUser", mergedByUser)
-            .append("mergeRequestAssignee", mergeRequestAssignee)
-            .append("mergeRequestTargetProjectId", mergeRequestTargetProjectId)
-            .append("targetBranch", targetBranch)
-            .append("targetRepoName", targetRepoName)
-            .append("targetNamespace", targetNamespace)
-            .append("targetRepoSshUrl", targetRepoSshUrl)
-            .append("targetRepoHttpUrl", targetRepoHttpUrl)
-            .append("triggeredByUser", triggeredByUser)
-            .append("before", before)
-            .append("after", after)
-            .append("lastCommit", lastCommit)
-            .append("targetProjectUrl", targetProjectUrl)
-            .append("ref", ref)
-            .append("isTag", isTag)
-            .append("sha", sha)
-            .append("beforeSha", beforeSha)
-            .append("status", status)
-            .append("stages", stages)
-            .append("createdAt", createdAt)
-            .append("finishedAt", finishedAt)
-            .append("duration", buildDuration)
-            .append("commentAuthor", commentAuthor)
-            .toString();
+                .append("actionType", actionType)
+                .append("sourceProjectId", sourceProjectId)
+                .append("targetProjectId", targetProjectId)
+                .append("branch", branch)
+                .append("sourceBranch", sourceBranch)
+                .append("userName", userName)
+                .append("userUsername", userUsername)
+                .append("userEmail", userEmail)
+                .append("sourceRepoHomepage", sourceRepoHomepage)
+                .append("sourceRepoName", sourceRepoName)
+                .append("sourceNamespace", sourceNamespace)
+                .append("sourceRepoUrl", sourceRepoUrl)
+                .append("sourceRepoSshUrl", sourceRepoSshUrl)
+                .append("sourceRepoHttpUrl", sourceRepoHttpUrl)
+                .append("mergeRequestTitle", mergeRequestTitle)
+                .append("mergeRequestDescription", mergeRequestDescription)
+                .append("mergeRequestId", mergeRequestId)
+                .append("mergeRequestIid", mergeRequestIid)
+                .append("mergeRequestState", mergeRequestState)
+                .append("mergedByUser", mergedByUser)
+                .append("mergeRequestAssignee", mergeRequestAssignee)
+                .append("mergeRequestTargetProjectId", mergeRequestTargetProjectId)
+                .append("targetBranch", targetBranch)
+                .append("targetRepoName", targetRepoName)
+                .append("targetNamespace", targetNamespace)
+                .append("targetRepoSshUrl", targetRepoSshUrl)
+                .append("targetRepoHttpUrl", targetRepoHttpUrl)
+                .append("triggeredByUser", triggeredByUser)
+                .append("before", before)
+                .append("after", after)
+                .append("lastCommit", lastCommit)
+                .append("targetProjectUrl", targetProjectUrl)
+                .append("ref", ref)
+                .append("isTag", isTag)
+                .append("sha", sha)
+                .append("beforeSha", beforeSha)
+                .append("status", status)
+                .append("stages", stages)
+                .append("createdAt", createdAt)
+                .append("finishedAt", finishedAt)
+                .append("duration", buildDuration)
+                .append("commentAuthor", commentAuthor)
+                .toString();
     }
 
     public enum ActionType {
@@ -522,54 +587,68 @@ public final class CauseData {
             String getShortDescription(CauseData data) {
                 return getShortDescriptionPush(data);
             }
-        }, TAG_PUSH {
+        },
+        TAG_PUSH {
             @Override
             String getShortDescription(CauseData data) {
                 return getShortDescriptionPush(data);
             }
-        }, MERGE {
+        },
+        MERGE {
             @Override
             String getShortDescription(CauseData data) {
-                String forkNamespace = StringUtils.equals(data.getSourceNamespace(), data.getTargetBranch()) ? "" : data.getSourceNamespace() + "/";
-                if (Jenkins.getActiveInstance().getMarkupFormatter() instanceof EscapedMarkupFormatter || data.getTargetProjectUrl() == null) {
-                    return Messages.GitLabWebHookCause_ShortDescription_MergeRequestHook_plain(String.valueOf(data.getMergeRequestIid()),
-                                                                                               forkNamespace + data.getSourceBranch(),
-                                                                                               data.getTargetBranch());
+                String forkNamespace = StringUtils.equals(data.getSourceNamespace(), data.getTargetBranch())
+                        ? ""
+                        : data.getSourceNamespace() + "/";
+                if (Jenkins.getActiveInstance().getMarkupFormatter() instanceof EscapedMarkupFormatter
+                        || data.getTargetProjectUrl() == null) {
+                    return Messages.GitLabWebHookCause_ShortDescription_MergeRequestHook_plain(
+                            String.valueOf(data.getMergeRequestIid()),
+                            forkNamespace + data.getSourceBranch(),
+                            data.getTargetBranch());
                 } else {
-                    return Messages.GitLabWebHookCause_ShortDescription_MergeRequestHook_html(String.valueOf(data.getMergeRequestIid()),
-                                                                                              forkNamespace + data.getSourceBranch(),
-                                                                                              data.getTargetBranch(),
-                                                                                              data.getTargetProjectUrl());
+                    return Messages.GitLabWebHookCause_ShortDescription_MergeRequestHook_html(
+                            String.valueOf(data.getMergeRequestIid()),
+                            forkNamespace + data.getSourceBranch(),
+                            data.getTargetBranch(),
+                            data.getTargetProjectUrl());
                 }
             }
-        }, NOTE {
+        },
+        NOTE {
             @Override
             String getShortDescription(CauseData data) {
                 String triggeredBy = data.getTriggeredByUser();
-                String forkNamespace = StringUtils.equals(data.getSourceNamespace(), data.getTargetBranch()) ? "" : data.getSourceNamespace() + "/";
-                if (Jenkins.getActiveInstance().getMarkupFormatter() instanceof EscapedMarkupFormatter || data.getTargetProjectUrl() == null) {
-                    return Messages.GitLabWebHookCause_ShortDescription_NoteHook_plain(triggeredBy,
-                        String.valueOf(data.getMergeRequestIid()),
-                        forkNamespace + data.getSourceBranch(),
-                        data.getTargetBranch());
+                String forkNamespace = StringUtils.equals(data.getSourceNamespace(), data.getTargetBranch())
+                        ? ""
+                        : data.getSourceNamespace() + "/";
+                if (Jenkins.getActiveInstance().getMarkupFormatter() instanceof EscapedMarkupFormatter
+                        || data.getTargetProjectUrl() == null) {
+                    return Messages.GitLabWebHookCause_ShortDescription_NoteHook_plain(
+                            triggeredBy,
+                            String.valueOf(data.getMergeRequestIid()),
+                            forkNamespace + data.getSourceBranch(),
+                            data.getTargetBranch());
                 } else {
-                    return Messages.GitLabWebHookCause_ShortDescription_NoteHook_html(triggeredBy,
-                        String.valueOf(data.getMergeRequestIid()),
-                        forkNamespace + data.getSourceBranch(),
-                        data.getTargetBranch(),
-                        data.getTargetProjectUrl());
+                    return Messages.GitLabWebHookCause_ShortDescription_NoteHook_html(
+                            triggeredBy,
+                            String.valueOf(data.getMergeRequestIid()),
+                            forkNamespace + data.getSourceBranch(),
+                            data.getTargetBranch(),
+                            data.getTargetProjectUrl());
                 }
             }
-        }, PIPELINE {
-                @Override
-                String getShortDescription(CauseData data) {
-                    String getStatus = data.getStatus();
-                    if (getStatus == null) {
-                       return Messages.GitLabWebHookCause_ShortDescription_PipelineHook_noStatus();
-                    } else {
-                      return Messages.GitLabWebHookCause_ShortDescription_PipelineHook(getStatus);
-                    }
+        },
+        PIPELINE {
+            @Override
+            String getShortDescription(CauseData data) {
+                String getStatus = data.getStatus();
+                if (getStatus == null) {
+                    return Messages.GitLabWebHookCause_ShortDescription_PipelineHook_noStatus();
+                } else {
+                    return Messages.GitLabWebHookCause_ShortDescription_PipelineHook(getStatus);
                 }
+            }
         };
 
         private static String getShortDescriptionPush(CauseData data) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnection.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnection.java
@@ -1,30 +1,8 @@
 package com.dabsquared.gitlabjenkins.connection;
 
-
 import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
 import static com.dabsquared.gitlabjenkins.gitlab.api.GitLabClientBuilder.getAllGitLabClientBuilders;
 import static com.dabsquared.gitlabjenkins.gitlab.api.GitLabClientBuilder.getGitLabClientBuilderById;
-
-import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
-import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
-import hudson.model.Descriptor;
-import hudson.util.FormValidation;
-import hudson.util.ListBoxModel;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
-import org.eclipse.jgit.util.StringUtils;
-import org.jenkinsci.plugins.plaincredentials.StringCredentials;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.DoNotUse;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -32,22 +10,39 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClientBuilder;
 import com.dabsquared.gitlabjenkins.gitlab.api.impl.AutodetectGitLabClientBuilder;
-
+import hudson.Extension;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.security.ACL;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import hudson.util.Secret;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
 import jenkins.model.Jenkins;
+import org.eclipse.jgit.util.StringUtils;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
-
 
 /**
  * @author Robin Müller
@@ -64,33 +59,51 @@ public class GitLabConnection extends AbstractDescribableImpl<GitLabConnection> 
     private final Integer readTimeout;
     private transient Map<String, GitLabClient> clientCache;
 
-    public GitLabConnection(String name, String url, String apiTokenId, boolean ignoreCertificateErrors, Integer connectionTimeout, Integer readTimeout) {
+    public GitLabConnection(
+            String name,
+            String url,
+            String apiTokenId,
+            boolean ignoreCertificateErrors,
+            Integer connectionTimeout,
+            Integer readTimeout) {
         this(
-            name,
-            url,
-            apiTokenId,
-            new AutodetectGitLabClientBuilder(),
-            ignoreCertificateErrors,
-            connectionTimeout,
-            readTimeout
-        );
+                name,
+                url,
+                apiTokenId,
+                new AutodetectGitLabClientBuilder(),
+                ignoreCertificateErrors,
+                connectionTimeout,
+                readTimeout);
     }
 
     @DataBoundConstructor
-    public GitLabConnection(String name, String url, String apiTokenId, String clientBuilderId, boolean ignoreCertificateErrors, Integer connectionTimeout, Integer readTimeout) {
+    public GitLabConnection(
+            String name,
+            String url,
+            String apiTokenId,
+            String clientBuilderId,
+            boolean ignoreCertificateErrors,
+            Integer connectionTimeout,
+            Integer readTimeout) {
         this(
-            name,
-            url,
-            apiTokenId,
-            getGitLabClientBuilderById(clientBuilderId),
-            ignoreCertificateErrors,
-            connectionTimeout,
-            readTimeout
-        );
+                name,
+                url,
+                apiTokenId,
+                getGitLabClientBuilderById(clientBuilderId),
+                ignoreCertificateErrors,
+                connectionTimeout,
+                readTimeout);
     }
 
     @Restricted(NoExternalUse.class)
-    public GitLabConnection(String name, String url, String apiTokenId, GitLabClientBuilder clientBuilder, boolean ignoreCertificateErrors, Integer connectionTimeout, Integer readTimeout) {
+    public GitLabConnection(
+            String name,
+            String url,
+            String apiTokenId,
+            GitLabClientBuilder clientBuilder,
+            boolean ignoreCertificateErrors,
+            Integer connectionTimeout,
+            Integer readTimeout) {
         this.name = name;
         this.url = url == null ? "" : url;
         this.apiTokenId = apiTokenId;
@@ -143,9 +156,8 @@ public class GitLabConnection extends AbstractDescribableImpl<GitLabConnection> 
 
         if (!clientCache.containsKey(clientId)) {
             clientCache.put(
-                clientId,
-                clientBuilder.buildClient(url, token, ignoreCertificateErrors, connectionTimeout, readTimeout)
-            );
+                    clientId,
+                    clientBuilder.buildClient(url, token, ignoreCertificateErrors, connectionTimeout, readTimeout));
         }
         return clientCache.get(clientId);
     }
@@ -154,12 +166,12 @@ public class GitLabConnection extends AbstractDescribableImpl<GitLabConnection> 
     private String getApiToken(String apiTokenId, Item item) {
         ItemGroup<?> context = item != null ? item.getParent() : Jenkins.get();
         StandardCredentials credentials = CredentialsMatchers.firstOrNull(
-            lookupCredentials(
-                    StandardCredentials.class,
-                    context, 
-                    ACL.SYSTEM,
-                    URIRequirementBuilder.fromUri(url).build()),
-            CredentialsMatchers.withId(apiTokenId));
+                lookupCredentials(
+                        StandardCredentials.class,
+                        context,
+                        ACL.SYSTEM,
+                        URIRequirementBuilder.fromUri(url).build()),
+                CredentialsMatchers.withId(apiTokenId));
         if (credentials != null) {
             if (credentials instanceof GitLabApiToken) {
                 return ((GitLabApiToken) credentials).getApiToken().getPlainText();
@@ -173,10 +185,18 @@ public class GitLabConnection extends AbstractDescribableImpl<GitLabConnection> 
 
     protected GitLabConnection readResolve() {
         if (connectionTimeout == null || readTimeout == null) {
-            return new GitLabConnection(name, url, apiTokenId, new AutodetectGitLabClientBuilder(), ignoreCertificateErrors, 10, 10);
+            return new GitLabConnection(
+                    name, url, apiTokenId, new AutodetectGitLabClientBuilder(), ignoreCertificateErrors, 10, 10);
         }
         if (clientBuilder == null) {
-            return new GitLabConnection(name, url, apiTokenId, new AutodetectGitLabClientBuilder(), ignoreCertificateErrors, connectionTimeout, readTimeout);
+            return new GitLabConnection(
+                    name,
+                    url,
+                    apiTokenId,
+                    new AutodetectGitLabClientBuilder(),
+                    ignoreCertificateErrors,
+                    connectionTimeout,
+                    readTimeout);
         }
         if (clientCache == null) {
             clientCache = new HashMap<>();
@@ -187,7 +207,8 @@ public class GitLabConnection extends AbstractDescribableImpl<GitLabConnection> 
 
     @Initializer(after = InitMilestone.PLUGINS_STARTED)
     public static void migrate() throws IOException {
-        GitLabConnectionConfig descriptor = (GitLabConnectionConfig) Jenkins.get().getDescriptor(GitLabConnectionConfig.class);
+        GitLabConnectionConfig descriptor =
+                (GitLabConnectionConfig) Jenkins.get().getDescriptor(GitLabConnectionConfig.class);
         if (descriptor == null) return;
         for (GitLabConnection connection : descriptor.getConnections()) {
             if (connection.apiTokenId == null && connection.apiToken != null) {
@@ -195,8 +216,13 @@ public class GitLabConnection extends AbstractDescribableImpl<GitLabConnection> 
                     if (credentialsStore instanceof SystemCredentialsProvider.StoreImpl) {
                         List<Domain> domains = credentialsStore.getDomains();
                         connection.apiTokenId = UUID.randomUUID().toString();
-                        credentialsStore.addCredentials(domains.get(0),
-                            new GitLabApiTokenImpl(CredentialsScope.SYSTEM, connection.apiTokenId, "GitLab API Token", Secret.fromString(connection.apiToken)));
+                        credentialsStore.addCredentials(
+                                domains.get(0),
+                                new GitLabApiTokenImpl(
+                                        CredentialsScope.SYSTEM,
+                                        connection.apiTokenId,
+                                        "GitLab API Token",
+                                        Secret.fromString(connection.apiToken)));
                     }
                 }
             }
@@ -248,33 +274,45 @@ public class GitLabConnection extends AbstractDescribableImpl<GitLabConnection> 
 
         @RequirePOST
         @Restricted(DoNotUse.class) // WebOnly
-        public FormValidation doTestConnection(@QueryParameter String url,
-            @QueryParameter String apiTokenId,
-            @QueryParameter String clientBuilderId,
-            @QueryParameter boolean ignoreCertificateErrors,
-            @QueryParameter int connectionTimeout,
-            @QueryParameter int readTimeout) {
+        public FormValidation doTestConnection(
+                @QueryParameter String url,
+                @QueryParameter String apiTokenId,
+                @QueryParameter String clientBuilderId,
+                @QueryParameter boolean ignoreCertificateErrors,
+                @QueryParameter int connectionTimeout,
+                @QueryParameter int readTimeout) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             try {
-                new GitLabConnection("", url, apiTokenId, clientBuilderId, ignoreCertificateErrors, connectionTimeout, readTimeout).getClient(null, null).getCurrentUser();
+                new GitLabConnection(
+                                "",
+                                url,
+                                apiTokenId,
+                                clientBuilderId,
+                                ignoreCertificateErrors,
+                                connectionTimeout,
+                                readTimeout)
+                        .getClient(null, null)
+                        .getCurrentUser();
                 return FormValidation.ok(Messages.connection_success());
             } catch (WebApplicationException e) {
                 return FormValidation.error(Messages.connection_error(e.getMessage()));
             } catch (ProcessingException e) {
-                return FormValidation.error(Messages.connection_error(e.getCause().getMessage()));
+                return FormValidation.error(
+                        Messages.connection_error(e.getCause().getMessage()));
             }
         }
 
         public ListBoxModel doFillApiTokenIdItems(@QueryParameter String url, @QueryParameter String apiTokenId) {
             if (Jenkins.get().hasPermission(Item.CONFIGURE)) {
                 return new StandardListBoxModel()
-                    .includeEmptyValue()
-                    .includeMatchingAs(ACL.SYSTEM,
-                        Jenkins.get(),
-                        StandardCredentials.class,
-                        URIRequirementBuilder.fromUri(url).build(),
-                        new GitLabCredentialMatcher())
-                    .includeCurrentValue(apiTokenId);
+                        .includeEmptyValue()
+                        .includeMatchingAs(
+                                ACL.SYSTEM,
+                                Jenkins.get(),
+                                StandardCredentials.class,
+                                URIRequirementBuilder.fromUri(url).build(),
+                                new GitLabCredentialMatcher())
+                        .includeCurrentValue(apiTokenId);
             }
             return new StandardListBoxModel();
         }

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfig.java
@@ -1,18 +1,16 @@
 package com.dabsquared.gitlabjenkins.connection;
 
-
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Item;
-import jenkins.model.GlobalConfiguration;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import jenkins.model.GlobalConfiguration;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * @author Robin Müller
@@ -53,7 +51,7 @@ public class GitLabConnectionConfig extends GlobalConfiguration {
     public void setConnections(List<GitLabConnection> newConnections) {
         connections = new ArrayList<>();
         connectionMap = new HashMap<>();
-        for (GitLabConnection connection: newConnections){
+        for (GitLabConnection connection : newConnections) {
             addConnection(connection);
         }
         save();
@@ -73,7 +71,7 @@ public class GitLabConnectionConfig extends GlobalConfiguration {
         }
     }
 
-    //For backwards compatibility. ReadResolve is called on startup
+    // For backwards compatibility. ReadResolve is called on startup
     protected GitLabConnectionConfig readResolve() {
         if (useAuthenticatedEndpoint == null) {
             setUseAuthenticatedEndpoint(false);

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionProperty.java
@@ -1,11 +1,11 @@
 package com.dabsquared.gitlabjenkins.connection;
 
-
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.Job;
@@ -15,13 +15,10 @@ import hudson.model.Run;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import jenkins.model.Jenkins;
-import net.sf.json.JSONObject;
-
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -71,7 +68,8 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
 
     public GitLabClient getClient() {
         if (StringUtils.isNotEmpty(gitLabConnection)) {
-            GitLabConnectionConfig connectionConfig = (GitLabConnectionConfig) Jenkins.getActiveInstance().getDescriptor(GitLabConnectionConfig.class);
+            GitLabConnectionConfig connectionConfig =
+                    (GitLabConnectionConfig) Jenkins.getActiveInstance().getDescriptor(GitLabConnectionConfig.class);
             if (connectionConfig != null) {
                 if (useAlternativeCredential) {
                     return connectionConfig.getClient(gitLabConnection, this.owner, jobCredentialId);
@@ -116,19 +114,20 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
 
         public ListBoxModel doFillGitLabConnectionItems() {
             ListBoxModel options = new ListBoxModel();
-            GitLabConnectionConfig descriptor = (GitLabConnectionConfig) Jenkins.getInstance().getDescriptor(GitLabConnectionConfig.class);
+            GitLabConnectionConfig descriptor =
+                    (GitLabConnectionConfig) Jenkins.getInstance().getDescriptor(GitLabConnectionConfig.class);
             for (GitLabConnection connection : descriptor.getConnections()) {
                 options.add(connection.getName(), connection.getName());
             }
             return options;
         }
-        
-        public ListBoxModel doFillJobCredentialIdItems(@AncestorInPath Item item, @QueryParameter String url,
-                @QueryParameter String jobCredentialId) {
+
+        public ListBoxModel doFillJobCredentialIdItems(
+                @AncestorInPath Item item, @QueryParameter String url, @QueryParameter String jobCredentialId) {
             StandardListBoxModel result = new StandardListBoxModel();
             if (item == null) {
                 if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
-                  return result.includeCurrentValue(jobCredentialId);
+                    return result.includeCurrentValue(jobCredentialId);
                 }
             } else {
                 if (!item.hasPermission(Item.EXTENDED_READ) && !item.hasPermission(CredentialsProvider.USE_ITEM)) {
@@ -136,20 +135,26 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
                 }
             }
             return result.includeEmptyValue()
-                    .includeMatchingAs(ACL.SYSTEM, item, StandardCredentials.class,
-                            URIRequirementBuilder.fromUri(url).build(), new GitLabCredentialMatcher())
+                    .includeMatchingAs(
+                            ACL.SYSTEM,
+                            item,
+                            StandardCredentials.class,
+                            URIRequirementBuilder.fromUri(url).build(),
+                            new GitLabCredentialMatcher())
                     .includeCurrentValue(jobCredentialId);
         }
 
         @RequirePOST
         @Restricted(DoNotUse.class)
-        public FormValidation doTestConnection(@QueryParameter String jobCredentialId,
-                @QueryParameter String gitLabConnection, @AncestorInPath Item item) {
+        public FormValidation doTestConnection(
+                @QueryParameter String jobCredentialId,
+                @QueryParameter String gitLabConnection,
+                @AncestorInPath Item item) {
             item.checkPermission(Item.CONFIGURE);
             try {
                 GitLabConnection gitLabConnectionTested = null;
-                GitLabConnectionConfig descriptor = (GitLabConnectionConfig) Jenkins.getInstance()
-                        .getDescriptor(GitLabConnectionConfig.class);
+                GitLabConnectionConfig descriptor =
+                        (GitLabConnectionConfig) Jenkins.getInstance().getDescriptor(GitLabConnectionConfig.class);
                 for (GitLabConnection connection : descriptor.getConnections()) {
                     if (gitLabConnection.equals(connection.getName())) {
                         gitLabConnectionTested = connection;
@@ -158,15 +163,22 @@ public class GitLabConnectionProperty extends JobProperty<Job<?, ?>> {
                 if (gitLabConnectionTested == null) {
                     return FormValidation.error(Messages.connection_error("The GitLab Connection does not exist"));
                 }
-                new GitLabConnection("", gitLabConnectionTested.getUrl(), jobCredentialId,
-                        gitLabConnectionTested.getClientBuilderId(), true,
-                        gitLabConnectionTested.getConnectionTimeout(), gitLabConnectionTested.getReadTimeout())
-                                .getClient(item, jobCredentialId).getCurrentUser();
+                new GitLabConnection(
+                                "",
+                                gitLabConnectionTested.getUrl(),
+                                jobCredentialId,
+                                gitLabConnectionTested.getClientBuilderId(),
+                                true,
+                                gitLabConnectionTested.getConnectionTimeout(),
+                                gitLabConnectionTested.getReadTimeout())
+                        .getClient(item, jobCredentialId)
+                        .getCurrentUser();
                 return FormValidation.ok(Messages.connection_success());
             } catch (WebApplicationException e) {
                 return FormValidation.error(Messages.connection_error(e.getMessage()));
             } catch (ProcessingException e) {
-                return FormValidation.error(Messages.connection_error(e.getCause().getMessage()));
+                return FormValidation.error(
+                        Messages.connection_error(e.getCause().getMessage()));
             }
         }
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabCredentialMatcher.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabCredentialMatcher.java
@@ -1,11 +1,9 @@
 package com.dabsquared.gitlabjenkins.connection;
 
-import org.jenkinsci.plugins.plaincredentials.StringCredentials;
-
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatcher;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 public class GitLabCredentialMatcher implements CredentialsMatcher {
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributor.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributor.java
@@ -1,15 +1,14 @@
 package com.dabsquared.gitlabjenkins.environment;
 
 import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
-import hudson.matrix.MatrixRun;
 import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixRun;
 import hudson.model.EnvironmentContributor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 
 /**
@@ -18,10 +17,11 @@ import java.io.IOException;
 @Extension
 public class GitLabEnvironmentContributor extends EnvironmentContributor {
     @Override
-    public void buildEnvironmentFor(@NonNull Run r, @NonNull EnvVars envs, @NonNull TaskListener listener) throws IOException, InterruptedException {
+    public void buildEnvironmentFor(@NonNull Run r, @NonNull EnvVars envs, @NonNull TaskListener listener)
+            throws IOException, InterruptedException {
         GitLabWebHookCause cause = null;
         if (r instanceof MatrixRun) {
-            MatrixBuild parent = ((MatrixRun)r).getParentBuild();
+            MatrixBuild parent = ((MatrixRun) r).getParentBuild();
             if (parent != null) {
                 cause = (GitLabWebHookCause) parent.getCause(GitLabWebHookCause.class);
             }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/JacksonConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/JacksonConfig.java
@@ -3,7 +3,6 @@ package com.dabsquared.gitlabjenkins.gitlab;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClient.java
@@ -10,7 +10,13 @@ public interface GitLabClient {
     List<Group> getGroups();
 
     List<Project> getGroupProjects(String groupId);
-    List<Project> getGroupProjects(String groupId, Boolean includeSubgroups, ProjectVisibilityType visibility, OrderType orderBy, SortType sort);
+
+    List<Project> getGroupProjects(
+            String groupId,
+            Boolean includeSubgroups,
+            ProjectVisibilityType visibility,
+            OrderType orderBy,
+            SortType sort);
 
     List<Group> getGroups(Boolean allAvailable, Boolean topLevelOnly, OrderType orderBy, SortType sort);
 
@@ -26,13 +32,34 @@ public interface GitLabClient {
 
     List<ProjectHook> getProjectHooks(String projectName);
 
-    void addProjectHook(String projectId, String url, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents);
+    void addProjectHook(
+            String projectId, String url, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents);
 
-    void addProjectHook(String projectId, String url, String secretToken, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents);
+    void addProjectHook(
+            String projectId,
+            String url,
+            String secretToken,
+            Boolean pushEvents,
+            Boolean mergeRequestEvents,
+            Boolean noteEvents);
 
-    void changeBuildStatus(String projectId, String sha, BuildState state, String ref, String context, String targetUrl, String description);
+    void changeBuildStatus(
+            String projectId,
+            String sha,
+            BuildState state,
+            String ref,
+            String context,
+            String targetUrl,
+            String description);
 
-    void changeBuildStatus(Integer projectId, String sha, BuildState state, String ref, String context, String targetUrl, String description);
+    void changeBuildStatus(
+            Integer projectId,
+            String sha,
+            BuildState state,
+            String ref,
+            String context,
+            String targetUrl,
+            String description);
 
     void getCommit(String projectId, String sha);
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClientBuilder.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClientBuilder.java
@@ -1,18 +1,16 @@
 package com.dabsquared.gitlabjenkins.gitlab.api;
 
-
-import hudson.ExtensionPoint;
-import jenkins.model.Jenkins;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
+import static java.util.Collections.sort;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionPoint;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
-
-import static java.util.Collections.sort;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 @Restricted(NoExternalUse.class)
 public abstract class GitLabClientBuilder implements Comparable<GitLabClientBuilder>, ExtensionPoint, Serializable {
@@ -27,7 +25,8 @@ public abstract class GitLabClientBuilder implements Comparable<GitLabClientBuil
     }
 
     public static List<GitLabClientBuilder> getAllGitLabClientBuilders() {
-        List<GitLabClientBuilder> builders = new ArrayList<>(Jenkins.getInstance().getExtensionList(GitLabClientBuilder.class));
+        List<GitLabClientBuilder> builders =
+                new ArrayList<>(Jenkins.getInstance().getExtensionList(GitLabClientBuilder.class));
         sort(builders);
         return builders;
     }
@@ -46,7 +45,8 @@ public abstract class GitLabClientBuilder implements Comparable<GitLabClientBuil
     }
 
     @NonNull
-    public abstract GitLabClient buildClient(String url, String token, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout);
+    public abstract GitLabClient buildClient(
+            String url, String token, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout);
 
     @Override
     public final int compareTo(@NonNull GitLabClientBuilder other) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectGitLabClientBuilder.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectGitLabClientBuilder.java
@@ -1,16 +1,13 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.impl;
 
-
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClientBuilder;
-import hudson.Extension;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
 import java.util.ArrayList;
 import java.util.Collection;
-
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 @Extension
 @Restricted(NoExternalUse.class)
@@ -21,9 +18,11 @@ public final class AutodetectGitLabClientBuilder extends GitLabClientBuilder {
 
     @Override
     @NonNull
-    public GitLabClient buildClient(String url, String token, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout) {
+    public GitLabClient buildClient(
+            String url, String token, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout) {
         Collection<GitLabClientBuilder> candidates = new ArrayList<>(getAllGitLabClientBuilders());
         candidates.remove(this);
-        return new AutodetectingGitLabClient(candidates, url, token, ignoreCertificateErrors, connectionTimeout, readTimeout);
+        return new AutodetectingGitLabClient(
+                candidates, url, token, ignoreCertificateErrors, connectionTimeout, readTimeout);
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
@@ -17,8 +17,13 @@ final class AutodetectingGitLabClient implements GitLabClient {
     private final int readTimeout;
     private GitLabClient delegate;
 
-
-    AutodetectingGitLabClient(Iterable<GitLabClientBuilder> builders, String url, String token, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout) {
+    AutodetectingGitLabClient(
+            Iterable<GitLabClientBuilder> builders,
+            String url,
+            String token,
+            boolean ignoreCertificateErrors,
+            int connectionTimeout,
+            int readTimeout) {
         this.builders = builders;
         this.url = url;
         this.token = token;
@@ -34,326 +39,326 @@ final class AutodetectingGitLabClient implements GitLabClient {
 
     @Override
     public List<Group> getGroups() {
-        return execute(
-                new GitLabOperation<List<Group>>() {
-                    @Override
-                    List<Group> execute(GitLabClient client) {
-                        return client.getGroups();
-                    }
-                });
+        return execute(new GitLabOperation<List<Group>>() {
+            @Override
+            List<Group> execute(GitLabClient client) {
+                return client.getGroups();
+            }
+        });
     }
 
     @Override
     public List<Project> getGroupProjects(String groupId) {
-        return execute(
-                new GitLabOperation<List<Project>>() {
-                    @Override
-                    List<Project> execute(GitLabClient client) {
-                        return client.getGroupProjects(groupId);
-                    }
-                });
+        return execute(new GitLabOperation<List<Project>>() {
+            @Override
+            List<Project> execute(GitLabClient client) {
+                return client.getGroupProjects(groupId);
+            }
+        });
     }
 
     @Override
-    public List<Project> getGroupProjects(String groupId, Boolean includeSubgroups, ProjectVisibilityType visibility,
-            OrderType orderBy, SortType sort) {
-        return execute(
-                new GitLabOperation<List<Project>>() {
-                    @Override
-                    List<Project> execute(GitLabClient client) {
-                        return client.getGroupProjects(groupId, includeSubgroups, visibility, orderBy, sort);
-                    }
-                });
+    public List<Project> getGroupProjects(
+            String groupId,
+            Boolean includeSubgroups,
+            ProjectVisibilityType visibility,
+            OrderType orderBy,
+            SortType sort) {
+        return execute(new GitLabOperation<List<Project>>() {
+            @Override
+            List<Project> execute(GitLabClient client) {
+                return client.getGroupProjects(groupId, includeSubgroups, visibility, orderBy, sort);
+            }
+        });
     }
 
     @Override
     public List<Group> getGroups(Boolean allAvailable, Boolean topLevelOnly, OrderType orderBy, SortType sort) {
-        return execute(
-                new GitLabOperation<List<Group>>() {
-                    @Override
-                    List<Group> execute(GitLabClient client) {
-                        return client.getGroups(allAvailable, topLevelOnly, orderBy, sort);
-                    }
-                });
+        return execute(new GitLabOperation<List<Group>>() {
+            @Override
+            List<Group> execute(GitLabClient client) {
+                return client.getGroups(allAvailable, topLevelOnly, orderBy, sort);
+            }
+        });
     }
 
     @Override
     public Project createProject(final String projectName) {
-        return execute(
-            new GitLabOperation<Project>() {
-                @Override
-                Project execute(GitLabClient client) {
-                    return client.createProject(projectName);
-                }
-            });
+        return execute(new GitLabOperation<Project>() {
+            @Override
+            Project execute(GitLabClient client) {
+                return client.createProject(projectName);
+            }
+        });
     }
 
     @Override
-    public MergeRequest createMergeRequest(final Integer projectId, final String sourceBranch, final String targetBranch, final String title) {
-        return execute(
-            new GitLabOperation<MergeRequest>() {
-                @Override
-                MergeRequest execute(GitLabClient client) {
-                    return client.createMergeRequest(projectId, sourceBranch, targetBranch, title);
-                }
-            });
+    public MergeRequest createMergeRequest(
+            final Integer projectId, final String sourceBranch, final String targetBranch, final String title) {
+        return execute(new GitLabOperation<MergeRequest>() {
+            @Override
+            MergeRequest execute(GitLabClient client) {
+                return client.createMergeRequest(projectId, sourceBranch, targetBranch, title);
+            }
+        });
     }
 
     @Override
     public Project getProject(final String projectName) {
-        return execute(
-            new GitLabOperation<Project>() {
-                @Override
-                Project execute(GitLabClient client) {
-                    return client.getProject(projectName);
-                }
-            });
+        return execute(new GitLabOperation<Project>() {
+            @Override
+            Project execute(GitLabClient client) {
+                return client.getProject(projectName);
+            }
+        });
     }
 
     @Override
     public List<ProjectHook> getProjectHooks(String projectName) {
-        return execute(
-                new GitLabOperation<List<ProjectHook>>() {
-                    @Override
-                    List<ProjectHook> execute(GitLabClient client) {
-                        return client.getProjectHooks(projectName);
-                    }
-                });
+        return execute(new GitLabOperation<List<ProjectHook>>() {
+            @Override
+            List<ProjectHook> execute(GitLabClient client) {
+                return client.getProjectHooks(projectName);
+            }
+        });
     }
 
     @Override
     public Project updateProject(final String projectId, final String name, final String path) {
-        return execute(
-            new GitLabOperation<Project>() {
-                @Override
-                Project execute(GitLabClient client) {
-                    return client.updateProject(projectId, name, path);
-                }
-            });
+        return execute(new GitLabOperation<Project>() {
+            @Override
+            Project execute(GitLabClient client) {
+                return client.updateProject(projectId, name, path);
+            }
+        });
     }
 
     @Override
     public void deleteProject(final String projectId) {
-        execute(
-            new GitLabOperation<Void>() {
-                @Override
-                Void execute(GitLabClient client) {
-                    client.deleteProject(projectId);
-                    return null;
-                }
-            });
+        execute(new GitLabOperation<Void>() {
+            @Override
+            Void execute(GitLabClient client) {
+                client.deleteProject(projectId);
+                return null;
+            }
+        });
     }
 
     @Override
-    public void addProjectHook(final String projectId, final String url, final Boolean pushEvents, final Boolean mergeRequestEvents, final Boolean noteEvents) {
-        execute(
-            new GitLabOperation<Void>() {
-                @Override
-                Void execute(GitLabClient client) {
-                    client.addProjectHook(projectId, url, pushEvents, mergeRequestEvents, noteEvents);
-                    return null;
-                }
-            });
+    public void addProjectHook(
+            final String projectId,
+            final String url,
+            final Boolean pushEvents,
+            final Boolean mergeRequestEvents,
+            final Boolean noteEvents) {
+        execute(new GitLabOperation<Void>() {
+            @Override
+            Void execute(GitLabClient client) {
+                client.addProjectHook(projectId, url, pushEvents, mergeRequestEvents, noteEvents);
+                return null;
+            }
+        });
     }
 
     @Override
-    public void addProjectHook(final String projectId, final String url, String secretToken, final Boolean pushEvents, final Boolean mergeRequestEvents, final Boolean noteEvents) {
-        execute(
-            new GitLabOperation<Void>() {
-                @Override
-                Void execute(GitLabClient client) {
-                    client.addProjectHook(projectId, url, secretToken, pushEvents, mergeRequestEvents, noteEvents);
-                    return null;
-                }
-            });
+    public void addProjectHook(
+            final String projectId,
+            final String url,
+            String secretToken,
+            final Boolean pushEvents,
+            final Boolean mergeRequestEvents,
+            final Boolean noteEvents) {
+        execute(new GitLabOperation<Void>() {
+            @Override
+            Void execute(GitLabClient client) {
+                client.addProjectHook(projectId, url, secretToken, pushEvents, mergeRequestEvents, noteEvents);
+                return null;
+            }
+        });
     }
 
     @Override
-    public void changeBuildStatus(final String projectId, final String sha, final BuildState state, final String ref, final String context, final String targetUrl, final String description) {
-        execute(
-            new GitLabOperation<Void>() {
-                @Override
-                Void execute(GitLabClient client) {
-                    client.changeBuildStatus(projectId, sha, state, ref, context, targetUrl, description);
-                    return null;
-                }
-            });
+    public void changeBuildStatus(
+            final String projectId,
+            final String sha,
+            final BuildState state,
+            final String ref,
+            final String context,
+            final String targetUrl,
+            final String description) {
+        execute(new GitLabOperation<Void>() {
+            @Override
+            Void execute(GitLabClient client) {
+                client.changeBuildStatus(projectId, sha, state, ref, context, targetUrl, description);
+                return null;
+            }
+        });
     }
 
     @Override
-    public void changeBuildStatus(final Integer projectId, final String sha, final BuildState state, final String ref, final String context, final String targetUrl, final String description) {
-        execute(
-            new GitLabOperation<Void>() {
-                @Override
-                Void execute(GitLabClient client) {
-                    client.changeBuildStatus(projectId, sha, state, ref, context, targetUrl, description);
-                    return null;
-                }
-            });
+    public void changeBuildStatus(
+            final Integer projectId,
+            final String sha,
+            final BuildState state,
+            final String ref,
+            final String context,
+            final String targetUrl,
+            final String description) {
+        execute(new GitLabOperation<Void>() {
+            @Override
+            Void execute(GitLabClient client) {
+                client.changeBuildStatus(projectId, sha, state, ref, context, targetUrl, description);
+                return null;
+            }
+        });
     }
 
     @Override
     public void getCommit(final String projectId, final String sha) {
-        execute(
-            new GitLabOperation<Void>() {
-                @Override
-                Void execute(GitLabClient client) {
-                    client.getCommit(projectId, sha);
-                    return null;
-                }
-            });
+        execute(new GitLabOperation<Void>() {
+            @Override
+            Void execute(GitLabClient client) {
+                client.getCommit(projectId, sha);
+                return null;
+            }
+        });
     }
 
     @Override
-    public void acceptMergeRequest(final MergeRequest mr, final String mergeCommitMessage, final Boolean shouldRemoveSourceBranch) {
-        execute(
-            new GitLabOperation<Void>() {
-                @Override
-                Void execute(GitLabClient client) {
-                    client.acceptMergeRequest(mr, mergeCommitMessage, shouldRemoveSourceBranch);
-                    return null;
-                }
+    public void acceptMergeRequest(
+            final MergeRequest mr, final String mergeCommitMessage, final Boolean shouldRemoveSourceBranch) {
+        execute(new GitLabOperation<Void>() {
+            @Override
+            Void execute(GitLabClient client) {
+                client.acceptMergeRequest(mr, mergeCommitMessage, shouldRemoveSourceBranch);
+                return null;
             }
-        );
+        });
     }
 
     @Override
     public void createMergeRequestNote(final MergeRequest mr, final String body) {
-        execute(
-            new GitLabOperation<Void>() {
-                @Override
-                Void execute(GitLabClient client) {
-                    client.createMergeRequestNote(mr, body);
-                    return null;
-                }
+        execute(new GitLabOperation<Void>() {
+            @Override
+            Void execute(GitLabClient client) {
+                client.createMergeRequestNote(mr, body);
+                return null;
             }
-        );
+        });
     }
 
     @Override
     public List<Awardable> getMergeRequestEmoji(final MergeRequest mr) {
-        return execute(
-            new GitLabOperation<List<Awardable>>() {
-                @Override
-                List<Awardable> execute(GitLabClient client) {
-                    return client.getMergeRequestEmoji(mr);
-                }
+        return execute(new GitLabOperation<List<Awardable>>() {
+            @Override
+            List<Awardable> execute(GitLabClient client) {
+                return client.getMergeRequestEmoji(mr);
             }
-        );
+        });
     }
 
     @Override
     public void awardMergeRequestEmoji(final MergeRequest mr, final String body) {
-        execute(
-            new GitLabOperation<Void>() {
-                @Override
-                Void execute(GitLabClient client) {
-                    client.awardMergeRequestEmoji(mr, body);
-                    return null;
-                }
+        execute(new GitLabOperation<Void>() {
+            @Override
+            Void execute(GitLabClient client) {
+                client.awardMergeRequestEmoji(mr, body);
+                return null;
             }
-        );
+        });
     }
 
     @Override
     public void deleteMergeRequestEmoji(final MergeRequest mr, final Integer awardId) {
-        execute(
-            new GitLabOperation<Void>() {
-                @Override
-                Void execute(GitLabClient client) {
-                    client.deleteMergeRequestEmoji(mr, awardId);
-                    return null;
-                }
+        execute(new GitLabOperation<Void>() {
+            @Override
+            Void execute(GitLabClient client) {
+                client.deleteMergeRequestEmoji(mr, awardId);
+                return null;
             }
-        );
+        });
     }
 
     @Override
-    public List<MergeRequest> getMergeRequests(final String projectId, final State state, final int page, final int perPage) {
-        return execute(
-            new GitLabOperation<List<MergeRequest>>() {
-                @Override
-                List<MergeRequest> execute(GitLabClient client) {
-                    return client.getMergeRequests(projectId, state, page, perPage);
-                }
-            });
+    public List<MergeRequest> getMergeRequests(
+            final String projectId, final State state, final int page, final int perPage) {
+        return execute(new GitLabOperation<List<MergeRequest>>() {
+            @Override
+            List<MergeRequest> execute(GitLabClient client) {
+                return client.getMergeRequests(projectId, state, page, perPage);
+            }
+        });
     }
 
     @Override
     public List<Branch> getBranches(final String projectId) {
-        return execute(
-            new GitLabOperation<List<Branch>>() {
-                @Override
-                List<Branch> execute(GitLabClient client) {
-                    return client.getBranches(projectId);
-                }
-            });
+        return execute(new GitLabOperation<List<Branch>>() {
+            @Override
+            List<Branch> execute(GitLabClient client) {
+                return client.getBranches(projectId);
+            }
+        });
     }
 
     @Override
     public Branch getBranch(final String projectId, final String branch) {
-        return execute(
-            new GitLabOperation<Branch>() {
-                @Override
-                Branch execute(GitLabClient client) {
-                    return client.getBranch(projectId, branch);
-                }
-            });
+        return execute(new GitLabOperation<Branch>() {
+            @Override
+            Branch execute(GitLabClient client) {
+                return client.getBranch(projectId, branch);
+            }
+        });
     }
 
     @Override
     public User getCurrentUser() {
-        return execute(
-            new GitLabOperation<User>() {
-                @Override
-                User execute(GitLabClient client) {
-                    return client.getCurrentUser();
-                }
-            });
+        return execute(new GitLabOperation<User>() {
+            @Override
+            User execute(GitLabClient client) {
+                return client.getCurrentUser();
+            }
+        });
     }
 
     @Override
     public User addUser(final String email, final String username, final String name, final String password) {
-        return execute(
-            new GitLabOperation<User>() {
-                @Override
-                User execute(GitLabClient client) {
-                    return client.addUser(email, username, name, password);
-                }
-            });
+        return execute(new GitLabOperation<User>() {
+            @Override
+            User execute(GitLabClient client) {
+                return client.addUser(email, username, name, password);
+            }
+        });
     }
 
     @Override
-    public User updateUser(final String userId, final String email, final String username, final String name, final String password) {
-        return execute(
-            new GitLabOperation<User>() {
-                @Override
-                User execute(GitLabClient client) {
-                    return client.updateUser(userId, email, username, name, password);
-                }
-            });
+    public User updateUser(
+            final String userId, final String email, final String username, final String name, final String password) {
+        return execute(new GitLabOperation<User>() {
+            @Override
+            User execute(GitLabClient client) {
+                return client.updateUser(userId, email, username, name, password);
+            }
+        });
     }
 
     @Override
     public List<Label> getLabels(final String projectId) {
-        return execute(
-            new GitLabOperation<List<Label>>() {
-                @Override
-                List<Label> execute(GitLabClient client) {
-                    return client.getLabels(projectId);
-                }
-            });
+        return execute(new GitLabOperation<List<Label>>() {
+            @Override
+            List<Label> execute(GitLabClient client) {
+                return client.getLabels(projectId);
+            }
+        });
     }
 
     @Override
     public List<Pipeline> getPipelines(final String projectName) {
-        return execute(
-            new GitLabOperation<List<Pipeline>>() {
-                @Override
-                List<Pipeline> execute(GitLabClient client) {
-                    return client.getPipelines(projectName);
-                }
-            });
+        return execute(new GitLabOperation<List<Pipeline>>() {
+            @Override
+            List<Pipeline> execute(GitLabClient client) {
+                return client.getPipelines(projectName);
+            }
+        });
     }
 
     private GitLabClient delegate(boolean reset) {
@@ -375,7 +380,8 @@ final class AutodetectingGitLabClient implements GitLabClient {
 
     private GitLabClient autodetect() {
         for (GitLabClientBuilder candidate : builders) {
-            GitLabClient client = candidate.buildClient(url, token, ignoreCertificateErrors, connectionTimeout, readTimeout);
+            GitLabClient client =
+                    candidate.buildClient(url, token, ignoreCertificateErrors, connectionTimeout, readTimeout);
             try {
                 client.getCurrentUser();
                 return client;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/GitLabApiProxy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/GitLabApiProxy.java
@@ -6,7 +6,9 @@ import java.util.List;
 
 interface GitLabApiProxy {
     List<Group> getGroups(Boolean allAvailable, Boolean topLevelOnly, String orderBy, String sort);
-    List<Project> getGroupProjects(String groupId, Boolean includeSubgroups, String visibility, String orderBy, String sort);
+
+    List<Project> getGroupProjects(
+            String groupId, Boolean includeSubgroups, String visibility, String orderBy, String sort);
 
     Project createProject(String projectName);
 
@@ -20,17 +22,39 @@ interface GitLabApiProxy {
 
     List<ProjectHook> getProjectHooks(String projectName);
 
-    void addProjectHook(String projectId, String url, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents);
+    void addProjectHook(
+            String projectId, String url, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents);
 
-    void addProjectHook(String projectId, String url, String secretToken, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents);
+    void addProjectHook(
+            String projectId,
+            String url,
+            String secretToken,
+            Boolean pushEvents,
+            Boolean mergeRequestEvents,
+            Boolean noteEvents);
 
-    void changeBuildStatus(String projectId, String sha, BuildState state, String ref, String context, String targetUrl, String description);
+    void changeBuildStatus(
+            String projectId,
+            String sha,
+            BuildState state,
+            String ref,
+            String context,
+            String targetUrl,
+            String description);
 
-    void changeBuildStatus(Integer projectId, String sha, BuildState state, String ref, String context, String targetUrl, String description);
+    void changeBuildStatus(
+            Integer projectId,
+            String sha,
+            BuildState state,
+            String ref,
+            String context,
+            String targetUrl,
+            String description);
 
     void getCommit(String projectId, String sha);
 
-    void acceptMergeRequest(Integer projectId, Integer mergeRequestId, String mergeCommitMessage, Boolean shouldRemoveSourceBranch);
+    void acceptMergeRequest(
+            Integer projectId, Integer mergeRequestId, String mergeCommitMessage, Boolean shouldRemoveSourceBranch);
 
     void createMergeRequestNote(Integer projectId, Integer mergeRequestId, String body);
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClient.java
@@ -24,45 +24,36 @@ final class ResteasyGitLabClient implements GitLabClient {
 
     @Override
     public List<Group> getGroups() {
-        return api.getGroups(
-            true,
-            false,
-            OrderType.path.name(),
-            SortType.asc.name()
-        );
+        return api.getGroups(true, false, OrderType.path.name(), SortType.asc.name());
     }
 
     @Override
     public List<Group> getGroups(Boolean allAvailable, Boolean topLevelOnly, OrderType orderBy, SortType sort) {
         return api.getGroups(
-            allAvailable,
-            topLevelOnly,
-            orderBy == null ? OrderType.path.name() : orderBy.name(),
-            sort == null ? SortType.asc.name() : sort.name()
-        );
+                allAvailable,
+                topLevelOnly,
+                orderBy == null ? OrderType.path.name() : orderBy.name(),
+                sort == null ? SortType.asc.name() : sort.name());
     }
 
     @Override
     public List<Project> getGroupProjects(String groupId) {
-        return api.getGroupProjects(
-            groupId,
-            Boolean.FALSE,
-            null,
-            OrderType.path.name(),
-            SortType.asc.name()
-        );
+        return api.getGroupProjects(groupId, Boolean.FALSE, null, OrderType.path.name(), SortType.asc.name());
     }
 
     @Override
-    public List<Project> getGroupProjects(String groupId, Boolean includeSubgroups, ProjectVisibilityType visibility,
-            OrderType orderBy, SortType sort) {
+    public List<Project> getGroupProjects(
+            String groupId,
+            Boolean includeSubgroups,
+            ProjectVisibilityType visibility,
+            OrderType orderBy,
+            SortType sort) {
         return api.getGroupProjects(
-            groupId,
-            includeSubgroups == null ? Boolean.FALSE : includeSubgroups,
-            visibility == null ? null : visibility.getValue(),
-            orderBy == null ? OrderType.path.name() : orderBy.name(),
-            sort == null ? SortType.asc.name() : sort.name()
-        );
+                groupId,
+                includeSubgroups == null ? Boolean.FALSE : includeSubgroups,
+                visibility == null ? null : visibility.getValue(),
+                orderBy == null ? OrderType.path.name() : orderBy.name(),
+                sort == null ? SortType.asc.name() : sort.name());
     }
 
     @Override
@@ -96,22 +87,43 @@ final class ResteasyGitLabClient implements GitLabClient {
     }
 
     @Override
-    public void addProjectHook(String projectId, String url, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents) {
+    public void addProjectHook(
+            String projectId, String url, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents) {
         api.addProjectHook(projectId, url, pushEvents, mergeRequestEvents, noteEvents);
     }
 
     @Override
-    public void addProjectHook(String projectId, String url, String secretToken, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents) {
+    public void addProjectHook(
+            String projectId,
+            String url,
+            String secretToken,
+            Boolean pushEvents,
+            Boolean mergeRequestEvents,
+            Boolean noteEvents) {
         api.addProjectHook(projectId, url, secretToken, pushEvents, mergeRequestEvents, noteEvents);
     }
 
     @Override
-    public void changeBuildStatus(String projectId, String sha, BuildState state, String ref, String context, String targetUrl, String description) {
+    public void changeBuildStatus(
+            String projectId,
+            String sha,
+            BuildState state,
+            String ref,
+            String context,
+            String targetUrl,
+            String description) {
         api.changeBuildStatus(projectId, sha, state, ref, context, targetUrl, description);
     }
 
     @Override
-    public void changeBuildStatus(Integer projectId, String sha, BuildState state, String ref, String context, String targetUrl, String description) {
+    public void changeBuildStatus(
+            Integer projectId,
+            String sha,
+            BuildState state,
+            String ref,
+            String context,
+            String targetUrl,
+            String description) {
         api.changeBuildStatus(projectId, sha, state, ref, context, targetUrl, description);
     }
 
@@ -122,7 +134,8 @@ final class ResteasyGitLabClient implements GitLabClient {
 
     @Override
     public void acceptMergeRequest(MergeRequest mr, String mergeCommitMessage, Boolean shouldRemoveSourceBranch) {
-        api.acceptMergeRequest(mr.getProjectId(), mergeRequestIdProvider.apply(mr), mergeCommitMessage, shouldRemoveSourceBranch);
+        api.acceptMergeRequest(
+                mr.getProjectId(), mergeRequestIdProvider.apply(mr), mergeCommitMessage, shouldRemoveSourceBranch);
     }
 
     @Override

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClientBuilder.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClientBuilder.java
@@ -1,5 +1,6 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.impl;
 
+import static java.net.Proxy.Type.HTTP;
 
 import com.dabsquared.gitlabjenkins.gitlab.JacksonConfig;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
@@ -8,13 +9,37 @@ import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
 import com.dabsquared.gitlabjenkins.util.JsonUtil;
 import com.dabsquared.gitlabjenkins.util.LoggerUtil;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ProxyConfiguration;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import javax.annotation.Priority;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.RuntimeDelegate;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -38,34 +63,6 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import javax.annotation.Priority;
-import javax.ws.rs.Priorities;
-import javax.ws.rs.client.ClientRequestContext;
-import javax.ws.rs.client.ClientRequestFilter;
-import javax.ws.rs.client.ClientResponseContext;
-import javax.ws.rs.client.ClientResponseFilter;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.RuntimeDelegate;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
-import java.net.Proxy;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-
-import static java.net.Proxy.Type.HTTP;
-
-
 @Restricted(NoExternalUse.class)
 public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
     private static final Logger LOGGER = Logger.getLogger(ResteasyGitLabClientBuilder.class.getName());
@@ -79,7 +76,11 @@ public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
     private final Class<? extends GitLabApiProxy> apiProxyClass;
     private final Function<MergeRequest, Integer> mergeRequestIdProvider;
 
-    ResteasyGitLabClientBuilder(String id, int ordinal, Class<? extends GitLabApiProxy> apiProxyClass, Function<MergeRequest, Integer> mergeRequestIdProvider) {
+    ResteasyGitLabClientBuilder(
+            String id,
+            int ordinal,
+            Class<? extends GitLabApiProxy> apiProxyClass,
+            Function<MergeRequest, Integer> mergeRequestIdProvider) {
         super(id, ordinal);
         this.apiProxyClass = apiProxyClass;
         this.mergeRequestIdProvider = mergeRequestIdProvider;
@@ -87,18 +88,24 @@ public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
 
     @NonNull
     @Override
-    public final GitLabClient buildClient(String url, String apiToken, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout) {
+    public final GitLabClient buildClient(
+            String url, String apiToken, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout) {
         return buildClient(
-            url,
-            apiToken,
-            Jenkins.getActiveInstance().proxy,
-            ignoreCertificateErrors,
-            connectionTimeout,
-            readTimeout
-        );
+                url,
+                apiToken,
+                Jenkins.getActiveInstance().proxy,
+                ignoreCertificateErrors,
+                connectionTimeout,
+                readTimeout);
     }
 
-    private GitLabClient buildClient(String url, String apiToken, ProxyConfiguration httpProxyConfig, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout) {
+    private GitLabClient buildClient(
+            String url,
+            String apiToken,
+            ProxyConfiguration httpProxyConfig,
+            boolean ignoreCertificateErrors,
+            int connectionTimeout,
+            int readTimeout) {
         ResteasyClientBuilder builder = new ResteasyClientBuilder();
 
         if (ignoreCertificateErrors) {
@@ -111,42 +118,39 @@ public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
             if (proxy.type() == HTTP) {
                 InetSocketAddress address = (InetSocketAddress) proxy.address();
                 String hostname = address.getHostString().replaceFirst("^.*://", "");
-                builder.defaultProxy(hostname,
-                    address.getPort(),
-                    address.getHostName().startsWith("https") ? "https" : "http");
+                builder.defaultProxy(
+                        hostname, address.getPort(), address.getHostName().startsWith("https") ? "https" : "http");
 
-                if (httpProxyConfig.getUserName() != null
-                        && httpProxyConfig.getPassword() != null) {
+                if (httpProxyConfig.getUserName() != null && httpProxyConfig.getPassword() != null) {
                     CredentialsProvider proxyCredentials = new BasicCredentialsProvider();
                     proxyCredentials.setCredentials(
                             new AuthScope(hostname, address.getPort()),
                             new UsernamePasswordCredentials(
                                     httpProxyConfig.getUserName(), httpProxyConfig.getPassword()));
 
-                    ClientHttpEngine httpEngine =
-                            new ClientHttpEngineBuilder43(proxyCredentials)
-                                    .resteasyClientBuilder(builder)
-                                    .build();
+                    ClientHttpEngine httpEngine = new ClientHttpEngineBuilder43(proxyCredentials)
+                            .resteasyClientBuilder(builder)
+                            .build();
                     builder.httpEngine(httpEngine);
                 }
             }
         }
 
-        GitLabApiProxy apiProxy = builder
-            .connectionPoolSize(60)
-            .maxPooledPerRoute(30)
-            .establishConnectionTimeout(connectionTimeout, TimeUnit.SECONDS)
-            .socketTimeout(readTimeout, TimeUnit.SECONDS)
-            .register(new JacksonFeature())
-            .register(new JacksonConfig())
-            .register(new ApiHeaderTokenFilter(apiToken))
-            .register(new LoggingFilter())
-            .register(new RemoveAcceptEncodingFilter())
-            .register(new JaxrsFormProvider())
-            .build().target(url)
-            .proxyBuilder(apiProxyClass)
-            .classloader(apiProxyClass.getClassLoader())
-            .build();
+        GitLabApiProxy apiProxy = builder.connectionPoolSize(60)
+                .maxPooledPerRoute(30)
+                .establishConnectionTimeout(connectionTimeout, TimeUnit.SECONDS)
+                .socketTimeout(readTimeout, TimeUnit.SECONDS)
+                .register(new JacksonFeature())
+                .register(new JacksonConfig())
+                .register(new ApiHeaderTokenFilter(apiToken))
+                .register(new LoggingFilter())
+                .register(new RemoveAcceptEncodingFilter())
+                .register(new JaxrsFormProvider())
+                .build()
+                .target(url)
+                .proxyBuilder(apiProxyClass)
+                .classloader(apiProxyClass.getClassLoader())
+                .build();
 
         return new ResteasyGitLabClient(url, apiProxy, mergeRequestIdProvider);
     }
@@ -177,16 +181,25 @@ public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
         @Override
         public void filter(ClientRequestContext context) {
             if (LOGGER.isLoggable(Level.FINEST)) {
-                LOGGER.log(Level.FINEST, "Call GitLab:\nHTTP method: {0}\nURL: {1}\nRequest headers: [\n{2}\n]",
-                        LoggerUtil.toArray(context.getMethod(), context.getUri(), toFilteredString(context.getStringHeaders())));
+                LOGGER.log(
+                        Level.FINEST,
+                        "Call GitLab:\nHTTP method: {0}\nURL: {1}\nRequest headers: [\n{2}\n]",
+                        LoggerUtil.toArray(
+                                context.getMethod(), context.getUri(), toFilteredString(context.getStringHeaders())));
             }
         }
 
         @Override
         public void filter(ClientRequestContext request, ClientResponseContext response) {
             if (LOGGER.isLoggable(Level.FINEST)) {
-                LOGGER.log(Level.FINEST, "Got response from GitLab:\nURL: {0}\nStatus: {1} {2}\nResponse headers: [\n{3}\n]\nResponse body: {4}",
-                        LoggerUtil.toArray(request.getUri(), response.getStatus(), response.getStatusInfo(), toString(response.getHeaders()),
+                LOGGER.log(
+                        Level.FINEST,
+                        "Got response from GitLab:\nURL: {0}\nStatus: {1} {2}\nResponse headers: [\n{3}\n]\nResponse body: {4}",
+                        LoggerUtil.toArray(
+                                request.getUri(),
+                                response.getStatus(),
+                                response.getStatusInfo(),
+                                toString(response.getHeaders()),
                                 getPrettyPrintResponseBody(response)));
             }
         }
@@ -201,14 +214,16 @@ public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
 
         private String getPrettyPrintResponseBody(ClientResponseContext responseContext) {
             String responseBody = getResponseBody(responseContext);
-            if (StringUtils.isNotEmpty(responseBody) && responseContext.getMediaType().equals(MediaType.APPLICATION_JSON_TYPE)) {
+            if (StringUtils.isNotEmpty(responseBody)
+                    && responseContext.getMediaType().equals(MediaType.APPLICATION_JSON_TYPE)) {
                 return JsonUtil.toPrettyPrint(responseBody);
             }
             return responseBody;
         }
 
         private String getResponseBody(ClientResponseContext context) {
-            // Cannot use try-with-resources here because the stream needs to remain open for reading later. Instead, we reset it when done.
+            // Cannot use try-with-resources here because the stream needs to remain open for reading later. Instead, we
+            // reset it when done.
             try {
                 InputStream entityStream = context.getEntityStream();
                 if (entityStream != null && entityStream.markSupported()) {
@@ -240,7 +255,9 @@ public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
             @CheckForNull
             @Override
             public String apply(Map.Entry<String, List<String>> input) {
-                return input == null ? null : input.getKey() + " = [" + input.getValue().stream().collect(Collectors.joining(", ")) + "]";
+                return input == null
+                        ? null
+                        : input.getKey() + " = [" + input.getValue().stream().collect(Collectors.joining(", ")) + "]";
             }
         }
     }
@@ -248,6 +265,7 @@ public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
     @Priority(Priorities.HEADER_DECORATOR)
     private static class RemoveAcceptEncodingFilter implements ClientRequestFilter {
         RemoveAcceptEncodingFilter() {}
+
         @Override
         public void filter(ClientRequestContext clientRequestContext) {
             clientRequestContext.getHeaders().remove("Accept-Encoding");
@@ -279,33 +297,27 @@ public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
                 final HostnameVerifier verifier,
                 final SSLContext theContext) {
             final HttpClient httpClient;
-            rcBuilder.setProxy(
-                    new HttpHost(
-                            that.getDefaultProxyHostname(),
-                            that.getDefaultProxyPort(),
-                            that.getDefaultProxyScheme()));
+            rcBuilder.setProxy(new HttpHost(
+                    that.getDefaultProxyHostname(), that.getDefaultProxyPort(), that.getDefaultProxyScheme()));
             if (System.getSecurityManager() == null) {
-                httpClient =
-                        HttpClientBuilder.create()
+                httpClient = HttpClientBuilder.create()
+                        .setConnectionManager(cm)
+                        .setDefaultCredentialsProvider(proxyCredentials)
+                        .setDefaultRequestConfig(rcBuilder.build())
+                        .disableContentCompression()
+                        .build();
+            } else {
+                httpClient = AccessController.doPrivileged(new PrivilegedAction<HttpClient>() {
+                    @Override
+                    public HttpClient run() {
+                        return HttpClientBuilder.create()
                                 .setConnectionManager(cm)
                                 .setDefaultCredentialsProvider(proxyCredentials)
                                 .setDefaultRequestConfig(rcBuilder.build())
                                 .disableContentCompression()
                                 .build();
-            } else {
-                httpClient =
-                        AccessController.doPrivileged(
-                                new PrivilegedAction<HttpClient>() {
-                                    @Override
-                                    public HttpClient run() {
-                                        return HttpClientBuilder.create()
-                                                .setConnectionManager(cm)
-                                                .setDefaultCredentialsProvider(proxyCredentials)
-                                                .setDefaultRequestConfig(rcBuilder.build())
-                                                .disableContentCompression()
-                                                .build();
-                                    }
-                                });
+                    }
+                });
             }
 
             ApacheHttpClient43Engine engine =

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V3GitLabApiProxy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V3GitLabApiProxy.java
@@ -40,23 +40,21 @@ interface V3GitLabApiProxy extends GitLabApiProxy {
     @Path("/groups")
     @Override
     List<Group> getGroups(
-        @QueryParam("all_available") Boolean allAvailable,
-        @QueryParam("top_level_only") Boolean topLevelOnly,
-        @QueryParam("order_by") String orderBy,
-        @QueryParam("sort") String sort
-    );
+            @QueryParam("all_available") Boolean allAvailable,
+            @QueryParam("top_level_only") Boolean topLevelOnly,
+            @QueryParam("order_by") String orderBy,
+            @QueryParam("sort") String sort);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/groups/{groupId}/projects")
     @Override
     List<Project> getGroupProjects(
-        @PathParam("groupId") @Encoded String groupId,
-        @QueryParam("include_subgroups") Boolean includeSubgroups,
-        @QueryParam("visibility") String visibility,
-        @QueryParam("order_by") String orderBy,
-        @QueryParam("sort") String sort
-    );
+            @PathParam("groupId") @Encoded String groupId,
+            @QueryParam("include_subgroups") Boolean includeSubgroups,
+            @QueryParam("visibility") String visibility,
+            @QueryParam("order_by") String orderBy,
+            @QueryParam("sort") String sort);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
@@ -71,10 +69,10 @@ interface V3GitLabApiProxy extends GitLabApiProxy {
     @Path("/projects/{projectId}/merge_requests")
     @Override
     MergeRequest createMergeRequest(
-        @PathParam("projectId") @Encoded Integer projectId,
-        @FormParam("source_branch") String sourceBranch,
-        @FormParam("target_branch") String targetBranch,
-        @FormParam("title") String title);
+            @PathParam("projectId") @Encoded Integer projectId,
+            @FormParam("source_branch") String sourceBranch,
+            @FormParam("target_branch") String targetBranch,
+            @FormParam("title") String title);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -87,9 +85,10 @@ interface V3GitLabApiProxy extends GitLabApiProxy {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}")
     @Override
-    Project updateProject(@PathParam("projectId") @Encoded String projectId,
-                          @FormParam("name") String name,
-                          @FormParam("path") String path);
+    Project updateProject(
+            @PathParam("projectId") @Encoded String projectId,
+            @FormParam("name") String name,
+            @FormParam("path") String path);
 
     @DELETE
     @Path("/projects/{projectId}")
@@ -107,49 +106,53 @@ interface V3GitLabApiProxy extends GitLabApiProxy {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/hooks")
     @Override
-    void addProjectHook(@PathParam("projectId") @Encoded String projectId,
-                        @FormParam("url") String url,
-                        @FormParam("push_events") Boolean pushEvents,
-                        @FormParam("merge_requests_events") Boolean mergeRequestEvents,
-                        @FormParam("note_events") Boolean noteEvents);
+    void addProjectHook(
+            @PathParam("projectId") @Encoded String projectId,
+            @FormParam("url") String url,
+            @FormParam("push_events") Boolean pushEvents,
+            @FormParam("merge_requests_events") Boolean mergeRequestEvents,
+            @FormParam("note_events") Boolean noteEvents);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/hooks")
     @Override
-    void addProjectHook(@PathParam("projectId") @Encoded String projectId,
-                        @FormParam("url") String url,
-                        @FormParam("token") String secretToken,
-                        @FormParam("push_events") Boolean pushEvents,
-                        @FormParam("merge_requests_events") Boolean mergeRequestEvents,
-                        @FormParam("note_events") Boolean noteEvents);
+    void addProjectHook(
+            @PathParam("projectId") @Encoded String projectId,
+            @FormParam("url") String url,
+            @FormParam("token") String secretToken,
+            @FormParam("push_events") Boolean pushEvents,
+            @FormParam("merge_requests_events") Boolean mergeRequestEvents,
+            @FormParam("note_events") Boolean noteEvents);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/statuses/{sha}")
     @Override
-    void changeBuildStatus(@PathParam("projectId") @Encoded String projectId,
-                           @PathParam("sha") @Encoded String sha,
-                           @FormParam("state") BuildState state,
-                           @FormParam("ref") String ref,
-                           @FormParam("context") String context,
-                           @FormParam("target_url") String targetUrl,
-                           @FormParam("description") String description);
+    void changeBuildStatus(
+            @PathParam("projectId") @Encoded String projectId,
+            @PathParam("sha") @Encoded String sha,
+            @FormParam("state") BuildState state,
+            @FormParam("ref") String ref,
+            @FormParam("context") String context,
+            @FormParam("target_url") String targetUrl,
+            @FormParam("description") String description);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/statuses/{sha}")
     @Override
-    void changeBuildStatus(@PathParam("projectId") @Encoded Integer projectId,
-                           @PathParam("sha") @Encoded String sha,
-                           @FormParam("state") BuildState state,
-                           @FormParam("ref") String ref,
-                           @FormParam("context") String context,
-                           @FormParam("target_url") String targetUrl,
-                           @FormParam("description") String description);
+    void changeBuildStatus(
+            @PathParam("projectId") @Encoded Integer projectId,
+            @PathParam("sha") @Encoded String sha,
+            @FormParam("state") BuildState state,
+            @FormParam("ref") String ref,
+            @FormParam("context") String context,
+            @FormParam("target_url") String targetUrl,
+            @FormParam("description") String description);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -157,60 +160,65 @@ interface V3GitLabApiProxy extends GitLabApiProxy {
     @Override
     void getCommit(@PathParam("projectId") @Encoded String projectId, @PathParam("sha") @Encoded String sha);
 
-
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/merge_requests/{mergeRequestId}/merge")
     @Override
-    void acceptMergeRequest(@PathParam("projectId") @Encoded Integer projectId,
-                            @PathParam("mergeRequestId") @Encoded Integer mergeRequestId,
-                            @FormParam("merge_commit_message") String mergeCommitMessage,
-                            @FormParam("should_remove_source_branch") Boolean shouldRemoveSourceBranch);
+    void acceptMergeRequest(
+            @PathParam("projectId") @Encoded Integer projectId,
+            @PathParam("mergeRequestId") @Encoded Integer mergeRequestId,
+            @FormParam("merge_commit_message") String mergeCommitMessage,
+            @FormParam("should_remove_source_branch") Boolean shouldRemoveSourceBranch);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/merge_requests/{mergeRequestId}/notes")
     @Override
-    void createMergeRequestNote(@PathParam("projectId") @Encoded Integer projectId,
-                                @PathParam("mergeRequestId") @Encoded Integer mergeRequestId,
-                                @FormParam("body") String body);
+    void createMergeRequestNote(
+            @PathParam("projectId") @Encoded Integer projectId,
+            @PathParam("mergeRequestId") @Encoded Integer mergeRequestId,
+            @FormParam("body") String body);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/merge_requests/{mergeRequestId}/award_emoji")
     @Override
-    List<Awardable> getMergeRequestEmoji(@PathParam("projectId") @Encoded Integer projectId,
-                              @PathParam("mergeRequestId") @Encoded Integer mergeRequestId);
+    List<Awardable> getMergeRequestEmoji(
+            @PathParam("projectId") @Encoded Integer projectId,
+            @PathParam("mergeRequestId") @Encoded Integer mergeRequestId);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/merge_requests/{mergeRequestId}/award_emoji")
     @Override
-    void awardMergeRequestEmoji(@PathParam("projectId") @Encoded Integer projectId,
-                                @PathParam("mergeRequestId") @Encoded Integer mergeRequestId,
-                                @QueryParam("name") String name);
+    void awardMergeRequestEmoji(
+            @PathParam("projectId") @Encoded Integer projectId,
+            @PathParam("mergeRequestId") @Encoded Integer mergeRequestId,
+            @QueryParam("name") String name);
 
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/merge_requests/{mergeRequestId}/award_emoji/{awardId}")
     @Override
-    void deleteMergeRequestEmoji(@PathParam("projectId") @Encoded Integer projectId,
-                                @PathParam("mergeRequestId") @Encoded Integer mergeRequestId,
-                                @PathParam("awardId") @Encoded Integer awardId);
+    void deleteMergeRequestEmoji(
+            @PathParam("projectId") @Encoded Integer projectId,
+            @PathParam("mergeRequestId") @Encoded Integer mergeRequestId,
+            @PathParam("awardId") @Encoded Integer awardId);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/projects/{projectId}/merge_requests")
     @Override
-    List<MergeRequest> getMergeRequests(@PathParam("projectId") @Encoded String projectId,
-                                        @QueryParam("state") State state,
-                                        @QueryParam("page") int page,
-                                        @QueryParam("per_page") int perPage);
+    List<MergeRequest> getMergeRequests(
+            @PathParam("projectId") @Encoded String projectId,
+            @QueryParam("state") State state,
+            @QueryParam("page") int page,
+            @QueryParam("per_page") int perPage);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -222,8 +230,7 @@ interface V3GitLabApiProxy extends GitLabApiProxy {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/projects/{projectId}/repository/branches/{branch}")
     @Override
-    Branch getBranch(@PathParam("projectId") @Encoded String projectId,
-                     @PathParam("branch") @Encoded String branch);
+    Branch getBranch(@PathParam("projectId") @Encoded String projectId, @PathParam("branch") @Encoded String branch);
 
     @HEAD
     @Produces(MediaType.APPLICATION_JSON)
@@ -242,21 +249,23 @@ interface V3GitLabApiProxy extends GitLabApiProxy {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/users")
     @Override
-    User addUser(@FormParam("email") String email,
-                 @FormParam("username") String username,
-                 @FormParam("name") String name,
-                 @FormParam("password") String password);
+    User addUser(
+            @FormParam("email") String email,
+            @FormParam("username") String username,
+            @FormParam("name") String name,
+            @FormParam("password") String password);
 
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/users/{userId}")
     @Override
-    User updateUser(@PathParam("userId") @Encoded String userId,
-                    @FormParam("email") String email,
-                    @FormParam("username") String username,
-                    @FormParam("name") String name,
-                    @FormParam("password") String password);
+    User updateUser(
+            @PathParam("userId") @Encoded String userId,
+            @FormParam("email") String email,
+            @FormParam("username") String username,
+            @FormParam("name") String name,
+            @FormParam("password") String password);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V3GitLabClientBuilder.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V3GitLabClientBuilder.java
@@ -1,23 +1,22 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.impl;
 
-
 import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
 import hudson.Extension;
 import java.util.function.Function;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-
 @Extension
 @Restricted(NoExternalUse.class)
 public final class V3GitLabClientBuilder extends ResteasyGitLabClientBuilder {
     private static final int ORDINAL = 2;
-    private static final Function<MergeRequest, Integer> MERGE_REQUEST_ID_PROVIDER = new Function<MergeRequest, Integer>() {
-        @Override
-        public Integer apply(MergeRequest mergeRequest) {
-            return mergeRequest.getId();
-        }
-    };
+    private static final Function<MergeRequest, Integer> MERGE_REQUEST_ID_PROVIDER =
+            new Function<MergeRequest, Integer>() {
+                @Override
+                public Integer apply(MergeRequest mergeRequest) {
+                    return mergeRequest.getId();
+                }
+            };
 
     public V3GitLabClientBuilder() {
         super(V3GitLabApiProxy.ID, ORDINAL, V3GitLabApiProxy.class, MERGE_REQUEST_ID_PROVIDER);

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V4GitLabApiProxy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V4GitLabApiProxy.java
@@ -31,23 +31,21 @@ interface V4GitLabApiProxy extends GitLabApiProxy {
     @Path("/groups")
     @Override
     List<Group> getGroups(
-        @QueryParam("all_available") Boolean allAvailable,
-        @QueryParam("top_level_only") Boolean topLevelOnly,
-        @QueryParam("order_by") String orderBy,
-        @QueryParam("sort") String sort
-    );
+            @QueryParam("all_available") Boolean allAvailable,
+            @QueryParam("top_level_only") Boolean topLevelOnly,
+            @QueryParam("order_by") String orderBy,
+            @QueryParam("sort") String sort);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/groups/{groupId}/projects")
     @Override
     List<Project> getGroupProjects(
-        @PathParam("groupId") @Encoded String groupId,
-        @QueryParam("include_subgroups") Boolean includeSubgroups,
-        @QueryParam("visibility") String visibility,
-        @QueryParam("order_by") String orderBy,
-        @QueryParam("sort") String sort
-    );
+            @PathParam("groupId") @Encoded String groupId,
+            @QueryParam("include_subgroups") Boolean includeSubgroups,
+            @QueryParam("visibility") String visibility,
+            @QueryParam("order_by") String orderBy,
+            @QueryParam("sort") String sort);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
@@ -62,10 +60,10 @@ interface V4GitLabApiProxy extends GitLabApiProxy {
     @Path("/projects/{projectId}/merge_requests")
     @Override
     MergeRequest createMergeRequest(
-        @PathParam("projectId") @Encoded Integer projectId,
-        @FormParam("source_branch") String sourceBranch,
-        @FormParam("target_branch") String targetBranch,
-        @FormParam("title") String title);
+            @PathParam("projectId") @Encoded Integer projectId,
+            @FormParam("source_branch") String sourceBranch,
+            @FormParam("target_branch") String targetBranch,
+            @FormParam("title") String title);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -78,9 +76,10 @@ interface V4GitLabApiProxy extends GitLabApiProxy {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}")
     @Override
-    Project updateProject(@PathParam("projectId") @Encoded String projectId,
-                          @FormParam("name") String name,
-                          @FormParam("path") String path);
+    Project updateProject(
+            @PathParam("projectId") @Encoded String projectId,
+            @FormParam("name") String name,
+            @FormParam("path") String path);
 
     @DELETE
     @Path("/projects/{projectId}")
@@ -98,49 +97,53 @@ interface V4GitLabApiProxy extends GitLabApiProxy {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/hooks")
     @Override
-    void addProjectHook(@PathParam("projectId") @Encoded String projectId,
-                        @FormParam("url") String url,
-                        @FormParam("push_events") Boolean pushEvents,
-                        @FormParam("merge_requests_events") Boolean mergeRequestEvents,
-                        @FormParam("note_events") Boolean noteEvents);
+    void addProjectHook(
+            @PathParam("projectId") @Encoded String projectId,
+            @FormParam("url") String url,
+            @FormParam("push_events") Boolean pushEvents,
+            @FormParam("merge_requests_events") Boolean mergeRequestEvents,
+            @FormParam("note_events") Boolean noteEvents);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/hooks")
     @Override
-    void addProjectHook(@PathParam("projectId") @Encoded String projectId,
-                        @FormParam("url") String url,
-                        @FormParam("token") String secretToken,
-                        @FormParam("push_events") Boolean pushEvents,
-                        @FormParam("merge_requests_events") Boolean mergeRequestEvents,
-                        @FormParam("note_events") Boolean noteEvents);
+    void addProjectHook(
+            @PathParam("projectId") @Encoded String projectId,
+            @FormParam("url") String url,
+            @FormParam("token") String secretToken,
+            @FormParam("push_events") Boolean pushEvents,
+            @FormParam("merge_requests_events") Boolean mergeRequestEvents,
+            @FormParam("note_events") Boolean noteEvents);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/statuses/{sha}")
     @Override
-    void changeBuildStatus(@PathParam("projectId") @Encoded String projectId,
-                           @PathParam("sha") @Encoded String sha,
-                           @FormParam("state") BuildState state,
-                           @FormParam("ref") String ref,
-                           @FormParam("context") String context,
-                           @FormParam("target_url") String targetUrl,
-                           @FormParam("description") String description);
+    void changeBuildStatus(
+            @PathParam("projectId") @Encoded String projectId,
+            @PathParam("sha") @Encoded String sha,
+            @FormParam("state") BuildState state,
+            @FormParam("ref") String ref,
+            @FormParam("context") String context,
+            @FormParam("target_url") String targetUrl,
+            @FormParam("description") String description);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/statuses/{sha}")
     @Override
-    void changeBuildStatus(@PathParam("projectId") @Encoded Integer projectId,
-                           @PathParam("sha") @Encoded String sha,
-                           @FormParam("state") BuildState state,
-                           @FormParam("ref") String ref,
-                           @FormParam("context") String context,
-                           @FormParam("target_url") String targetUrl,
-                           @FormParam("description") String description);
+    void changeBuildStatus(
+            @PathParam("projectId") @Encoded Integer projectId,
+            @PathParam("sha") @Encoded String sha,
+            @FormParam("state") BuildState state,
+            @FormParam("ref") String ref,
+            @FormParam("context") String context,
+            @FormParam("target_url") String targetUrl,
+            @FormParam("description") String description);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -148,60 +151,65 @@ interface V4GitLabApiProxy extends GitLabApiProxy {
     @Override
     void getCommit(@PathParam("projectId") @Encoded String projectId, @PathParam("sha") @Encoded String sha);
 
-
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/merge_requests/{mergeRequestIid}/merge")
     @Override
-    void acceptMergeRequest(@PathParam("projectId") @Encoded Integer projectId,
-                            @PathParam("mergeRequestIid") @Encoded Integer mergeRequestIid,
-                            @FormParam("merge_commit_message") String mergeCommitMessage,
-                            @FormParam("should_remove_source_branch") Boolean shouldRemoveSourceBranch);
+    void acceptMergeRequest(
+            @PathParam("projectId") @Encoded Integer projectId,
+            @PathParam("mergeRequestIid") @Encoded Integer mergeRequestIid,
+            @FormParam("merge_commit_message") String mergeCommitMessage,
+            @FormParam("should_remove_source_branch") Boolean shouldRemoveSourceBranch);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/merge_requests/{mergeRequestIid}/notes")
     @Override
-    void createMergeRequestNote(@PathParam("projectId") @Encoded Integer projectId,
-                                @PathParam("mergeRequestIid") @Encoded Integer mergeRequestIid,
-                                @FormParam("body") String body);
+    void createMergeRequestNote(
+            @PathParam("projectId") @Encoded Integer projectId,
+            @PathParam("mergeRequestIid") @Encoded Integer mergeRequestIid,
+            @FormParam("body") String body);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/merge_requests/{mergeRequestIid}/award_emoji")
     @Override
-    List<Awardable> getMergeRequestEmoji(@PathParam("projectId") @Encoded Integer projectId,
-                                         @PathParam("mergeRequestIid") @Encoded Integer mergeRequestIid);
+    List<Awardable> getMergeRequestEmoji(
+            @PathParam("projectId") @Encoded Integer projectId,
+            @PathParam("mergeRequestIid") @Encoded Integer mergeRequestIid);
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/merge_requests/{mergeRequestIid}/award_emoji")
     @Override
-    void awardMergeRequestEmoji(@PathParam("projectId") @Encoded Integer projectId,
-                                @PathParam("mergeRequestIid") @Encoded Integer mergeRequestIid,
-                                @QueryParam("name") String name);
+    void awardMergeRequestEmoji(
+            @PathParam("projectId") @Encoded Integer projectId,
+            @PathParam("mergeRequestIid") @Encoded Integer mergeRequestIid,
+            @QueryParam("name") String name);
 
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/projects/{projectId}/merge_requests/{mergeRequestIid}/award_emoji/{awardId}")
     @Override
-    void deleteMergeRequestEmoji(@PathParam("projectId") @Encoded Integer projectId,
-                                 @PathParam("mergeRequestIid") @Encoded Integer mergeRequestIid,
-                                 @PathParam("awardId") @Encoded Integer awardId);
+    void deleteMergeRequestEmoji(
+            @PathParam("projectId") @Encoded Integer projectId,
+            @PathParam("mergeRequestIid") @Encoded Integer mergeRequestIid,
+            @PathParam("awardId") @Encoded Integer awardId);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/projects/{projectId}/merge_requests")
     @Override
-    List<MergeRequest> getMergeRequests(@PathParam("projectId") @Encoded String projectId,
-                                        @QueryParam("state") State state,
-                                        @QueryParam("page") int page,
-                                        @QueryParam("per_page") int perPage);
+    List<MergeRequest> getMergeRequests(
+            @PathParam("projectId") @Encoded String projectId,
+            @QueryParam("state") State state,
+            @QueryParam("page") int page,
+            @QueryParam("per_page") int perPage);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -213,8 +221,7 @@ interface V4GitLabApiProxy extends GitLabApiProxy {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/projects/{projectId}/repository/branches/{branch}")
     @Override
-    Branch getBranch(@PathParam("projectId") @Encoded String projectId,
-                     @PathParam("branch") @Encoded String branch);
+    Branch getBranch(@PathParam("projectId") @Encoded String projectId, @PathParam("branch") @Encoded String branch);
 
     @HEAD
     @Produces(MediaType.APPLICATION_JSON)
@@ -233,21 +240,23 @@ interface V4GitLabApiProxy extends GitLabApiProxy {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/users")
     @Override
-    User addUser(@FormParam("email") String email,
-                 @FormParam("username") String username,
-                 @FormParam("name") String name,
-                 @FormParam("password") String password);
+    User addUser(
+            @FormParam("email") String email,
+            @FormParam("username") String username,
+            @FormParam("name") String name,
+            @FormParam("password") String password);
 
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/users/{userId}")
     @Override
-    User updateUser(@PathParam("userId") @Encoded String userId,
-                    @FormParam("email") @Encoded String email,
-                    @FormParam("username") String username,
-                    @FormParam("name") String name,
-                    @FormParam("password") String password);
+    User updateUser(
+            @PathParam("userId") @Encoded String userId,
+            @FormParam("email") @Encoded String email,
+            @FormParam("username") String username,
+            @FormParam("name") String name,
+            @FormParam("password") String password);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V4GitLabClientBuilder.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V4GitLabClientBuilder.java
@@ -1,23 +1,22 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.impl;
 
-
 import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
 import hudson.Extension;
 import java.util.function.Function;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-
 @Extension
 @Restricted(NoExternalUse.class)
 public final class V4GitLabClientBuilder extends ResteasyGitLabClientBuilder {
     private static final int ORDINAL = 1;
-    private static final Function<MergeRequest, Integer> MERGE_REQUEST_ID_PROVIDER = new Function<MergeRequest, Integer>() {
-        @Override
-        public Integer apply(MergeRequest mergeRequest) {
-            return mergeRequest.getIid();
-        }
-    };
+    private static final Function<MergeRequest, Integer> MERGE_REQUEST_ID_PROVIDER =
+            new Function<MergeRequest, Integer>() {
+                @Override
+                public Integer apply(MergeRequest mergeRequest) {
+                    return mergeRequest.getIid();
+                }
+            };
 
     public V4GitLabClientBuilder() {
         super(V4GitLabApiProxy.ID, ORDINAL, V4GitLabApiProxy.class, MERGE_REQUEST_ID_PROVIDER);

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Awardable.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Awardable.java
@@ -1,8 +1,6 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
-
 import net.karneim.pojobuilder.GeneratePojoBuilder;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -14,7 +12,9 @@ public class Awardable {
     private User user;
     private Integer awardableId;
 
-    public Awardable() { /* default-constructor for Resteasy-based-api-proxies */ }
+    public Awardable() {
+        /* default-constructor for Resteasy-based-api-proxies */
+    }
 
     public Awardable(Integer id, String name, User user, Integer awardable_id) {
         this.id = id;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/BuildState.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/BuildState.java
@@ -4,5 +4,10 @@ package com.dabsquared.gitlabjenkins.gitlab.api.model;
  * @author Robin Müller
  */
 public enum BuildState {
-    pending, running, canceled, success, failed, skipped
+    pending,
+    running,
+    canceled,
+    success,
+    failed,
+    skipped
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Commit.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Commit.java
@@ -1,11 +1,10 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
+import java.util.Date;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
-
-import java.util.Date;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Label.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Label.java
@@ -11,13 +11,13 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
 public class Label {
     /*
-          "name" : "bug",
-      "color" : "#d9534f",
-      "description": "Bug reported by user",
-      "open_issues_count": 1,
-      "closed_issues_count": 0,
-      "open_merge_requests_count": 1
-     */
+         "name" : "bug",
+     "color" : "#d9534f",
+     "description": "Bug reported by user",
+     "open_issues_count": 1,
+     "closed_issues_count": 0,
+     "open_merge_requests_count": 1
+    */
     private String name;
     private String color;
     private String description;
@@ -83,36 +83,36 @@ public class Label {
         }
         Label label = (Label) o;
         return new EqualsBuilder()
-            .append(openIssuesCount, label.openIssuesCount)
-            .append(closedIssuesCount, label.closedIssuesCount)
-            .append(openMergeRequestsCount, label.openMergeRequestsCount)
-            .append(name, label.name)
-            .append(color, label.color)
-            .append(description, label.description)
-            .isEquals();
+                .append(openIssuesCount, label.openIssuesCount)
+                .append(closedIssuesCount, label.closedIssuesCount)
+                .append(openMergeRequestsCount, label.openMergeRequestsCount)
+                .append(name, label.name)
+                .append(color, label.color)
+                .append(description, label.description)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
-            .append(name)
-            .append(color)
-            .append(description)
-            .append(openIssuesCount)
-            .append(closedIssuesCount)
-            .append(openMergeRequestsCount)
-            .toHashCode();
+                .append(name)
+                .append(color)
+                .append(description)
+                .append(openIssuesCount)
+                .append(closedIssuesCount)
+                .append(openMergeRequestsCount)
+                .toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .append("name", name)
-            .append("color", color)
-            .append("description", description)
-            .append("openIssuesCount", openIssuesCount)
-            .append("closedIssuesCount", closedIssuesCount)
-            .append("openMergeRequestsCount", openMergeRequestsCount)
-            .toString();
+                .append("name", name)
+                .append("color", color)
+                .append("description", description)
+                .append("openIssuesCount", openIssuesCount)
+                .append("closedIssuesCount", closedIssuesCount)
+                .append("openMergeRequestsCount", openMergeRequestsCount)
+                .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/MergeRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/MergeRequest.java
@@ -1,14 +1,13 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
+import java.util.List;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
-
-import java.util.List;
 
 /**
  * @author Robin Müller
@@ -35,13 +34,22 @@ public class MergeRequest {
     private Boolean mergeWhenBuildSucceeds;
     private String mergeStatus;
 
-    public MergeRequest() { /* default-constructor for Resteasy-based-api-proxies */ }
+    public MergeRequest() {
+        /* default-constructor for Resteasy-based-api-proxies */
+    }
 
-    public MergeRequest(int id, int iid, String sourceBranch, String targetBranch, String title,
-                        int sourceProjectId, int targetProjectId,
-                        String description, String mergeStatus) {
+    public MergeRequest(
+            int id,
+            int iid,
+            String sourceBranch,
+            String targetBranch,
+            String title,
+            int sourceProjectId,
+            int targetProjectId,
+            String description,
+            String mergeStatus) {
         this.id = id;
-        this.iid= iid;
+        this.iid = iid;
         this.sourceBranch = sourceBranch;
         this.targetBranch = targetBranch;
         this.title = title;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Namespace.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Namespace.java
@@ -30,22 +30,16 @@ public class Namespace {
             return false;
         }
         Namespace namespace = (Namespace) o;
-        return new EqualsBuilder()
-            .append(path, namespace.path)
-            .isEquals();
+        return new EqualsBuilder().append(path, namespace.path).isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)
-            .append(path)
-            .toHashCode();
+        return new HashCodeBuilder(17, 37).append(path).toHashCode();
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
-            .append("path", path)
-            .toString();
+        return new ToStringBuilder(this).append("path", path).toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Note.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Note.java
@@ -1,12 +1,10 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
+import java.util.Date;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
-
-import java.util.Date;
-
 
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
 public class Note {
@@ -77,36 +75,36 @@ public class Note {
         }
         Note that = (Note) o;
         return new EqualsBuilder()
-            .append(id, that.id)
-            .append(projectId, that.projectId)
-            .append(author, that.author)
-            .append(createdAt, that.createdAt)
-            .append(updatedAt, that.updatedAt)
-            .append(note, that.note)
-            .isEquals();
+                .append(id, that.id)
+                .append(projectId, that.projectId)
+                .append(author, that.author)
+                .append(createdAt, that.createdAt)
+                .append(updatedAt, that.updatedAt)
+                .append(note, that.note)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
-            .append(id)
-            .append(projectId)
-            .append(author)
-            .append(createdAt)
-            .append(updatedAt)
-            .append(note)
-            .toHashCode();
+                .append(id)
+                .append(projectId)
+                .append(author)
+                .append(createdAt)
+                .append(updatedAt)
+                .append(note)
+                .toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .append("id", id)
-            .append("projectId", projectId)
-            .append("author", author)
-            .append("createdAt", createdAt)
-            .append("updatedAt", updatedAt)
-            .append("note", note)
-            .toString();
+                .append("id", id)
+                .append("projectId", projectId)
+                .append("author", author)
+                .append("createdAt", createdAt)
+                .append("updatedAt", updatedAt)
+                .append("note", note)
+                .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Project.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Project.java
@@ -76,33 +76,33 @@ public class Project {
         }
         Project project = (Project) o;
         return new EqualsBuilder()
-            .append(id, project.id)
-            .append(name, project.name)
-            .append(webUrl, project.webUrl)
-            .append(sshUrlToRepo, project.sshUrlToRepo)
-            .append(httpUrlToRepo, project.httpUrlToRepo)
-            .isEquals();
+                .append(id, project.id)
+                .append(name, project.name)
+                .append(webUrl, project.webUrl)
+                .append(sshUrlToRepo, project.sshUrlToRepo)
+                .append(httpUrlToRepo, project.httpUrlToRepo)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
-            .append(id)
-            .append(name)
-            .append(webUrl)
-            .append(sshUrlToRepo)
-            .append(httpUrlToRepo)
-            .toHashCode();
+                .append(id)
+                .append(name)
+                .append(webUrl)
+                .append(sshUrlToRepo)
+                .append(httpUrlToRepo)
+                .toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .append("id", id)
-            .append("name", name)
-            .append("webUrl", webUrl)
-            .append("sshUrlToRepo", sshUrlToRepo)
-            .append("httpUrlToRepo", httpUrlToRepo)
-            .toString();
+                .append("id", id)
+                .append("name", name)
+                .append("webUrl", webUrl)
+                .append("sshUrlToRepo", sshUrlToRepo)
+                .append("httpUrlToRepo", httpUrlToRepo)
+                .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Action.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Action.java
@@ -4,5 +4,10 @@ package com.dabsquared.gitlabjenkins.gitlab.hook.model;
  * @author Robin Müller
  */
 public enum Action {
-    open, update, approved, merge, close, reopen
+    open,
+    update,
+    approved,
+    merge,
+    close,
+    reopen
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Commit.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Commit.java
@@ -1,12 +1,11 @@
 package com.dabsquared.gitlabjenkins.gitlab.hook.model;
 
+import java.util.Date;
+import java.util.List;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
-
-import java.util.Date;
-import java.util.List;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestChangedLabels.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestChangedLabels.java
@@ -1,11 +1,10 @@
 package com.dabsquared.gitlabjenkins.gitlab.hook.model;
 
+import java.util.List;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
-
-import java.util.List;
 
 /**
  * @author Anton Johansson
@@ -46,24 +45,21 @@ public class MergeRequestChangedLabels {
         }
         MergeRequestChangedLabels that = (MergeRequestChangedLabels) o;
         return new EqualsBuilder()
-            .append(previous, that.previous)
-            .append(current, that.current)
-            .isEquals();
+                .append(previous, that.previous)
+                .append(current, that.current)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)
-            .append(previous)
-            .append(current)
-            .toHashCode();
+        return new HashCodeBuilder(17, 37).append(previous).append(current).toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .append("previous", previous)
-            .append("current", current)
-            .toString();
+                .append("previous", previous)
+                .append("current", current)
+                .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestChangedTitle.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestChangedTitle.java
@@ -5,7 +5,6 @@ import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
-
 /**
  * @author Anton Johansson
  */
@@ -45,24 +44,21 @@ public class MergeRequestChangedTitle {
         }
         MergeRequestChangedTitle that = (MergeRequestChangedTitle) o;
         return new EqualsBuilder()
-            .append(previous, that.previous)
-            .append(current, that.current)
-            .isEquals();
+                .append(previous, that.previous)
+                .append(current, that.current)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)
-            .append(previous)
-            .append(current)
-            .toHashCode();
+        return new HashCodeBuilder(17, 37).append(previous).append(current).toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .append("previous", previous)
-            .append("current", current)
-            .toString();
+                .append("previous", previous)
+                .append("current", current)
+                .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestChanges.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestChanges.java
@@ -24,16 +24,18 @@ public class MergeRequestChanges {
         this.labels = labels;
     }
 
-
-
     /*
         "title": {...}
     */
     private MergeRequestChangedTitle title;
 
-    public MergeRequestChangedTitle getTitle() { return title; }
+    public MergeRequestChangedTitle getTitle() {
+        return title;
+    }
 
-    public void setTitle(MergeRequestChangedTitle title) { this.title = title; }
+    public void setTitle(MergeRequestChangedTitle title) {
+        this.title = title;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -44,22 +46,16 @@ public class MergeRequestChanges {
             return false;
         }
         MergeRequestChanges that = (MergeRequestChanges) o;
-        return new EqualsBuilder()
-            .append(labels, that.labels)
-            .isEquals();
+        return new EqualsBuilder().append(labels, that.labels).isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)
-            .append(labels)
-            .toHashCode();
+        return new HashCodeBuilder(17, 37).append(labels).toHashCode();
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
-            .append("labels", labels)
-            .toString();
+        return new ToStringBuilder(this).append("labels", labels).toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestHook.java
@@ -1,12 +1,10 @@
 package com.dabsquared.gitlabjenkins.gitlab.hook.model;
 
-
+import java.util.List;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
-
-import java.util.List;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestLabel.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestLabel.java
@@ -1,11 +1,10 @@
 package com.dabsquared.gitlabjenkins.gitlab.hook.model;
 
+import java.util.Date;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
-
-import java.util.Date;
 
 /**
  * @author Benjamin ROBIN
@@ -126,48 +125,48 @@ public class MergeRequestLabel {
         }
         MergeRequestLabel that = (MergeRequestLabel) o;
         return new EqualsBuilder()
-            .append(id, that.id)
-            .append(title, that.title)
-            .append(color, that.color)
-            .append(projectId, that.projectId)
-            .append(createdAt, that.createdAt)
-            .append(updatedAt, that.updatedAt)
-            .append(template, that.template)
-            .append(description, that.description)
-            .append(type, that.type)
-            .append(groupId, that.groupId)
-            .isEquals();
+                .append(id, that.id)
+                .append(title, that.title)
+                .append(color, that.color)
+                .append(projectId, that.projectId)
+                .append(createdAt, that.createdAt)
+                .append(updatedAt, that.updatedAt)
+                .append(template, that.template)
+                .append(description, that.description)
+                .append(type, that.type)
+                .append(groupId, that.groupId)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
-            .append(id)
-            .append(title)
-            .append(color)
-            .append(projectId)
-            .append(createdAt)
-            .append(updatedAt)
-            .append(template)
-            .append(description)
-            .append(type)
-            .append(groupId)
-            .toHashCode();
+                .append(id)
+                .append(title)
+                .append(color)
+                .append(projectId)
+                .append(createdAt)
+                .append(updatedAt)
+                .append(template)
+                .append(description)
+                .append(type)
+                .append(groupId)
+                .toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .append("id", id)
-            .append("title", title)
-            .append("color", color)
-            .append("projectId", projectId)
-            .append("createdAt", createdAt)
-            .append("updatedAt", updatedAt)
-            .append("template", template)
-            .append("description", description)
-            .append("type", type)
-            .append("groupId", groupId)
-            .toString();
+                .append("id", id)
+                .append("title", title)
+                .append("color", color)
+                .append("projectId", projectId)
+                .append("createdAt", createdAt)
+                .append("updatedAt", updatedAt)
+                .append("template", template)
+                .append("description", description)
+                .append("type", type)
+                .append("groupId", groupId)
+                .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestObjectAttributes.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestObjectAttributes.java
@@ -1,11 +1,10 @@
 package com.dabsquared.gitlabjenkins.gitlab.hook.model;
 
+import java.util.Date;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
-
-import java.util.Date;
 
 /**
  * @author Robin Müller
@@ -163,9 +162,13 @@ public class MergeRequestObjectAttributes {
         this.lastCommit = lastCommit;
     }
 
-    public String getOldrev() { return oldrev; }
+    public String getOldrev() {
+        return oldrev;
+    }
 
-    public void setOldrev(String oldrev) { this.oldrev = oldrev; }
+    public void setOldrev(String oldrev) {
+        this.oldrev = oldrev;
+    }
 
     public String getMergeStatus() {
         return mergeStatus;
@@ -209,80 +212,80 @@ public class MergeRequestObjectAttributes {
         }
         MergeRequestObjectAttributes that = (MergeRequestObjectAttributes) o;
         return new EqualsBuilder()
-            .append(id, that.id)
-            .append(iid, that.iid)
-            .append(sourceBranch, that.sourceBranch)
-            .append(targetBranch, that.targetBranch)
-            .append(sourceProjectId, that.sourceProjectId)
-            .append(targetProjectId, that.targetProjectId)
-            .append(authorId, that.authorId)
-            .append(assigneeId, that.assigneeId)
-            .append(title, that.title)
-            .append(createdAt, that.createdAt)
-            .append(updatedAt, that.updatedAt)
-            .append(state, that.state)
-            .append(description, that.description)
-            .append(source, that.source)
-            .append(target, that.target)
-            .append(lastCommit, that.lastCommit)
-            .append(mergeStatus, that.mergeStatus)
-            .append(url, that.url)
-            .append(action, that.action)
-            .append(oldrev, that.oldrev)
-            .append(workInProgress, that.workInProgress)
-            .isEquals();
+                .append(id, that.id)
+                .append(iid, that.iid)
+                .append(sourceBranch, that.sourceBranch)
+                .append(targetBranch, that.targetBranch)
+                .append(sourceProjectId, that.sourceProjectId)
+                .append(targetProjectId, that.targetProjectId)
+                .append(authorId, that.authorId)
+                .append(assigneeId, that.assigneeId)
+                .append(title, that.title)
+                .append(createdAt, that.createdAt)
+                .append(updatedAt, that.updatedAt)
+                .append(state, that.state)
+                .append(description, that.description)
+                .append(source, that.source)
+                .append(target, that.target)
+                .append(lastCommit, that.lastCommit)
+                .append(mergeStatus, that.mergeStatus)
+                .append(url, that.url)
+                .append(action, that.action)
+                .append(oldrev, that.oldrev)
+                .append(workInProgress, that.workInProgress)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
-            .append(id)
-            .append(iid)
-            .append(sourceBranch)
-            .append(targetBranch)
-            .append(sourceProjectId)
-            .append(targetProjectId)
-            .append(authorId)
-            .append(assigneeId)
-            .append(title)
-            .append(createdAt)
-            .append(updatedAt)
-            .append(state)
-            .append(description)
-            .append(source)
-            .append(target)
-            .append(lastCommit)
-            .append(mergeStatus)
-            .append(url)
-            .append(action)
-            .append(workInProgress)
-            .toHashCode();
+                .append(id)
+                .append(iid)
+                .append(sourceBranch)
+                .append(targetBranch)
+                .append(sourceProjectId)
+                .append(targetProjectId)
+                .append(authorId)
+                .append(assigneeId)
+                .append(title)
+                .append(createdAt)
+                .append(updatedAt)
+                .append(state)
+                .append(description)
+                .append(source)
+                .append(target)
+                .append(lastCommit)
+                .append(mergeStatus)
+                .append(url)
+                .append(action)
+                .append(workInProgress)
+                .toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .append("id", id)
-            .append("iid", iid)
-            .append("sourceBranch", sourceBranch)
-            .append("targetBranch", targetBranch)
-            .append("sourceProjectId", sourceProjectId)
-            .append("targetProjectId", targetProjectId)
-            .append("authorId", authorId)
-            .append("assigneeId", assigneeId)
-            .append("title", title)
-            .append("createdAt", createdAt)
-            .append("updatedAt", updatedAt)
-            .append("state", state)
-            .append("description", description)
-            .append("source", source)
-            .append("target", target)
-            .append("lastCommit", lastCommit)
-            .append("mergeStatus", mergeStatus)
-            .append("url", url)
-            .append("action", action)
-            .append("oldrev", oldrev)
-            .append("workInProgress", workInProgress)
-            .toString();
+                .append("id", id)
+                .append("iid", iid)
+                .append("sourceBranch", sourceBranch)
+                .append("targetBranch", targetBranch)
+                .append("sourceProjectId", sourceProjectId)
+                .append("targetProjectId", targetProjectId)
+                .append("authorId", authorId)
+                .append("assigneeId", assigneeId)
+                .append("title", title)
+                .append("createdAt", createdAt)
+                .append("updatedAt", updatedAt)
+                .append("state", state)
+                .append("description", description)
+                .append("source", source)
+                .append("target", target)
+                .append("lastCommit", lastCommit)
+                .append("mergeStatus", mergeStatus)
+                .append("url", url)
+                .append("action", action)
+                .append("oldrev", oldrev)
+                .append("workInProgress", workInProgress)
+                .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/NoteHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/NoteHook.java
@@ -1,6 +1,5 @@
 package com.dabsquared.gitlabjenkins.gitlab.hook.model;
 
-
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/NoteObjectAttributes.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/NoteObjectAttributes.java
@@ -1,11 +1,10 @@
 package com.dabsquared.gitlabjenkins.gitlab.hook.model;
 
+import java.util.Date;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
-
-import java.util.Date;
 
 /**
  * @author Nikolay Ustinov

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PipelineEventObjectAttributes.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PipelineEventObjectAttributes.java
@@ -1,12 +1,11 @@
 package com.dabsquared.gitlabjenkins.gitlab.hook.model;
 
+import java.util.Date;
+import java.util.List;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
-
-import java.util.Date;
-import java.util.List;
 
 /**
  * @author Milena Zachow
@@ -97,9 +96,6 @@ public class PipelineEventObjectAttributes {
         this.duration = duration;
     }
 
-
-
-
     public Integer getId() {
         return id;
     }
@@ -107,7 +103,6 @@ public class PipelineEventObjectAttributes {
     public void setId(Integer id) {
         this.id = id;
     }
-
 
     @Override
     public boolean equals(Object o) {
@@ -119,48 +114,48 @@ public class PipelineEventObjectAttributes {
         }
         PipelineEventObjectAttributes that = (PipelineEventObjectAttributes) o;
         return new EqualsBuilder()
-            .append(id, that.id)
-            .append(ref, that.ref)
-            .append(tag, that.tag)
-            .append(sha, that.sha)
-            .append(beforeSha, that.beforeSha)
-            .append(status, that.status)
-            .append(stages, that.stages)
-            .append(createdAt, that.createdAt)
-            .append(finishedAt, that.finishedAt)
-            .append(duration, that.duration)
-            .isEquals();
+                .append(id, that.id)
+                .append(ref, that.ref)
+                .append(tag, that.tag)
+                .append(sha, that.sha)
+                .append(beforeSha, that.beforeSha)
+                .append(status, that.status)
+                .append(stages, that.stages)
+                .append(createdAt, that.createdAt)
+                .append(finishedAt, that.finishedAt)
+                .append(duration, that.duration)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
-            .append(id)
-            .append(ref)
-            .append(tag)
-            .append(sha)
-            .append(beforeSha)
-            .append(status)
-            .append(stages)
-            .append(createdAt)
-            .append(finishedAt)
-            .append(duration)
-            .toHashCode();
+                .append(id)
+                .append(ref)
+                .append(tag)
+                .append(sha)
+                .append(beforeSha)
+                .append(status)
+                .append(stages)
+                .append(createdAt)
+                .append(finishedAt)
+                .append(duration)
+                .toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .append("id", id)
-            .append("ref", ref)
-            .append("tag", tag)
-            .append("sha", sha)
-            .append("beforeSha", beforeSha)
-            .append("status", status)
-            .append("stages", stages)
-            .append("createdAt", createdAt)
-            .append("finishedAt", finishedAt)
-            .append("duration", duration)
-            .toString();
+                .append("id", id)
+                .append("ref", ref)
+                .append("tag", tag)
+                .append("sha", sha)
+                .append("beforeSha", beforeSha)
+                .append("status", status)
+                .append("stages", stages)
+                .append("createdAt", createdAt)
+                .append("finishedAt", finishedAt)
+                .append("duration", duration)
+                .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PipelineHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PipelineHook.java
@@ -1,12 +1,10 @@
 package com.dabsquared.gitlabjenkins.gitlab.hook.model;
 
+import java.util.List;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
-
-import java.util.List;
-
 
 /**
  * @author Milena Zachow
@@ -58,7 +56,6 @@ public class PipelineHook extends WebHook {
 
     public void setObjectAttributes(PipelineEventObjectAttributes objectAttributes) {
         this.objectAttributes = objectAttributes;
-
     }
 
     @Override

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PushHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PushHook.java
@@ -1,11 +1,10 @@
 package com.dabsquared.gitlabjenkins.gitlab.hook.model;
 
+import java.util.List;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
-
-import java.util.List;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/State.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/State.java
@@ -4,5 +4,9 @@ package com.dabsquared.gitlabjenkins.gitlab.hook.model;
  * @author Robin Müller
  */
 public enum State {
-    opened, reopened, updated, closed, merged
+    opened,
+    reopened,
+    updated,
+    closed,
+    merged
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/WebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/WebHook.java
@@ -45,10 +45,7 @@ public abstract class WebHook {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)
-                .append(repository)
-                .append(objectKind)
-                .toHashCode();
+        return new HashCodeBuilder(17, 37).append(repository).append(objectKind).toHashCode();
     }
 
     @Override

--- a/src/main/java/com/dabsquared/gitlabjenkins/listener/GitLabBuildDescriptionRunListener.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/listener/GitLabBuildDescriptionRunListener.java
@@ -7,7 +7,6 @@ import hudson.model.Cause;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
-
 import java.io.IOException;
 
 /**
@@ -33,5 +32,4 @@ public class GitLabBuildDescriptionRunListener extends RunListener<Run<?, ?>> {
             }
         }
     }
-
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabAcceptMergeRequestPublisher.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabAcceptMergeRequestPublisher.java
@@ -1,6 +1,5 @@
 package com.dabsquared.gitlabjenkins.publisher;
 
-
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
 import hudson.Extension;
@@ -11,13 +10,12 @@ import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * @author Robin Müller
@@ -28,17 +26,16 @@ public class GitLabAcceptMergeRequestPublisher extends MergeRequestNotifier {
     private Boolean deleteSourceBranch;
 
     @DataBoundConstructor
-    public GitLabAcceptMergeRequestPublisher() {
-    }
+    public GitLabAcceptMergeRequestPublisher() {}
 
     @DataBoundSetter
     public void setDeleteSourceBranch(boolean deleteSourceBranch) {
         this.deleteSourceBranch = deleteSourceBranch;
     }
 
-    public boolean isDeleteSourceBranch() { return deleteSourceBranch; }
-
-
+    public boolean isDeleteSourceBranch() {
+        return deleteSourceBranch;
+    }
 
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
@@ -62,11 +59,18 @@ public class GitLabAcceptMergeRequestPublisher extends MergeRequestNotifier {
     protected void perform(Run<?, ?> build, TaskListener listener, GitLabClient client, MergeRequest mergeRequest) {
         try {
             if (build.getResult() == Result.SUCCESS) {
-                client.acceptMergeRequest(mergeRequest, "Merge Request accepted by jenkins build success", this.deleteSourceBranch);
+                client.acceptMergeRequest(
+                        mergeRequest, "Merge Request accepted by jenkins build success", this.deleteSourceBranch);
             }
         } catch (WebApplicationException | ProcessingException e) {
-            listener.getLogger().printf("Failed to accept merge request for project '%s': %s%n", mergeRequest.getProjectId(), e.getMessage());
-            LOGGER.log(Level.SEVERE, String.format("Failed to accept merge request for project '%s'", mergeRequest.getProjectId()), e);
+            listener.getLogger()
+                    .printf(
+                            "Failed to accept merge request for project '%s': %s%n",
+                            mergeRequest.getProjectId(), e.getMessage());
+            LOGGER.log(
+                    Level.SEVERE,
+                    String.format("Failed to accept merge request for project '%s'", mergeRequest.getProjectId()),
+                    e);
         }
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisher.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisher.java
@@ -16,11 +16,10 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
+import java.io.IOException;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-
-import java.io.IOException;
 
 /**
  * @author Robin Müller
@@ -47,7 +46,8 @@ public class GitLabCommitStatusPublisher extends Notifier implements MatrixAggre
     }
 
     @Override
-    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException, IOException {
         Result buildResult = build.getResult();
         if (buildResult == Result.SUCCESS || (buildResult == Result.UNSTABLE && markUnstableAsSuccess)) {
             CommitStatusUpdater.updateCommitStatus(build, listener, BuildState.success, name);

--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisher.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisher.java
@@ -1,6 +1,5 @@
 package com.dabsquared.gitlabjenkins.publisher;
 
-
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
 import hudson.Extension;
@@ -11,17 +10,16 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
-import jenkins.model.Jenkins;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * @author Nikolay Ustinov
@@ -51,8 +49,16 @@ public class GitLabMessagePublisher extends MergeRequestNotifier {
      * @param unstableNoteText Text of message for unstable build
      */
     @Deprecated
-    public GitLabMessagePublisher(boolean onlyForFailure, boolean replaceSuccessNote, boolean replaceFailureNote, boolean replaceAbortNote, boolean replaceUnstableNote,
-                                  String successNoteText, String failureNoteText, String abortNoteText, String unstableNoteText) {
+    public GitLabMessagePublisher(
+            boolean onlyForFailure,
+            boolean replaceSuccessNote,
+            boolean replaceFailureNote,
+            boolean replaceAbortNote,
+            boolean replaceUnstableNote,
+            String successNoteText,
+            String failureNoteText,
+            String abortNoteText,
+            String unstableNoteText) {
         this.onlyForFailure = onlyForFailure;
         this.replaceSuccessNote = replaceSuccessNote;
         this.replaceFailureNote = replaceFailureNote;
@@ -65,7 +71,7 @@ public class GitLabMessagePublisher extends MergeRequestNotifier {
     }
 
     @DataBoundConstructor
-    public GitLabMessagePublisher() { }
+    public GitLabMessagePublisher() {}
 
     public boolean isOnlyForFailure() {
         return onlyForFailure;
@@ -174,8 +180,15 @@ public class GitLabMessagePublisher extends MergeRequestNotifier {
                 client.createMergeRequestNote(mergeRequest, getNote(build, listener));
             }
         } catch (WebApplicationException | ProcessingException e) {
-            listener.getLogger().printf("Failed to add comment on Merge Request for project '%s': %s%n", mergeRequest.getProjectId(), e.getMessage());
-            LOGGER.log(Level.SEVERE, String.format("Failed to add comment on Merge Request for project '%s'", mergeRequest.getProjectId()), e);
+            listener.getLogger()
+                    .printf(
+                            "Failed to add comment on Merge Request for project '%s': %s%n",
+                            mergeRequest.getProjectId(), e.getMessage());
+            LOGGER.log(
+                    Level.SEVERE,
+                    String.format(
+                            "Failed to add comment on Merge Request for project '%s'", mergeRequest.getProjectId()),
+                    e);
         }
     }
 
@@ -233,8 +246,13 @@ public class GitLabMessagePublisher extends MergeRequestNotifier {
         } else {
             String icon = getResultIcon(build.getResult());
             String buildUrl = Jenkins.getInstance().getRootUrl() + build.getUrl();
-            message = MessageFormat.format("{0} Jenkins Build {1}\n\nResults available at: [Jenkins [{2} #{3}]]({4})",
-                                           icon, build.getResult().toString(), build.getParent().getDisplayName(), build.getNumber(), buildUrl);
+            message = MessageFormat.format(
+                    "{0} Jenkins Build {1}\n\nResults available at: [Jenkins [{2} #{3}]]({4})",
+                    icon,
+                    build.getResult().toString(),
+                    build.getParent().getDisplayName(),
+                    build.getNumber(),
+                    buildUrl);
         }
         return message;
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabVotePublisher.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/GitLabVotePublisher.java
@@ -1,10 +1,8 @@
 package com.dabsquared.gitlabjenkins.publisher;
 
-
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.Awardable;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
-
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Result;
@@ -13,13 +11,12 @@ import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
-import org.kohsuke.stapler.DataBoundConstructor;
-
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * @author Robin Müller
@@ -28,7 +25,7 @@ public class GitLabVotePublisher extends MergeRequestNotifier {
     private static final Logger LOGGER = Logger.getLogger(GitLabVotePublisher.class.getName());
 
     @DataBoundConstructor
-    public GitLabVotePublisher() { }
+    public GitLabVotePublisher() {}
 
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
@@ -65,8 +62,15 @@ public class GitLabVotePublisher extends MergeRequestNotifier {
                 }
             }
         } catch (WebApplicationException | ProcessingException e) {
-            listener.getLogger().printf("Failed to remove vote on Merge Request for project '%s': %s%n", mergeRequest.getProjectId(), e.getMessage());
-            LOGGER.log(Level.SEVERE, String.format("Failed to remove vote on Merge Request for project '%s'", mergeRequest.getProjectId()), e);
+            listener.getLogger()
+                    .printf(
+                            "Failed to remove vote on Merge Request for project '%s': %s%n",
+                            mergeRequest.getProjectId(), e.getMessage());
+            LOGGER.log(
+                    Level.SEVERE,
+                    String.format(
+                            "Failed to remove vote on Merge Request for project '%s'", mergeRequest.getProjectId()),
+                    e);
         }
 
         try {
@@ -74,16 +78,23 @@ public class GitLabVotePublisher extends MergeRequestNotifier {
                 client.awardMergeRequestEmoji(mergeRequest, getResultIcon(build.getResult()));
             }
         } catch (NotFoundException e) {
-            String message = String.format("Failed to add vote on Merge Request for project '%s'%n" +
-                "Got unexpected 404, are you using the wrong API version or trying to vote on your own merge request?", mergeRequest.getProjectId());
+            String message = String.format(
+                    "Failed to add vote on Merge Request for project '%s'%n"
+                            + "Got unexpected 404, are you using the wrong API version or trying to vote on your own merge request?",
+                    mergeRequest.getProjectId());
             listener.getLogger().println(message);
             LOGGER.log(Level.WARNING, message, e);
         } catch (WebApplicationException | ProcessingException e) {
-            listener.getLogger().printf("Failed to add vote on Merge Request for project '%s': %s%n", mergeRequest.getProjectId(), e.getMessage());
-            LOGGER.log(Level.SEVERE, String.format("Failed to add vote on Merge Request for project '%s'", mergeRequest.getProjectId()), e);
+            listener.getLogger()
+                    .printf(
+                            "Failed to add vote on Merge Request for project '%s': %s%n",
+                            mergeRequest.getProjectId(), e.getMessage());
+            LOGGER.log(
+                    Level.SEVERE,
+                    String.format("Failed to add vote on Merge Request for project '%s'", mergeRequest.getProjectId()),
+                    e);
         }
     }
-
 
     private boolean isSuccessful(Result result) {
         if (result == Result.SUCCESS) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/MergeRequestNotifier.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/MergeRequestNotifier.java
@@ -1,5 +1,7 @@
 package com.dabsquared.gitlabjenkins.publisher;
 
+import static com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty.getClient;
+
 import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
@@ -13,10 +15,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
-
 import java.io.IOException;
-
-import static com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty.getClient;
 
 /**
  * @author Robin Müller
@@ -27,7 +26,8 @@ public abstract class MergeRequestNotifier extends Notifier implements MatrixAgg
     }
 
     @Override
-    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException, IOException {
         GitLabClient client = getClient(build);
         if (client == null) {
             listener.getLogger().println("No GitLab connection configured");
@@ -51,11 +51,11 @@ public abstract class MergeRequestNotifier extends Notifier implements MatrixAgg
         };
     }
 
-    protected abstract void perform(Run<?, ?> build, TaskListener listener, GitLabClient client, MergeRequest mergeRequest);
+    protected abstract void perform(
+            Run<?, ?> build, TaskListener listener, GitLabClient client, MergeRequest mergeRequest);
 
     MergeRequest getMergeRequest(Run<?, ?> run) {
         GitLabWebHookCause cause = run.getCause(GitLabWebHookCause.class);
         return cause == null ? null : cause.getData().getMergeRequest();
-
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/service/GitLabProjectBranchesService.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/service/GitLabProjectBranchesService.java
@@ -1,20 +1,17 @@
 package com.dabsquared.gitlabjenkins.service;
 
-
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.Branch;
 import com.dabsquared.gitlabjenkins.util.LoggerUtil;
 import com.dabsquared.gitlabjenkins.util.ProjectIdUtil;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 
 public class GitLabProjectBranchesService {
 
@@ -68,7 +65,10 @@ public class GitLabProjectBranchesService {
             for (Branch branch : client.getBranches(projectId)) {
                 result.add(branch.getName());
             }
-            LOGGER.log(Level.FINEST, "found these branches for repo {0} : {1}", LoggerUtil.toArray(sourceRepository, result));
+            LOGGER.log(
+                    Level.FINEST,
+                    "found these branches for repo {0} : {1}",
+                    LoggerUtil.toArray(sourceRepository, result));
             return result;
         }
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/service/GitLabProjectLabelsService.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/service/GitLabProjectLabelsService.java
@@ -1,20 +1,17 @@
 package com.dabsquared.gitlabjenkins.service;
 
-
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.Label;
 import com.dabsquared.gitlabjenkins.util.LoggerUtil;
 import com.dabsquared.gitlabjenkins.util.ProjectIdUtil;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 
 public class GitLabProjectLabelsService {
 
@@ -68,7 +65,10 @@ public class GitLabProjectLabelsService {
             for (Label label : client.getLabels(projectId)) {
                 result.add(label.getName());
             }
-            LOGGER.log(Level.FINEST, "found these labels for repo {0} : {1}", LoggerUtil.toArray(sourceRepository, result));
+            LOGGER.log(
+                    Level.FINEST,
+                    "found these labels for repo {0} : {1}",
+                    LoggerUtil.toArray(sourceRepository, result));
             return result;
         }
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/TriggerOpenMergeRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/TriggerOpenMergeRequest.java
@@ -4,5 +4,7 @@ package com.dabsquared.gitlabjenkins.trigger;
  * @author Robin Müller
  */
 public enum TriggerOpenMergeRequest {
-    never, source, both
+    never,
+    source,
+    both
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/branch/AntPathMatcherSet.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/branch/AntPathMatcherSet.java
@@ -1,16 +1,15 @@
 package com.dabsquared.gitlabjenkins.trigger.branch;
 
-import org.springframework.util.AntPathMatcher;
-
 import java.util.Collection;
 import java.util.HashSet;
+import org.springframework.util.AntPathMatcher;
 
 /**
  * @author Robin Müller
  */
 class AntPathMatcherSet extends HashSet<String> {
 
-    private transient final AntPathMatcher matcher = new AntPathMatcher();
+    private final transient AntPathMatcher matcher = new AntPathMatcher();
 
     public AntPathMatcherSet(Collection<? extends String> c) {
         super(c);

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/exception/NoRevisionToBuildException.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/exception/NoRevisionToBuildException.java
@@ -3,5 +3,4 @@ package com.dabsquared.gitlabjenkins.trigger.exception;
 /**
  * @author Robin Müller
  */
-public class NoRevisionToBuildException extends Exception {
-}
+public class NoRevisionToBuildException extends Exception {}

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/BranchFilterConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/BranchFilterConfig.java
@@ -11,7 +11,12 @@ public final class BranchFilterConfig {
     private final String sourceBranchRegex;
     private final String targetBranchRegex;
 
-    private BranchFilterConfig(BranchFilterType type, String includeBranchesSpec, String excludeBranchesSpec, String sourceBranchRegex, String targetBranchRegex) {
+    private BranchFilterConfig(
+            BranchFilterType type,
+            String includeBranchesSpec,
+            String excludeBranchesSpec,
+            String sourceBranchRegex,
+            String targetBranchRegex) {
         this.type = type;
         this.includeBranchesSpec = includeBranchesSpec;
         this.excludeBranchesSpec = excludeBranchesSpec;
@@ -70,7 +75,8 @@ public final class BranchFilterConfig {
         }
 
         public BranchFilterConfig build(BranchFilterType type) {
-            return new BranchFilterConfig(type, includeBranchesSpec, excludeBranchesSpec, sourceBranchRegex, targetBranchRegex);
+            return new BranchFilterConfig(
+                    type, includeBranchesSpec, excludeBranchesSpec, sourceBranchRegex, targetBranchRegex);
         }
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/BranchFilterFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/BranchFilterFactory.java
@@ -5,13 +5,12 @@ package com.dabsquared.gitlabjenkins.trigger.filter;
  */
 public final class BranchFilterFactory {
 
-    private BranchFilterFactory() { }
+    private BranchFilterFactory() {}
 
     public static BranchFilter newBranchFilter(BranchFilterConfig config) {
-		
-		if(config == null || config.getType() == null)
-			return new AllBranchesFilter();
-		
+
+        if (config == null || config.getType() == null) return new AllBranchesFilter();
+
         switch (config.getType()) {
             case NameBasedFilter:
                 return new NameBasedFilter(config.getIncludeBranchesSpec(), config.getExcludeBranchesSpec());

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/MergeRequestLabelFilterConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/MergeRequestLabelFilterConfig.java
@@ -21,7 +21,7 @@ public class MergeRequestLabelFilterConfig {
     }
 
     @DataBoundConstructor
-    public MergeRequestLabelFilterConfig() { }
+    public MergeRequestLabelFilterConfig() {}
 
     public String getInclude() {
         return include;

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/MergeRequestLabelFilterFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/MergeRequestLabelFilterFactory.java
@@ -5,7 +5,7 @@ package com.dabsquared.gitlabjenkins.trigger.filter;
  */
 public class MergeRequestLabelFilterFactory {
 
-    private MergeRequestLabelFilterFactory() { }
+    private MergeRequestLabelFilterFactory() {}
 
     public static MergeRequestLabelFilter newMergeRequestLabelFilter(MergeRequestLabelFilterConfig config) {
         if (config == null) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/MergeRequestLabelFilterImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/MergeRequestLabelFilterImpl.java
@@ -42,6 +42,9 @@ class MergeRequestLabelFilterImpl implements MergeRequestLabelFilter {
     }
 
     private Set<String> convert(String commaSeparatedString) {
-        return Arrays.stream(commaSeparatedString.split(",")).filter(s -> !s.isEmpty()).map(String::trim).collect(Collectors.toSet());
+        return Arrays.stream(commaSeparatedString.split(","))
+                .filter(s -> !s.isEmpty())
+                .map(String::trim)
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/NameBasedFilter.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/NameBasedFilter.java
@@ -1,11 +1,10 @@
 package com.dabsquared.gitlabjenkins.trigger.filter;
 
-import org.springframework.util.AntPathMatcher;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.util.AntPathMatcher;
 
 /**
  * @author Robin Müller
@@ -50,9 +49,11 @@ class NameBasedFilter implements BranchFilter {
     }
 
     private List<String> convert(String commaSeparatedString) {
-        if (commaSeparatedString == null)
-            return Collections.EMPTY_LIST;
+        if (commaSeparatedString == null) return Collections.EMPTY_LIST;
 
-        return Arrays.stream(commaSeparatedString.split(",")).filter(s -> !s.isEmpty()).map(String::trim).collect(Collectors.toList());
+        return Arrays.stream(commaSeparatedString.split(","))
+                .filter(s -> !s.isEmpty())
+                .map(String::trim)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/RegexBasedFilter.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/filter/RegexBasedFilter.java
@@ -7,21 +7,21 @@ import org.apache.commons.lang.StringUtils;
  */
 class RegexBasedFilter implements BranchFilter {
 
-	private final String sourceRegex;
-	private final String targetRegex;
+    private final String sourceRegex;
+    private final String targetRegex;
 
-	public RegexBasedFilter(String sourceRegex, String targetRegex) {
-		this.sourceRegex = sourceRegex;
-		this.targetRegex = targetRegex;
-	}
+    public RegexBasedFilter(String sourceRegex, String targetRegex) {
+        this.sourceRegex = sourceRegex;
+        this.targetRegex = targetRegex;
+    }
 
-	@Override
-	public boolean isBranchAllowed(String sourceBranchName, String targetBranchName) {
-		boolean isSourceBranchAllowed = StringUtils.isEmpty(sourceRegex) || sourceBranchName.matches(sourceRegex);
-		if (StringUtils.isEmpty(targetBranchName)) {
-			return isSourceBranchAllowed;
-		} else {
-			return isSourceBranchAllowed && (StringUtils.isEmpty(targetRegex) || targetBranchName.matches(targetRegex));
-		}
-	}
+    @Override
+    public boolean isBranchAllowed(String sourceBranchName, String targetBranchName) {
+        boolean isSourceBranchAllowed = StringUtils.isEmpty(sourceRegex) || sourceBranchName.matches(sourceRegex);
+        if (StringUtils.isEmpty(targetBranchName)) {
+            return isSourceBranchAllowed;
+        } else {
+            return isSourceBranchAllowed && (StringUtils.isEmpty(targetRegex) || targetBranchName.matches(targetRegex));
+        }
+    }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/AbstractWebHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/AbstractWebHookTriggerHandler.java
@@ -16,19 +16,18 @@ import hudson.model.Job;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.RevisionParameterAction;
 import hudson.scm.SCM;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.triggers.SCMTriggerItem;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
-
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * @author Robin Müller
@@ -39,7 +38,12 @@ public abstract class AbstractWebHookTriggerHandler<H extends WebHook> implement
     protected PendingBuildsHandler pendingBuildsHandler = new PendingBuildsHandler();
 
     @Override
-    public void handle(Job<?, ?> job, H hook, boolean ciSkip, BranchFilter branchFilter, MergeRequestLabelFilter mergeRequestLabelFilter) {
+    public void handle(
+            Job<?, ?> job,
+            H hook,
+            boolean ciSkip,
+            BranchFilter branchFilter,
+            MergeRequestLabelFilter mergeRequestLabelFilter) {
         if (ciSkip && isCiSkip(hook)) {
             LOGGER.log(Level.INFO, "Skipping due to ci-skip.");
             return;
@@ -53,7 +57,9 @@ public abstract class AbstractWebHookTriggerHandler<H extends WebHook> implement
             setCommitStatusPendingIfNecessary(job, hook);
             scheduleBuild(job, createActions(job, hook));
         } else {
-            LOGGER.log(Level.INFO, "Source branch {0} or target branch {1} is not allowed", new Object[]{sourceBranch, targetBranch});
+            LOGGER.log(Level.INFO, "Source branch {0} or target branch {1} is not allowed", new Object[] {
+                sourceBranch, targetBranch
+            });
         }
     }
 
@@ -65,7 +71,8 @@ public abstract class AbstractWebHookTriggerHandler<H extends WebHook> implement
         try {
             String buildName = PendingBuildsHandler.resolvePendingBuildName(job);
             if (StringUtils.isNotBlank(buildName)) {
-                GitLabClient client = job.getProperty(GitLabConnectionProperty.class).getClient();
+                GitLabClient client =
+                        job.getProperty(GitLabConnectionProperty.class).getClient();
                 BuildStatusUpdate buildStatusUpdate = retrieveBuildStatusUpdate(hook);
                 try {
                     if (client == null) {
@@ -73,8 +80,14 @@ public abstract class AbstractWebHookTriggerHandler<H extends WebHook> implement
                     } else {
                         String ref = StringUtils.removeStart(buildStatusUpdate.getRef(), "refs/tags/");
                         String targetUrl = DisplayURLProvider.get().getJobURL(job);
-                        client.changeBuildStatus(buildStatusUpdate.getProjectId(), buildStatusUpdate.getSha(),
-                                BuildState.pending, ref, buildName, targetUrl, BuildState.pending.name());
+                        client.changeBuildStatus(
+                                buildStatusUpdate.getProjectId(),
+                                buildStatusUpdate.getSha(),
+                                BuildState.pending,
+                                ref,
+                                buildName,
+                                targetUrl,
+                                BuildState.pending.name());
                     }
                 } catch (WebApplicationException | ProcessingException e) {
                     LOGGER.log(Level.SEVERE, "Failed to set build state to pending", e);
@@ -93,8 +106,10 @@ public abstract class AbstractWebHookTriggerHandler<H extends WebHook> implement
             GitSCM gitSCM = getGitSCM(item);
             actions.add(createRevisionParameter(hook, gitSCM));
         } catch (NoRevisionToBuildException e) {
-            LOGGER.log(Level.WARNING, "unknown handled situation, dont know what revision to build for req {0} for job {1}",
-                    new Object[]{hook, (job != null ? job.getFullName() : null)});
+            LOGGER.log(
+                    Level.WARNING,
+                    "unknown handled situation, dont know what revision to build for req {0} for job {1}",
+                    new Object[] {hook, (job != null ? job.getFullName() : null)});
         }
         return actions.toArray(new Action[actions.size()]);
     }
@@ -107,7 +122,8 @@ public abstract class AbstractWebHookTriggerHandler<H extends WebHook> implement
 
     protected abstract String getTargetBranch(H hook);
 
-    protected abstract RevisionParameterAction createRevisionParameter(H hook, GitSCM gitSCM) throws NoRevisionToBuildException;
+    protected abstract RevisionParameterAction createRevisionParameter(H hook, GitSCM gitSCM)
+            throws NoRevisionToBuildException;
 
     protected abstract BuildStatusUpdate retrieveBuildStatusUpdate(H hook);
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/PendingBuildsHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/PendingBuildsHandler.java
@@ -12,13 +12,12 @@ import hudson.model.AbstractProject;
 import hudson.model.Cause;
 import hudson.model.Job;
 import hudson.model.Queue;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class PendingBuildsHandler {
 
@@ -56,7 +55,8 @@ public class PendingBuildsHandler {
 
     private void cancel(Queue.Item item, Queue queue, String branch) {
         try {
-            LOGGER.log(Level.INFO, "Cancelling job {0} for branch {1}", LoggerUtil.toArray(item.task.getName(), branch));
+            LOGGER.log(
+                    Level.INFO, "Cancelling job {0} for branch {1}", LoggerUtil.toArray(item.task.getName(), branch));
             queue.cancel(item);
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Error cancelling queued build", e);
@@ -72,8 +72,14 @@ public class PendingBuildsHandler {
         GitLabClient client = job.getProperty(GitLabConnectionProperty.class).getClient();
         String ref = StringUtils.removeStart(causeData.getSourceBranch(), "refs/tags/");
         try {
-            client.changeBuildStatus(causeData.getSourceProjectId(), causeData.getLastCommit(), BuildState.canceled,
-                ref, buildName, targetUrl, BuildState.canceled.name());
+            client.changeBuildStatus(
+                    causeData.getSourceProjectId(),
+                    causeData.getLastCommit(),
+                    BuildState.canceled,
+                    ref,
+                    buildName,
+                    targetUrl,
+                    BuildState.canceled.name());
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to set build state to pending", e);
         }
@@ -81,8 +87,8 @@ public class PendingBuildsHandler {
 
     public static String resolvePendingBuildName(Job<?, ?> job) {
         if (job instanceof AbstractProject) {
-            GitLabCommitStatusPublisher publisher =
-                (GitLabCommitStatusPublisher) ((AbstractProject) job).getPublishersList().get(GitLabCommitStatusPublisher.class);
+            GitLabCommitStatusPublisher publisher = (GitLabCommitStatusPublisher)
+                    ((AbstractProject) job).getPublishersList().get(GitLabCommitStatusPublisher.class);
             if (publisher != null) {
                 return publisher.getName();
             }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/WebHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/WebHookTriggerHandler.java
@@ -10,5 +10,10 @@ import hudson.model.Job;
  */
 public interface WebHookTriggerHandler<H extends WebHook> {
 
-    void handle(Job<?, ?> job, H hook, boolean ciSkip, BranchFilter branchFilter, MergeRequestLabelFilter mergeRequestLabelFilter);
+    void handle(
+            Job<?, ?> job,
+            H hook,
+            boolean ciSkip,
+            BranchFilter branchFilter,
+            MergeRequestLabelFilter mergeRequestLabelFilter);
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandler.java
@@ -6,4 +6,4 @@ import com.dabsquared.gitlabjenkins.trigger.handler.WebHookTriggerHandler;
 /**
  * @author Robin Müller
  */
-public interface MergeRequestHookTriggerHandler extends WebHookTriggerHandler<MergeRequestHook> { }
+public interface MergeRequestHookTriggerHandler extends WebHookTriggerHandler<MergeRequestHook> {}

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
@@ -1,18 +1,16 @@
 package com.dabsquared.gitlabjenkins.trigger.handler.merge;
 
-import com.dabsquared.gitlabjenkins.MergeRequestTriggerConfig;
-import com.dabsquared.gitlabjenkins.gitlab.hook.model.Action;
-import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
-import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
-
 import static java.util.EnumSet.of;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang.StringUtils.split;
 import static org.apache.commons.lang.StringUtils.trimToEmpty;
 
+import com.dabsquared.gitlabjenkins.MergeRequestTriggerConfig;
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.Action;
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
+import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
 import java.util.Set;
 import java.util.stream.Stream;
-
 
 /**
  * @author Robin Müller
@@ -21,40 +19,49 @@ public final class MergeRequestHookTriggerHandlerFactory {
 
     private MergeRequestHookTriggerHandlerFactory() {}
 
-    public static MergeRequestHookTriggerHandler newMergeRequestHookTriggerHandler(boolean triggerOnMergeRequest,
-    		                                                                       boolean triggerOnlyWithNewCommitsPushed,
-    		                                                                       boolean triggerOnAcceptedMergeRequest,
-    		                                                                       boolean triggerOnClosedMergeRequest,
-                                                                                   TriggerOpenMergeRequest triggerOpenMergeRequest,
-                                                                                   boolean skipWorkInProgressMergeRequest,
-                                                                                   String labelsThatForcesBuildIfAdded,
-                                                                                   boolean triggerOnApprovedMergeRequest,
-                                                                                   boolean cancelPendingBuildsOnUpdate) {
+    public static MergeRequestHookTriggerHandler newMergeRequestHookTriggerHandler(
+            boolean triggerOnMergeRequest,
+            boolean triggerOnlyWithNewCommitsPushed,
+            boolean triggerOnAcceptedMergeRequest,
+            boolean triggerOnClosedMergeRequest,
+            TriggerOpenMergeRequest triggerOpenMergeRequest,
+            boolean skipWorkInProgressMergeRequest,
+            String labelsThatForcesBuildIfAdded,
+            boolean triggerOnApprovedMergeRequest,
+            boolean cancelPendingBuildsOnUpdate) {
 
         TriggerConfigChain chain = new TriggerConfigChain();
-        chain
-            .acceptOnlyIf(triggerOpenMergeRequest != TriggerOpenMergeRequest.never, of(State.opened, State.updated), of(Action.update))
-            .acceptOnlyIf(triggerOnApprovedMergeRequest, null, of(Action.approved))
-            .acceptIf(triggerOnMergeRequest, of(State.opened, State.reopened), null)
-            .acceptIf(triggerOnAcceptedMergeRequest, null, of(Action.merge))
-            .acceptIf(triggerOnClosedMergeRequest, null, of(Action.close))
-            .acceptIf(triggerOnClosedMergeRequest, of(State.closed), null)
-        ;
+        chain.acceptOnlyIf(
+                        triggerOpenMergeRequest != TriggerOpenMergeRequest.never,
+                        of(State.opened, State.updated),
+                        of(Action.update))
+                .acceptOnlyIf(triggerOnApprovedMergeRequest, null, of(Action.approved))
+                .acceptIf(triggerOnMergeRequest, of(State.opened, State.reopened), null)
+                .acceptIf(triggerOnAcceptedMergeRequest, null, of(Action.merge))
+                .acceptIf(triggerOnClosedMergeRequest, null, of(Action.close))
+                .acceptIf(triggerOnClosedMergeRequest, of(State.closed), null);
 
-        Set<String> labelsThatForcesBuildIfAddedSet = Stream.of(split(trimToEmpty(labelsThatForcesBuildIfAdded), ",")).collect(toSet());
-        return new MergeRequestHookTriggerHandlerImpl(chain, triggerOnlyWithNewCommitsPushed, skipWorkInProgressMergeRequest, labelsThatForcesBuildIfAddedSet, cancelPendingBuildsOnUpdate);
+        Set<String> labelsThatForcesBuildIfAddedSet =
+                Stream.of(split(trimToEmpty(labelsThatForcesBuildIfAdded), ",")).collect(toSet());
+        return new MergeRequestHookTriggerHandlerImpl(
+                chain,
+                triggerOnlyWithNewCommitsPushed,
+                skipWorkInProgressMergeRequest,
+                labelsThatForcesBuildIfAddedSet,
+                cancelPendingBuildsOnUpdate);
     }
 
     public static MergeRequestHookTriggerHandler newMergeRequestHookTriggerHandler(MergeRequestTriggerConfig config) {
-        return newMergeRequestHookTriggerHandler(config.getTriggerOnMergeRequest(),
-            config.isTriggerOnlyIfNewCommitsPushed(),
-            config.isTriggerOnAcceptedMergeRequest(),
-            config.isTriggerOnClosedMergeRequest(),
-            config.getTriggerOpenMergeRequestOnPush(),
-            config.isSkipWorkInProgressMergeRequest(),
-            config.getLabelsThatForcesBuildIfAdded(),
-            config.isTriggerOnApprovedMergeRequest(),
-            config.getCancelPendingBuildsOnUpdate());
+        return newMergeRequestHookTriggerHandler(
+                config.getTriggerOnMergeRequest(),
+                config.isTriggerOnlyIfNewCommitsPushed(),
+                config.isTriggerOnAcceptedMergeRequest(),
+                config.isTriggerOnClosedMergeRequest(),
+                config.getTriggerOpenMergeRequestOnPush(),
+                config.isSkipWorkInProgressMergeRequest(),
+                config.getLabelsThatForcesBuildIfAdded(),
+                config.isTriggerOnApprovedMergeRequest(),
+                config.getCancelPendingBuildsOnUpdate());
     }
 
     public static Config withConfig() {

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -1,5 +1,11 @@
 package com.dabsquared.gitlabjenkins.trigger.handler.merge;
 
+import static com.dabsquared.gitlabjenkins.cause.CauseDataBuilder.causeData;
+import static com.dabsquared.gitlabjenkins.trigger.handler.builder.generated.BuildStatusUpdateBuilder.buildStatusUpdate;
+import static com.dabsquared.gitlabjenkins.util.LoggerUtil.toArray;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+
 import com.dabsquared.gitlabjenkins.cause.CauseData;
 import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.*;
@@ -12,31 +18,23 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.RevisionParameterAction;
-import org.apache.commons.lang.StringUtils;
-
-import java.util.Collection;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
-
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.EnumSet;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static com.dabsquared.gitlabjenkins.cause.CauseDataBuilder.causeData;
-import static com.dabsquared.gitlabjenkins.trigger.handler.builder.generated.BuildStatusUpdateBuilder.buildStatusUpdate;
-import static com.dabsquared.gitlabjenkins.util.LoggerUtil.toArray;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * @author Robin Müller
  */
-class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<MergeRequestHook> implements MergeRequestHookTriggerHandler {
+class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<MergeRequestHook>
+        implements MergeRequestHookTriggerHandler {
 
     private static final Logger LOGGER = Logger.getLogger(MergeRequestHookTriggerHandlerImpl.class.getName());
 
@@ -48,18 +46,41 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
     private final EnumSet<Action> skipAllowedStateForActions = EnumSet.of(Action.approved);
     private final boolean cancelPendingBuildsOnUpdate;
 
-    MergeRequestHookTriggerHandlerImpl(Collection<State> allowedStates, boolean skipWorkInProgressMergeRequest, boolean cancelPendingBuildsOnUpdate) {
-        this(allowedStates, EnumSet.noneOf(Action.class), false, skipWorkInProgressMergeRequest, cancelPendingBuildsOnUpdate);
+    MergeRequestHookTriggerHandlerImpl(
+            Collection<State> allowedStates,
+            boolean skipWorkInProgressMergeRequest,
+            boolean cancelPendingBuildsOnUpdate) {
+        this(
+                allowedStates,
+                EnumSet.noneOf(Action.class),
+                false,
+                skipWorkInProgressMergeRequest,
+                cancelPendingBuildsOnUpdate);
     }
 
     // this retains internal API, however, the plugin code no longer instantiates the handler this way.
     // any code using it should test it on higher level
     @Deprecated
-    MergeRequestHookTriggerHandlerImpl(Collection<State> allowedStates, Collection<Action> allowedActions, boolean onlyIfNewCommitsPushed, boolean skipWorkInProgressMergeRequest, boolean cancelPendingBuildsOnUpdate) {
-        this(new TriggerConfigChain().add(allowedStates, null).add(null, allowedActions), onlyIfNewCommitsPushed, skipWorkInProgressMergeRequest, emptySet(), cancelPendingBuildsOnUpdate);
+    MergeRequestHookTriggerHandlerImpl(
+            Collection<State> allowedStates,
+            Collection<Action> allowedActions,
+            boolean onlyIfNewCommitsPushed,
+            boolean skipWorkInProgressMergeRequest,
+            boolean cancelPendingBuildsOnUpdate) {
+        this(
+                new TriggerConfigChain().add(allowedStates, null).add(null, allowedActions),
+                onlyIfNewCommitsPushed,
+                skipWorkInProgressMergeRequest,
+                emptySet(),
+                cancelPendingBuildsOnUpdate);
     }
 
-    MergeRequestHookTriggerHandlerImpl(Predicate<MergeRequestObjectAttributes> triggerConfig, boolean onlyIfNewCommitsPushed, boolean skipWorkInProgressMergeRequest, Set<String> labelsThatForcesBuildIfAdded, boolean cancelPendingBuildsOnUpdate) {
+    MergeRequestHookTriggerHandlerImpl(
+            Predicate<MergeRequestObjectAttributes> triggerConfig,
+            boolean onlyIfNewCommitsPushed,
+            boolean skipWorkInProgressMergeRequest,
+            Set<String> labelsThatForcesBuildIfAdded,
+            boolean cancelPendingBuildsOnUpdate) {
         this.triggerConfig = triggerConfig;
         this.onlyIfNewCommitsPushed = onlyIfNewCommitsPushed;
         this.skipWorkInProgressMergeRequest = skipWorkInProgressMergeRequest;
@@ -68,7 +89,12 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
     }
 
     @Override
-    public void handle(Job<?, ?> job, MergeRequestHook hook, boolean ciSkip, BranchFilter branchFilter, MergeRequestLabelFilter mergeRequestLabelFilter) {
+    public void handle(
+            Job<?, ?> job,
+            MergeRequestHook hook,
+            boolean ciSkip,
+            BranchFilter branchFilter,
+            MergeRequestLabelFilter mergeRequestLabelFilter) {
         if (isExecutable(job, hook)) {
             List<String> labelsNames = new ArrayList<>();
             if (hook.getLabels() != null) {
@@ -118,16 +144,14 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
     @Override
     protected boolean isCiSkip(MergeRequestHook hook) {
         return hook.getObjectAttributes() != null
-            && (
-                (hook.getObjectAttributes().getDescription() != null
-                    && hook.getObjectAttributes().getDescription().contains("[ci-skip]")
-                ) ||
-                (
-                    hook.getObjectAttributes().getLastCommit() != null &&
-                        hook.getObjectAttributes().getLastCommit().getMessage() != null &&
-                        hook.getObjectAttributes().getLastCommit().getMessage().contains("[ci-skip]")
-                )
-        );
+                && ((hook.getObjectAttributes().getDescription() != null
+                                && hook.getObjectAttributes().getDescription().contains("[ci-skip]"))
+                        || (hook.getObjectAttributes().getLastCommit() != null
+                                && hook.getObjectAttributes().getLastCommit().getMessage() != null
+                                && hook.getObjectAttributes()
+                                        .getLastCommit()
+                                        .getMessage()
+                                        .contains("[ci-skip]")));
     }
 
     @Override
@@ -138,17 +162,24 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
         if (!hook.getObjectAttributes().getAction().equals(Action.update)) {
             return;
         }
-        this.pendingBuildsHandler.cancelPendingBuilds(job, hook.getObjectAttributes().getSourceProjectId(), hook.getObjectAttributes().getSourceBranch());
+        this.pendingBuildsHandler.cancelPendingBuilds(
+                job,
+                hook.getObjectAttributes().getSourceProjectId(),
+                hook.getObjectAttributes().getSourceBranch());
     }
 
     @Override
     protected String getSourceBranch(MergeRequestHook hook) {
-        return hook.getObjectAttributes() == null ? null : hook.getObjectAttributes().getSourceBranch();
+        return hook.getObjectAttributes() == null
+                ? null
+                : hook.getObjectAttributes().getSourceBranch();
     }
 
     @Override
     protected String getTargetBranch(MergeRequestHook hook) {
-        return hook.getObjectAttributes() == null ? null : hook.getObjectAttributes().getTargetBranch();
+        return hook.getObjectAttributes() == null
+                ? null
+                : hook.getObjectAttributes().getTargetBranch();
     }
 
     @Override
@@ -164,8 +195,10 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
                 .withTargetProjectId(hook.getObjectAttributes().getTargetProjectId())
                 .withBranch(hook.getObjectAttributes().getSourceBranch())
                 .withSourceBranch(hook.getObjectAttributes().getSourceBranch())
-                .withUserName(hook.getObjectAttributes().getLastCommit().getAuthor().getName())
-                .withUserEmail(hook.getObjectAttributes().getLastCommit().getAuthor().getEmail())
+                .withUserName(
+                        hook.getObjectAttributes().getLastCommit().getAuthor().getName())
+                .withUserEmail(
+                        hook.getObjectAttributes().getLastCommit().getAuthor().getEmail())
                 .withSourceRepoHomepage(hook.getObjectAttributes().getSource().getHomepage())
                 .withSourceRepoName(hook.getObjectAttributes().getSource().getName())
                 .withSourceNamespace(hook.getObjectAttributes().getSource().getNamespace())
@@ -178,31 +211,34 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
                 .withMergeRequestIid(hook.getObjectAttributes().getIid())
                 .withMergeRequestState(hook.getObjectAttributes().getState().toString())
                 .withMergedByUser(hook.getUser() == null ? null : hook.getUser().getUsername())
-                .withMergeRequestAssignee(hook.getAssignee() == null ? null : hook.getAssignee().getUsername())
+                .withMergeRequestAssignee(
+                        hook.getAssignee() == null ? null : hook.getAssignee().getUsername())
                 .withMergeRequestTargetProjectId(hook.getObjectAttributes().getTargetProjectId())
                 .withTargetBranch(hook.getObjectAttributes().getTargetBranch())
                 .withTargetRepoName(hook.getObjectAttributes().getTarget().getName())
                 .withTargetNamespace(hook.getObjectAttributes().getTarget().getNamespace())
                 .withTargetRepoSshUrl(hook.getObjectAttributes().getTarget().getSshUrl())
                 .withTargetRepoHttpUrl(hook.getObjectAttributes().getTarget().getHttpUrl())
-                .withTriggeredByUser(hook.getObjectAttributes().getLastCommit().getAuthor().getName())
+                .withTriggeredByUser(
+                        hook.getObjectAttributes().getLastCommit().getAuthor().getName())
                 .withLastCommit(hook.getObjectAttributes().getLastCommit().getId())
                 .withTargetProjectUrl(hook.getObjectAttributes().getTarget().getWebUrl())
                 .build();
     }
 
     @Override
-    protected RevisionParameterAction createRevisionParameter(MergeRequestHook hook, GitSCM gitSCM) throws NoRevisionToBuildException {
+    protected RevisionParameterAction createRevisionParameter(MergeRequestHook hook, GitSCM gitSCM)
+            throws NoRevisionToBuildException {
         return new RevisionParameterAction(retrieveRevisionToBuild(hook), retrieveUrIish(hook));
     }
 
     @Override
     protected BuildStatusUpdate retrieveBuildStatusUpdate(MergeRequestHook hook) {
         return buildStatusUpdate()
-            .withProjectId(hook.getObjectAttributes().getSourceProjectId())
-            .withSha(hook.getObjectAttributes().getLastCommit().getId())
-            .withRef(hook.getObjectAttributes().getSourceBranch())
-            .build();
+                .withProjectId(hook.getObjectAttributes().getSourceProjectId())
+                .withSha(hook.getObjectAttributes().getLastCommit().getId())
+                .withRef(hook.getObjectAttributes().getSourceBranch())
+                .build();
     }
 
     private String retrieveRevisionToBuild(MergeRequestHook hook) throws NoRevisionToBuildException {
@@ -239,12 +275,16 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
             return true;
         }
 
-        if (!StringUtils.equals(getTargetMergeRequestStateFromBuild(mergeBuild), objectAttributes.getState().name())) {
+        if (!StringUtils.equals(
+                getTargetMergeRequestStateFromBuild(mergeBuild),
+                objectAttributes.getState().name())) {
             return true;
         }
 
         if (StringUtils.equals(getTargetBranchFromBuild(mergeBuild), objectAttributes.getTargetBranch())) {
-            LOGGER.log(Level.INFO, "Last commit in Merge Request has already been built in build #" + mergeBuild.getNumber());
+            LOGGER.log(
+                    Level.INFO,
+                    "Last commit in Merge Request has already been built in build #" + mergeBuild.getNumber());
             return false;
         }
 
@@ -261,11 +301,15 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
         return cause == null ? null : cause.getData().getMergeRequestState();
     }
 
-	private boolean isAllowedByConfig(MergeRequestObjectAttributes objectAttributes) {
-		return triggerConfig.test(objectAttributes);
+    private boolean isAllowedByConfig(MergeRequestObjectAttributes objectAttributes) {
+        return triggerConfig.test(objectAttributes);
     }
+
     private boolean isBecameNoWip(MergeRequestHook hook) {
-        MergeRequestChangedTitle changedTitle = Optional.of(hook).map(MergeRequestHook::getChanges).map(MergeRequestChanges::getTitle).orElse(new MergeRequestChangedTitle());
+        MergeRequestChangedTitle changedTitle = Optional.of(hook)
+                .map(MergeRequestHook::getChanges)
+                .map(MergeRequestChanges::getTitle)
+                .orElse(new MergeRequestChangedTitle());
         String current = changedTitle.getCurrent() != null ? changedTitle.getCurrent() : "";
         String previous = changedTitle.getPrevious() != null ? changedTitle.getPrevious() : "";
 
@@ -277,12 +321,17 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
             return false;
         }
 
-        MergeRequestChangedLabels changedLabels = Optional.of(hook).map(MergeRequestHook::getChanges).map(MergeRequestChanges::getLabels).orElse(new MergeRequestChangedLabels());
+        MergeRequestChangedLabels changedLabels = Optional.of(hook)
+                .map(MergeRequestHook::getChanges)
+                .map(MergeRequestChanges::getLabels)
+                .orElse(new MergeRequestChangedLabels());
         List<MergeRequestLabel> current = changedLabels.getCurrent() != null ? changedLabels.getCurrent() : emptyList();
-        List<MergeRequestLabel> previous = changedLabels.getPrevious() != null ? changedLabels.getPrevious() : emptyList();
+        List<MergeRequestLabel> previous =
+                changedLabels.getPrevious() != null ? changedLabels.getPrevious() : emptyList();
 
         return current.stream()
-                .filter(currentLabel -> !previous.stream().anyMatch(previousLabel -> Objects.equals(currentLabel.getId(), previousLabel.getId())))
+                .filter(currentLabel -> !previous.stream()
+                        .anyMatch(previousLabel -> Objects.equals(currentLabel.getId(), previousLabel.getId())))
                 .map(label -> label.getTitle())
                 .anyMatch(label -> labelsThatForcesBuildIfAdded.contains(label));
     }
@@ -290,7 +339,10 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
     private boolean isNotSkipWorkInProgressMergeRequest(MergeRequestObjectAttributes objectAttributes) {
         Boolean workInProgress = objectAttributes.getWorkInProgress();
         if (skipWorkInProgressMergeRequest && workInProgress != null && workInProgress) {
-            LOGGER.log(Level.INFO, "Skip WIP Merge Request #{0} ({1})", toArray(objectAttributes.getIid(), objectAttributes.getTitle()));
+            LOGGER.log(
+                    Level.INFO,
+                    "Skip WIP Merge Request #{0} ({1})",
+                    toArray(objectAttributes.getIid(), objectAttributes.getTitle()));
             return false;
         }
         return true;

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/NopMergeRequestHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/NopMergeRequestHookTriggerHandler.java
@@ -10,7 +10,12 @@ import hudson.model.Job;
  */
 class NopMergeRequestHookTriggerHandler implements MergeRequestHookTriggerHandler {
     @Override
-    public void handle(Job<?, ?> job, MergeRequestHook hook, boolean ciSkip, BranchFilter branchFilter, MergeRequestLabelFilter mergeRequestLabelFilter) {
+    public void handle(
+            Job<?, ?> job,
+            MergeRequestHook hook,
+            boolean ciSkip,
+            BranchFilter branchFilter,
+            MergeRequestLabelFilter mergeRequestLabelFilter) {
         // nothing to do
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/StateAndActionConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/StateAndActionConfig.java
@@ -3,7 +3,6 @@ package com.dabsquared.gitlabjenkins.trigger.handler.merge;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.Action;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.MergeRequestObjectAttributes;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
-
 import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -23,9 +22,8 @@ class StateAndActionConfig implements Predicate<MergeRequestObjectAttributes> {
 
     @Override
     public boolean test(MergeRequestObjectAttributes mergeRequestObjectAttributes) {
-        return
-            states.test(mergeRequestObjectAttributes.getState()) &&
-            actions.test(mergeRequestObjectAttributes.getAction());
+        return states.test(mergeRequestObjectAttributes.getState())
+                && actions.test(mergeRequestObjectAttributes.getAction());
     }
 
     static <T> Predicate<T> nullOrContains(final Collection<T> collection) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/TriggerConfigChain.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/TriggerConfigChain.java
@@ -3,7 +3,6 @@ package com.dabsquared.gitlabjenkins.trigger.handler.merge;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.Action;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.MergeRequestObjectAttributes;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -13,7 +12,6 @@ import java.util.function.Predicate;
 public class TriggerConfigChain implements Predicate<MergeRequestObjectAttributes> {
     private final List<Predicate<MergeRequestObjectAttributes>> acceptRules = new ArrayList<>();
     private final List<Predicate<MergeRequestObjectAttributes>> rejectRules = new ArrayList<>();
-
 
     public TriggerConfigChain rejectUnless(boolean condition, Predicate<MergeRequestObjectAttributes> trigger) {
         if (!condition) {
@@ -27,8 +25,7 @@ public class TriggerConfigChain implements Predicate<MergeRequestObjectAttribute
     }
 
     public TriggerConfigChain acceptOnlyIf(boolean condition, EnumSet<State> states, EnumSet<Action> actions) {
-        return rejectUnless(condition, states, actions)
-            .acceptIf(condition, states, actions);
+        return rejectUnless(condition, states, actions).acceptIf(condition, states, actions);
     }
 
     public TriggerConfigChain acceptIf(boolean condition, Predicate<MergeRequestObjectAttributes> trigger) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NopNoteHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NopNoteHookTriggerHandler.java
@@ -10,7 +10,12 @@ import hudson.model.Job;
  */
 class NopNoteHookTriggerHandler implements NoteHookTriggerHandler {
     @Override
-    public void handle(Job<?, ?> job, NoteHook hook, boolean ciSkip, BranchFilter branchFilter, MergeRequestLabelFilter mergeRequestLabelFilter) {
+    public void handle(
+            Job<?, ?> job,
+            NoteHook hook,
+            boolean ciSkip,
+            BranchFilter branchFilter,
+            MergeRequestLabelFilter mergeRequestLabelFilter) {
         // nothing to do
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandler.java
@@ -6,4 +6,4 @@ import com.dabsquared.gitlabjenkins.trigger.handler.WebHookTriggerHandler;
 /**
  * @author Nikolay Ustinov
  */
-public interface NoteHookTriggerHandler extends WebHookTriggerHandler<NoteHook> { }
+public interface NoteHookTriggerHandler extends WebHookTriggerHandler<NoteHook> {}

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImpl.java
@@ -1,5 +1,8 @@
 package com.dabsquared.gitlabjenkins.trigger.handler.note;
 
+import static com.dabsquared.gitlabjenkins.cause.CauseDataBuilder.causeData;
+import static com.dabsquared.gitlabjenkins.trigger.handler.builder.generated.BuildStatusUpdateBuilder.buildStatusUpdate;
+
 import com.dabsquared.gitlabjenkins.cause.CauseData;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.NoteHook;
 import com.dabsquared.gitlabjenkins.trigger.exception.NoRevisionToBuildException;
@@ -9,13 +12,9 @@ import com.dabsquared.gitlabjenkins.trigger.handler.AbstractWebHookTriggerHandle
 import hudson.model.Job;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.RevisionParameterAction;
-import org.apache.commons.lang.StringUtils;
-
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-
-import static com.dabsquared.gitlabjenkins.cause.CauseDataBuilder.causeData;
-import static com.dabsquared.gitlabjenkins.trigger.handler.builder.generated.BuildStatusUpdateBuilder.buildStatusUpdate;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * @author Nikolay Ustinov
@@ -31,7 +30,12 @@ class NoteHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<NoteHook>
     }
 
     @Override
-    public void handle(Job<?, ?> job, NoteHook hook, boolean ciSkip, BranchFilter branchFilter, MergeRequestLabelFilter mergeRequestLabelFilter) {
+    public void handle(
+            Job<?, ?> job,
+            NoteHook hook,
+            boolean ciSkip,
+            BranchFilter branchFilter,
+            MergeRequestLabelFilter mergeRequestLabelFilter) {
         if (isValidTriggerPhrase(hook.getObjectAttributes().getNote())) {
             super.handle(job, hook, ciSkip, branchFilter, mergeRequestLabelFilter);
         }
@@ -68,7 +72,8 @@ class NoteHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<NoteHook>
                 .withBranch(hook.getMergeRequest().getSourceBranch())
                 .withSourceBranch(hook.getMergeRequest().getSourceBranch())
                 .withUserName(hook.getMergeRequest().getLastCommit().getAuthor().getName())
-                .withUserEmail(hook.getMergeRequest().getLastCommit().getAuthor().getEmail())
+                .withUserEmail(
+                        hook.getMergeRequest().getLastCommit().getAuthor().getEmail())
                 .withSourceRepoHomepage(hook.getMergeRequest().getSource().getHomepage())
                 .withSourceRepoName(hook.getMergeRequest().getSource().getName())
                 .withSourceNamespace(hook.getMergeRequest().getSource().getNamespace())
@@ -85,26 +90,29 @@ class NoteHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<NoteHook>
                 .withTargetNamespace(hook.getMergeRequest().getTarget().getNamespace())
                 .withTargetRepoSshUrl(hook.getMergeRequest().getTarget().getSshUrl())
                 .withTargetRepoHttpUrl(hook.getMergeRequest().getTarget().getHttpUrl())
-                .withTriggeredByUser(hook.getMergeRequest().getLastCommit().getAuthor().getName())
+                .withTriggeredByUser(
+                        hook.getMergeRequest().getLastCommit().getAuthor().getName())
                 .withLastCommit(hook.getMergeRequest().getLastCommit().getId())
                 .withTargetProjectUrl(hook.getMergeRequest().getTarget().getWebUrl())
                 .withTriggerPhrase(hook.getObjectAttributes().getNote())
-                .withCommentAuthor(hook.getUser() == null ? null : hook.getUser().getUsername())
+                .withCommentAuthor(
+                        hook.getUser() == null ? null : hook.getUser().getUsername())
                 .build();
     }
 
     @Override
-    protected RevisionParameterAction createRevisionParameter(NoteHook hook, GitSCM gitSCM) throws NoRevisionToBuildException {
+    protected RevisionParameterAction createRevisionParameter(NoteHook hook, GitSCM gitSCM)
+            throws NoRevisionToBuildException {
         return new RevisionParameterAction(retrieveRevisionToBuild(hook), retrieveUrIish(hook));
     }
 
     @Override
     protected BuildStatusUpdate retrieveBuildStatusUpdate(NoteHook hook) {
         return buildStatusUpdate()
-            .withProjectId(hook.getMergeRequest().getSourceProjectId())
-            .withSha(hook.getMergeRequest().getLastCommit().getId())
-            .withRef(hook.getMergeRequest().getSourceBranch())
-            .build();
+                .withProjectId(hook.getMergeRequest().getSourceProjectId())
+                .withSha(hook.getMergeRequest().getLastCommit().getId())
+                .withRef(hook.getMergeRequest().getSourceBranch())
+                .build();
     }
 
     private String retrieveRevisionToBuild(NoteHook hook) throws NoRevisionToBuildException {

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/NopPipelineHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/NopPipelineHookTriggerHandler.java
@@ -11,7 +11,10 @@ import hudson.model.Job;
 class NopPipelineHookTriggerHandler implements PipelineHookTriggerHandler {
 
     @Override
-    public void handle(Job<?, ?> job, PipelineHook hook, boolean ciSkip, BranchFilter branchFilter, MergeRequestLabelFilter mergeRequestLabelFilter) {
-
-    }
+    public void handle(
+            Job<?, ?> job,
+            PipelineHook hook,
+            boolean ciSkip,
+            BranchFilter branchFilter,
+            MergeRequestLabelFilter mergeRequestLabelFilter) {}
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandler.java
@@ -6,4 +6,4 @@ import com.dabsquared.gitlabjenkins.trigger.handler.WebHookTriggerHandler;
 /**
  * @author Milena Zachow
  */
-public interface PipelineHookTriggerHandler extends WebHookTriggerHandler<PipelineHook> { }
+public interface PipelineHookTriggerHandler extends WebHookTriggerHandler<PipelineHook> {}

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerFactory.java
@@ -1,6 +1,5 @@
 package com.dabsquared.gitlabjenkins.trigger.handler.pipeline;
 
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,8 +10,7 @@ public final class PipelineHookTriggerHandlerFactory {
 
     public static final String SUCCESS = "success";
 
-    private PipelineHookTriggerHandlerFactory() {
-    }
+    private PipelineHookTriggerHandlerFactory() {}
 
     public static PipelineHookTriggerHandler newPipelineHookTriggerHandler(boolean triggerOnPipelineEvent) {
         if (triggerOnPipelineEvent) {
@@ -21,7 +19,6 @@ public final class PipelineHookTriggerHandlerFactory {
             return new NopPipelineHookTriggerHandler();
         }
     }
-
 
     private static List<String> retrieve(boolean triggerOnPipelineEvent) {
         List<String> result = new ArrayList<>();

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/NopPushHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/NopPushHookTriggerHandler.java
@@ -10,7 +10,12 @@ import hudson.model.Job;
  */
 class NopPushHookTriggerHandler implements PushHookTriggerHandler {
     @Override
-    public void handle(Job<?, ?> job, PushHook hook, boolean ciSkip, BranchFilter branchFilter, MergeRequestLabelFilter mergeRequestLabelFilter) {
+    public void handle(
+            Job<?, ?> job,
+            PushHook hook,
+            boolean ciSkip,
+            BranchFilter branchFilter,
+            MergeRequestLabelFilter mergeRequestLabelFilter) {
         // nothing to do
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
@@ -1,5 +1,7 @@
 package com.dabsquared.gitlabjenkins.trigger.handler.push;
 
+import static com.dabsquared.gitlabjenkins.cause.CauseDataBuilder.causeData;
+import static com.dabsquared.gitlabjenkins.util.LoggerUtil.toArray;
 
 import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
 import com.dabsquared.gitlabjenkins.cause.CauseData;
@@ -14,21 +16,13 @@ import com.dabsquared.gitlabjenkins.gitlab.hook.model.PushHook;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
 import com.dabsquared.gitlabjenkins.trigger.filter.BranchFilter;
 import com.dabsquared.gitlabjenkins.trigger.filter.MergeRequestLabelFilter;
-import com.dabsquared.gitlabjenkins.util.LoggerUtil;
 import com.dabsquared.gitlabjenkins.trigger.handler.PendingBuildsHandler;
+import com.dabsquared.gitlabjenkins.util.LoggerUtil;
 import hudson.model.Action;
 import hudson.model.CauseAction;
 import hudson.model.Job;
 import hudson.plugins.git.RevisionParameterAction;
 import hudson.triggers.Trigger;
-import jenkins.model.ParameterizedJobMixIn;
-import jenkins.model.ParameterizedJobMixIn.ParameterizedJob;
-import org.apache.commons.lang.StringUtils;
-import org.eclipse.jgit.transport.URIish;
-import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
-
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,16 +30,20 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static com.dabsquared.gitlabjenkins.cause.CauseDataBuilder.causeData;
-import static com.dabsquared.gitlabjenkins.util.LoggerUtil.toArray;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import jenkins.model.ParameterizedJobMixIn;
+import jenkins.model.ParameterizedJobMixIn.ParameterizedJob;
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jgit.transport.URIish;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 
 /**
  * @author Robin Müller
  */
 class OpenMergeRequestPushHookTriggerHandler implements PushHookTriggerHandler {
 
-    private final static Logger LOGGER = Logger.getLogger(OpenMergeRequestPushHookTriggerHandler.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(OpenMergeRequestPushHookTriggerHandler.class.getName());
 
     private final boolean skipWorkInProgressMergeRequest;
 
@@ -54,32 +52,44 @@ class OpenMergeRequestPushHookTriggerHandler implements PushHookTriggerHandler {
     }
 
     @Override
-    public void handle(Job<?, ?> job, PushHook hook, boolean ciSkip, BranchFilter branchFilter, MergeRequestLabelFilter mergeRequestLabelFilter) {
-    	try {
+    public void handle(
+            Job<?, ?> job,
+            PushHook hook,
+            boolean ciSkip,
+            BranchFilter branchFilter,
+            MergeRequestLabelFilter mergeRequestLabelFilter) {
+        try {
             if (job instanceof ParameterizedJobMixIn.ParameterizedJob) {
                 ParameterizedJob<?, ?> project = (ParameterizedJobMixIn.ParameterizedJob) job;
                 GitLabConnectionProperty property = job.getProperty(GitLabConnectionProperty.class);
                 Collection<Trigger<?>> triggerList = project.getTriggers().values();
                 for (Trigger<?> t : triggerList) {
-                	if (t instanceof GitLabPushTrigger) {
-                		final GitLabPushTrigger trigger = (GitLabPushTrigger) t;
+                    if (t instanceof GitLabPushTrigger) {
+                        final GitLabPushTrigger trigger = (GitLabPushTrigger) t;
                         Integer projectId = hook.getProjectId();
                         if (property != null && property.getClient() != null && projectId != null && trigger != null) {
                             GitLabClient client = property.getClient();
                             for (MergeRequest mergeRequest : getOpenMergeRequests(client, projectId.toString())) {
                                 if (mergeRequestLabelFilter.isMergeRequestAllowed(mergeRequest.getLabels())) {
-                                	handleMergeRequest(job, hook, ciSkip, branchFilter, client, mergeRequest);
+                                    handleMergeRequest(job, hook, ciSkip, branchFilter, client, mergeRequest);
                                 }
                             }
                         }
-                	}
+                    }
                 }
 
             } else {
-            	LOGGER.log(Level.FINE, "Not a ParameterizedJob: {0}",LoggerUtil.toArray(job.getClass().getName()));
+                LOGGER.log(
+                        Level.FINE,
+                        "Not a ParameterizedJob: {0}",
+                        LoggerUtil.toArray(job.getClass().getName()));
             }
         } catch (WebApplicationException | ProcessingException e) {
-            LOGGER.log(Level.WARNING, "Failed to communicate with gitlab server to determine if this is an update for a merge request: " + e.getMessage(), e);
+            LOGGER.log(
+                    Level.WARNING,
+                    "Failed to communicate with gitlab server to determine if this is an update for a merge request: "
+                            + e.getMessage(),
+                    e);
         }
     }
 
@@ -94,30 +104,48 @@ class OpenMergeRequestPushHookTriggerHandler implements PushHookTriggerHandler {
         return result;
     }
 
-    private void handleMergeRequest(Job<?, ?> job, PushHook hook, boolean ciSkip, BranchFilter branchFilter, GitLabClient client, MergeRequest mergeRequest) {
-        if (ciSkip && mergeRequest.getDescription() != null && mergeRequest.getDescription().contains("[ci-skip]")) {
+    private void handleMergeRequest(
+            Job<?, ?> job,
+            PushHook hook,
+            boolean ciSkip,
+            BranchFilter branchFilter,
+            GitLabClient client,
+            MergeRequest mergeRequest) {
+        if (ciSkip
+                && mergeRequest.getDescription() != null
+                && mergeRequest.getDescription().contains("[ci-skip]")) {
             LOGGER.log(Level.INFO, "Skipping MR " + mergeRequest.getTitle() + " due to ci-skip.");
             return;
         }
 
         Boolean workInProgress = mergeRequest.getWorkInProgress();
         if (skipWorkInProgressMergeRequest && workInProgress != null && workInProgress) {
-            LOGGER.log(Level.INFO, "Skip WIP Merge Request #{0} ({1})", toArray(mergeRequest.getIid(), mergeRequest.getTitle()));
+            LOGGER.log(
+                    Level.INFO,
+                    "Skip WIP Merge Request #{0} ({1})",
+                    toArray(mergeRequest.getIid(), mergeRequest.getTitle()));
             return;
         }
 
         String sourceBranch = mergeRequest.getSourceBranch();
         String targetBranch = mergeRequest.getTargetBranch();
-        if (targetBranch != null && branchFilter.isBranchAllowed(sourceBranch, targetBranch) && hook.getRef().equals("refs/heads/"+targetBranch) && sourceBranch != null) {
-            LOGGER.log(Level.INFO, "{0} triggered for push to target branch of open merge request #{1}.",
+        if (targetBranch != null
+                && branchFilter.isBranchAllowed(sourceBranch, targetBranch)
+                && hook.getRef().equals("refs/heads/" + targetBranch)
+                && sourceBranch != null) {
+            LOGGER.log(
+                    Level.INFO,
+                    "{0} triggered for push to target branch of open merge request #{1}.",
                     LoggerUtil.toArray(job.getFullName(), mergeRequest.getId()));
 
             Branch branch = client.getBranch(mergeRequest.getSourceProjectId().toString(), sourceBranch);
-            Project project = client.getProject(mergeRequest.getSourceProjectId().toString());
+            Project project =
+                    client.getProject(mergeRequest.getSourceProjectId().toString());
             String commit = branch.getCommit().getId();
             setCommitStatusPendingIfNecessary(job, mergeRequest.getSourceProjectId(), commit, branch.getName());
-            List<Action> actions = Arrays.<Action>asList(new CauseAction(new GitLabWebHookCause(retrieveCauseData(hook, project, mergeRequest, branch))),
-                                                         new RevisionParameterAction(commit, retrieveUrIish(hook)));
+            List<Action> actions = Arrays.<Action>asList(
+                    new CauseAction(new GitLabWebHookCause(retrieveCauseData(hook, project, mergeRequest, branch))),
+                    new RevisionParameterAction(commit, retrieveUrIish(hook)));
             scheduleBuild(job, actions.toArray(new Action[actions.size()]));
         }
     }
@@ -156,11 +184,19 @@ class OpenMergeRequestPushHookTriggerHandler implements PushHookTriggerHandler {
     private void setCommitStatusPendingIfNecessary(Job<?, ?> job, Integer projectId, String commit, String ref) {
         String buildName = PendingBuildsHandler.resolvePendingBuildName(job);
         if (StringUtils.isNotBlank(buildName)) {
-            GitLabClient client = job.getProperty(GitLabConnectionProperty.class).getClient();
+            GitLabClient client =
+                    job.getProperty(GitLabConnectionProperty.class).getClient();
             try {
                 String fixedTagRef = StringUtils.removeStart(ref, "refs/tags/");
                 String targetUrl = DisplayURLProvider.get().getJobURL(job);
-                client.changeBuildStatus(projectId, commit, BuildState.pending, fixedTagRef, buildName, targetUrl, BuildState.pending.name());
+                client.changeBuildStatus(
+                        projectId,
+                        commit,
+                        BuildState.pending,
+                        fixedTagRef,
+                        buildName,
+                        targetUrl,
+                        BuildState.pending.name());
             } catch (WebApplicationException | ProcessingException e) {
                 LOGGER.log(Level.SEVERE, "Failed to set build state to pending", e);
             }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandler.java
@@ -6,4 +6,4 @@ import com.dabsquared.gitlabjenkins.trigger.handler.WebHookTriggerHandler;
 /**
  * @author Robin Müller
  */
-public interface PushHookTriggerHandler extends WebHookTriggerHandler<PushHook> { }
+public interface PushHookTriggerHandler extends WebHookTriggerHandler<PushHook> {}

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerFactory.java
@@ -1,7 +1,6 @@
 package com.dabsquared.gitlabjenkins.trigger.handler.push;
 
 import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,21 +11,27 @@ public final class PushHookTriggerHandlerFactory {
 
     private PushHookTriggerHandlerFactory() {}
 
-    public static PushHookTriggerHandler newPushHookTriggerHandler(boolean triggerOnPush,
-                                                                   boolean triggerToBranchDeleteRequest,
-                                                                   TriggerOpenMergeRequest triggerOpenMergeRequestOnPush,
-                                                                   boolean skipWorkInProgressMergeRequest) {
+    public static PushHookTriggerHandler newPushHookTriggerHandler(
+            boolean triggerOnPush,
+            boolean triggerToBranchDeleteRequest,
+            TriggerOpenMergeRequest triggerOpenMergeRequestOnPush,
+            boolean skipWorkInProgressMergeRequest) {
         if (triggerOnPush || triggerOpenMergeRequestOnPush == TriggerOpenMergeRequest.both) {
-            return new PushHookTriggerHandlerList(retrieveHandlers(triggerOnPush, triggerToBranchDeleteRequest, triggerOpenMergeRequestOnPush, skipWorkInProgressMergeRequest));
+            return new PushHookTriggerHandlerList(retrieveHandlers(
+                    triggerOnPush,
+                    triggerToBranchDeleteRequest,
+                    triggerOpenMergeRequestOnPush,
+                    skipWorkInProgressMergeRequest));
         } else {
             return new NopPushHookTriggerHandler();
         }
     }
 
-    private static List<PushHookTriggerHandler> retrieveHandlers(boolean triggerOnPush,
-                                                                 boolean triggerToBranchDeleteRequest,
-                                                                 TriggerOpenMergeRequest triggerOpenMergeRequestOnPush,
-                                                                 boolean skipWorkInProgressMergeRequest) {
+    private static List<PushHookTriggerHandler> retrieveHandlers(
+            boolean triggerOnPush,
+            boolean triggerToBranchDeleteRequest,
+            TriggerOpenMergeRequest triggerOpenMergeRequestOnPush,
+            boolean skipWorkInProgressMergeRequest) {
         List<PushHookTriggerHandler> result = new ArrayList<>();
         if (triggerOnPush) {
             result.add(new PushHookTriggerHandlerImpl(triggerToBranchDeleteRequest));

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImpl.java
@@ -1,5 +1,8 @@
 package com.dabsquared.gitlabjenkins.trigger.handler.push;
 
+import static com.dabsquared.gitlabjenkins.cause.CauseDataBuilder.causeData;
+import static com.dabsquared.gitlabjenkins.trigger.handler.builder.generated.BuildStatusUpdateBuilder.buildStatusUpdate;
+
 import com.dabsquared.gitlabjenkins.cause.CauseData;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.Commit;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.PushHook;
@@ -10,15 +13,10 @@ import com.dabsquared.gitlabjenkins.trigger.handler.AbstractWebHookTriggerHandle
 import hudson.model.Job;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.RevisionParameterAction;
-import org.eclipse.jgit.util.StringUtils;
-
 import java.util.List;
-
-import java.util.logging.Logger;
 import java.util.logging.Level;
-
-import static com.dabsquared.gitlabjenkins.cause.CauseDataBuilder.causeData;
-import static com.dabsquared.gitlabjenkins.trigger.handler.builder.generated.BuildStatusUpdateBuilder.buildStatusUpdate;
+import java.util.logging.Logger;
+import org.eclipse.jgit.util.StringUtils;
 
 /**
  * @author Robin Müller
@@ -35,7 +33,11 @@ class PushHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<PushHook>
     }
 
     @Override
-    public void handle(Job<?, ?> job, PushHook hook, boolean ciSkip, BranchFilter branchFilter,
+    public void handle(
+            Job<?, ?> job,
+            PushHook hook,
+            boolean ciSkip,
+            BranchFilter branchFilter,
             MergeRequestLabelFilter mergeRequestLabelFilter) {
         if (isNoRemoveBranchPush(hook) || this.triggerToBranchDeleteRequest) {
             super.handle(job, hook, ciSkip, branchFilter, mergeRequestLabelFilter);
@@ -45,17 +47,17 @@ class PushHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<PushHook>
     @Override
     protected boolean isCiSkip(PushHook hook) {
         List<Commit> commits = hook.getCommits();
-        return commits != null &&
-                !commits.isEmpty() &&
-                commits.get(commits.size() - 1).getMessage() != null &&
-                commits.get(commits.size() - 1).getMessage().contains("[ci-skip]");
+        return commits != null
+                && !commits.isEmpty()
+                && commits.get(commits.size() - 1).getMessage() != null
+                && commits.get(commits.size() - 1).getMessage().contains("[ci-skip]");
     }
 
     @Override
     protected CauseData retrieveCauseData(PushHook hook) {
         try {
-            CauseData.ActionType actionType = hook.getObjectKind().equals("tag_push") ? CauseData.ActionType.TAG_PUSH
-                    : CauseData.ActionType.PUSH;
+            CauseData.ActionType actionType =
+                    hook.getObjectKind().equals("tag_push") ? CauseData.ActionType.TAG_PUSH : CauseData.ActionType.PUSH;
             return causeData()
                     .withActionType(actionType)
                     .withSourceProjectId(hook.getProjectId())

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerList.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerList.java
@@ -4,7 +4,6 @@ import com.dabsquared.gitlabjenkins.gitlab.hook.model.PushHook;
 import com.dabsquared.gitlabjenkins.trigger.filter.BranchFilter;
 import com.dabsquared.gitlabjenkins.trigger.filter.MergeRequestLabelFilter;
 import hudson.model.Job;
-
 import java.util.List;
 
 /**
@@ -19,7 +18,12 @@ class PushHookTriggerHandlerList implements PushHookTriggerHandler {
     }
 
     @Override
-    public void handle(Job<?, ?> job, PushHook hook, boolean ciSkip, BranchFilter branchFilter, MergeRequestLabelFilter mergeRequestLabelFilter) {
+    public void handle(
+            Job<?, ?> job,
+            PushHook hook,
+            boolean ciSkip,
+            BranchFilter branchFilter,
+            MergeRequestLabelFilter mergeRequestLabelFilter) {
         for (PushHookTriggerHandler handler : handlers) {
             handler.handle(job, hook, ciSkip, branchFilter, mergeRequestLabelFilter);
         }

--- a/src/main/java/com/dabsquared/gitlabjenkins/util/BuildUtil.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/BuildUtil.java
@@ -14,7 +14,7 @@ public class BuildUtil {
         for (Run<?, ?> build : project.getBuilds()) {
             BuildData data = build.getAction(BuildData.class);
             MergeRecord merge = build.getAction(MergeRecord.class);
-            if (hasLastBuild(data) && isNoMergeBuild(data, merge)) {    
+            if (hasLastBuild(data) && isNoMergeBuild(data, merge)) {
                 for (Branch branch : data.lastBuild.getRevision().getBranches()) {
                     if (branch.getName().endsWith("/" + branchName)) {
                         return build;
@@ -28,7 +28,7 @@ public class BuildUtil {
     public static Run<?, ?> getBuildBySHA1WithoutMergeBuilds(Job<?, ?> project, String sha1) {
         for (Run<?, ?> build : project.getBuilds()) {
             MergeRecord merge = build.getAction(MergeRecord.class);
-            for(BuildData data : build.getActions(BuildData.class)) {
+            for (BuildData data : build.getActions(BuildData.class)) {
                 if (hasLastBuild(data) && isNoMergeBuild(data, merge) && data.lastBuild.isFor(sha1)) {
                     return build;
                 }
@@ -39,11 +39,11 @@ public class BuildUtil {
 
     public static Run<?, ?> getBuildBySHA1IncludingMergeBuilds(Job<?, ?> project, String sha1) {
         for (Run<?, ?> build : project.getBuilds()) {
-            for(BuildData data : build.getActions(BuildData.class)) {
+            for (BuildData data : build.getActions(BuildData.class)) {
                 if (data != null
-                    && data.lastBuild != null
-                    && data.lastBuild.getMarked() != null
-                    && data.lastBuild.getMarked().getSha1String().equals(sha1)) {
+                        && data.lastBuild != null
+                        && data.lastBuild.getMarked() != null
+                        && data.lastBuild.getMarked().getSha1String().equals(sha1)) {
                     return build;
                 }
             }
@@ -52,7 +52,8 @@ public class BuildUtil {
     }
 
     private static boolean isNoMergeBuild(BuildData data, MergeRecord merge) {
-        return merge == null || merge.getSha1().equals(data.lastBuild.getMarked().getSha1String());
+        return merge == null
+                || merge.getSha1().equals(data.lastBuild.getMarked().getSha1String());
     }
 
     private static boolean hasLastBuild(BuildData data) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -1,5 +1,7 @@
 package com.dabsquared.gitlabjenkins.util;
 
+import static com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty.getClient;
+
 import com.dabsquared.gitlabjenkins.cause.CauseData;
 import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
@@ -12,16 +14,6 @@ import hudson.model.Cause.UpstreamCause;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.util.Build;
 import hudson.plugins.git.util.BuildData;
-import jenkins.plugins.git.AbstractGitSCMSource;
-import jenkins.scm.api.SCMRevision;
-import jenkins.scm.api.SCMRevisionAction;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
-import org.eclipse.jgit.lib.ObjectId;
-import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,17 +22,31 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty.getClient;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import jenkins.plugins.git.AbstractGitSCMSource;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMRevisionAction;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jgit.lib.ObjectId;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 
 /**
  * @author Robin Müller
  */
 public class CommitStatusUpdater {
 
-    private final static Logger LOGGER = Logger.getLogger(CommitStatusUpdater.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(CommitStatusUpdater.class.getName());
 
-    public static void updateCommitStatus(Run<?, ?> build, TaskListener listener, BuildState state, String name, List<GitLabBranchBuild> gitLabBranchBuilds, GitLabConnectionProperty connection) {
+    public static void updateCommitStatus(
+            Run<?, ?> build,
+            TaskListener listener,
+            BuildState state,
+            String name,
+            List<GitLabBranchBuild> gitLabBranchBuilds,
+            GitLabConnectionProperty connection) {
         GitLabClient client;
         if (connection != null) {
             client = connection.getClient();
@@ -69,7 +75,8 @@ public class CommitStatusUpdater {
                 try {
                     GitLabClient current_client = client;
                     if (gitLabBranchBuild.getConnection() != null) {
-                        GitLabClient build_specific_client = gitLabBranchBuild.getConnection().getClient();
+                        GitLabClient build_specific_client =
+                                gitLabBranchBuild.getConnection().getClient();
                         if (build_specific_client != null) {
                             current_client = build_specific_client;
                         }
@@ -80,18 +87,36 @@ public class CommitStatusUpdater {
                         current_build_name = gitLabBranchBuild.getName();
                     }
 
-                    if (existsCommit(current_client, gitLabBranchBuild.getProjectId(), gitLabBranchBuild.getRevisionHash())) {
-                        LOGGER.log(Level.INFO, String.format("Updating build '%s' to '%s'", gitLabBranchBuild.getProjectId(), state));
-                        current_client.changeBuildStatus(gitLabBranchBuild.getProjectId(), gitLabBranchBuild.getRevisionHash(), state, getBuildBranchOrTag(build), current_build_name, buildUrl, state.name());
+                    if (existsCommit(
+                            current_client, gitLabBranchBuild.getProjectId(), gitLabBranchBuild.getRevisionHash())) {
+                        LOGGER.log(
+                                Level.INFO,
+                                String.format("Updating build '%s' to '%s'", gitLabBranchBuild.getProjectId(), state));
+                        current_client.changeBuildStatus(
+                                gitLabBranchBuild.getProjectId(),
+                                gitLabBranchBuild.getRevisionHash(),
+                                state,
+                                getBuildBranchOrTag(build),
+                                current_build_name,
+                                buildUrl,
+                                state.name());
                     }
                 } catch (WebApplicationException | ProcessingException e) {
-                    printf(listener, "Failed to update Gitlab commit status for project '%s': %s%n", gitLabBranchBuild.getProjectId(), e.getMessage());
-                    LOGGER.log(Level.SEVERE, String.format("Failed to update Gitlab commit status for project '%s'", gitLabBranchBuild.getProjectId()), e);
+                    printf(
+                            listener,
+                            "Failed to update Gitlab commit status for project '%s': %s%n",
+                            gitLabBranchBuild.getProjectId(),
+                            e.getMessage());
+                    LOGGER.log(
+                            Level.SEVERE,
+                            String.format(
+                                    "Failed to update Gitlab commit status for project '%s'",
+                                    gitLabBranchBuild.getProjectId()),
+                            e);
                 }
             }
         }
     }
-
 
     public static void updateCommitStatus(Run<?, ?> build, TaskListener listener, BuildState state, String name) {
         try {
@@ -111,7 +136,8 @@ public class CommitStatusUpdater {
 
     private static void printf(TaskListener listener, String message, Object... args) {
         if (listener == null) {
-            LOGGER.log(Level.FINE, "failed to print message {0} due to null TaskListener", String.format(message, args));
+            LOGGER.log(
+                    Level.FINE, "failed to print message {0} due to null TaskListener", String.format(message, args));
         } else {
             listener.getLogger().printf(message, args);
         }
@@ -122,7 +148,9 @@ public class CommitStatusUpdater {
             client.getCommit(gitlabProjectId, commitHash);
             return true;
         } catch (NotFoundException e) {
-            LOGGER.log(Level.FINE, String.format("Project (%s) and commit (%s) combination not found", gitlabProjectId, commitHash));
+            LOGGER.log(
+                    Level.FINE,
+                    String.format("Project (%s) and commit (%s) combination not found", gitlabProjectId, commitHash));
             return false;
         }
     }
@@ -149,7 +177,8 @@ public class CommitStatusUpdater {
         GitLabWebHookCause gitlabCause = build.getCause(GitLabWebHookCause.class);
         if (gitlabCause != null) {
             return Collections.singletonList(new GitLabBranchBuild(
-                    gitlabCause.getData().getSourceProjectId().toString(), gitlabCause.getData().getLastCommit()));
+                    gitlabCause.getData().getSourceProjectId().toString(),
+                    gitlabCause.getData().getLastCommit()));
         }
 
         // Check upstream causes for GitLabWebHookCause
@@ -171,7 +200,8 @@ public class CommitStatusUpdater {
         }
 
         if (buildDatas.size() == 1) {
-            addGitLabBranchBuild(result, getBuildRevision(build), buildDatas.get(0).getRemoteUrls(), environment, gitLabClient);
+            addGitLabBranchBuild(
+                    result, getBuildRevision(build), buildDatas.get(0).getRemoteUrls(), environment, gitLabClient);
         } else {
             final SCMRevisionAction scmRevisionAction = build.getAction(SCMRevisionAction.class);
 
@@ -195,10 +225,12 @@ public class CommitStatusUpdater {
                 }
 
                 for (final BuildData buildData : buildDatas) {
-                    for (final Entry<String, Build> buildByBranchName : buildData.getBuildsByBranchName().entrySet()) {
-                        if (buildByBranchName.getValue().getSHA1() != null){
+                    for (final Entry<String, Build> buildByBranchName :
+                            buildData.getBuildsByBranchName().entrySet()) {
+                        if (buildByBranchName.getValue().getSHA1() != null) {
                             if (buildByBranchName.getValue().getSHA1().equals(ObjectId.fromString(scmRevisionHash))) {
-                                addGitLabBranchBuild(result, scmRevisionHash, buildData.getRemoteUrls(), environment, gitLabClient);
+                                addGitLabBranchBuild(
+                                        result, scmRevisionHash, buildData.getRemoteUrls(), environment, gitLabClient);
                             }
                         }
                     }
@@ -228,20 +260,31 @@ public class CommitStatusUpdater {
         return action.getLastBuild(lastBuiltRevision.getSha1()).getMarked().getSha1String();
     }
 
-	private static void addGitLabBranchBuild(List<GitLabBranchBuild> result, String scmRevisionHash,
-                                             Set<String> remoteUrls, EnvVars environment, GitLabClient gitLabClient) {
+    private static void addGitLabBranchBuild(
+            List<GitLabBranchBuild> result,
+            String scmRevisionHash,
+            Set<String> remoteUrls,
+            EnvVars environment,
+            GitLabClient gitLabClient) {
         for (String remoteUrl : remoteUrls) {
             try {
                 LOGGER.log(Level.INFO, "Retrieving the gitlab project id from remote url {0}", remoteUrl);
-                final String projectNameWithNameSpace = ProjectIdUtil.retrieveProjectId(gitLabClient, environment.expand(remoteUrl));
+                final String projectNameWithNameSpace =
+                        ProjectIdUtil.retrieveProjectId(gitLabClient, environment.expand(remoteUrl));
                 if (StringUtils.isNotBlank(projectNameWithNameSpace)) {
                     String projectId = projectNameWithNameSpace;
                     if (projectNameWithNameSpace.contains(".")) {
                         try {
-                            projectId = gitLabClient.getProject(projectNameWithNameSpace).getId().toString();
+                            projectId = gitLabClient
+                                    .getProject(projectNameWithNameSpace)
+                                    .getId()
+                                    .toString();
                         } catch (WebApplicationException | ProcessingException e) {
-                            LOGGER.log(Level.SEVERE, String.format("Failed to retrieve projectId for project '%s'",
-                                projectNameWithNameSpace), e);
+                            LOGGER.log(
+                                    Level.SEVERE,
+                                    String.format(
+                                            "Failed to retrieve projectId for project '%s'", projectNameWithNameSpace),
+                                    e);
                         }
                     }
                     result.add(new GitLabBranchBuild(projectId, scmRevisionHash));
@@ -255,13 +298,14 @@ public class CommitStatusUpdater {
     private static List<GitLabBranchBuild> findBuildsFromUpstreamCauses(List<Cause> causes) {
         for (Cause cause : causes) {
             if (cause instanceof UpstreamCause) {
-                List<Cause> upCauses = ((UpstreamCause) cause).getUpstreamCauses();    // Non null, returns empty list when none are set
+                List<Cause> upCauses =
+                        ((UpstreamCause) cause).getUpstreamCauses(); // Non null, returns empty list when none are set
                 for (Cause upCause : upCauses) {
                     if (upCause instanceof GitLabWebHookCause) {
                         GitLabWebHookCause gitlabCause = (GitLabWebHookCause) upCause;
-                        return Collections.singletonList(
-                                new GitLabBranchBuild(gitlabCause.getData().getSourceProjectId().toString(),
-                                        gitlabCause.getData().getLastCommit()));
+                        return Collections.singletonList(new GitLabBranchBuild(
+                                gitlabCause.getData().getSourceProjectId().toString(),
+                                gitlabCause.getData().getLastCommit()));
                     }
                 }
                 List<GitLabBranchBuild> builds = findBuildsFromUpstreamCauses(upCauses);

--- a/src/main/java/com/dabsquared/gitlabjenkins/util/JsonUtil.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/JsonUtil.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -27,7 +26,7 @@ public final class JsonUtil {
             .configure(SerializationFeature.INDENT_OUTPUT, true)
             .registerModule(new DateModule());
 
-    private JsonUtil() { }
+    private JsonUtil() {}
 
     public static String toPrettyPrint(String json) {
         try {
@@ -71,17 +70,21 @@ public final class JsonUtil {
 
     private static class DateModule extends SimpleModule {
         private static final String[] DATE_FORMATS = new String[] {
-                "yyyy-MM-dd HH:mm:ss Z", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "yyyy-MM-dd'T'HH:mm:ssX", "yyyy-MM-dd'T'HH:mm:ss.SSSX", "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+            "yyyy-MM-dd HH:mm:ss Z",
+            "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+            "yyyy-MM-dd'T'HH:mm:ssX",
+            "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+            "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
         };
 
         private DateModule() {
             addDeserializer(Date.class, new com.fasterxml.jackson.databind.JsonDeserializer<Date>() {
                 @Override
-                public Date deserialize(com.fasterxml.jackson.core.JsonParser p, DeserializationContext ctxt) throws IOException {
+                public Date deserialize(com.fasterxml.jackson.core.JsonParser p, DeserializationContext ctxt)
+                        throws IOException {
                     for (String format : DATE_FORMATS) {
                         try {
-                            return new SimpleDateFormat(format, Locale.US)
-                                    .parse(p.getValueAsString());
+                            return new SimpleDateFormat(format, Locale.US).parse(p.getValueAsString());
                         } catch (ParseException e) {
                             // nothing to do
                         }

--- a/src/main/java/com/dabsquared/gitlabjenkins/util/ProjectIdUtil.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/ProjectIdUtil.java
@@ -1,12 +1,10 @@
 package com.dabsquared.gitlabjenkins.util;
 
-
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
-import org.eclipse.jgit.transport.URIish;
-
 import java.net.URISyntaxException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.eclipse.jgit.transport.URIish;
 
 /**
  * @author Robin Müller
@@ -15,8 +13,7 @@ public final class ProjectIdUtil {
 
     private static final Pattern PROJECT_ID_PATTERN = Pattern.compile("^/?(?<projectId>.*?)(\\.git)?$");
 
-    private ProjectIdUtil() {
-    }
+    private ProjectIdUtil() {}
 
     public static String retrieveProjectId(GitLabClient client, String remoteUrl) throws ProjectIdResolutionException {
         try {
@@ -40,10 +37,12 @@ public final class ProjectIdUtil {
             if (matcher.matches()) {
                 return matcher.group("projectId");
             } else {
-                throw new ProjectIdResolutionException(String.format("Failed to retrieve GitLab projectId for %s", remoteUrl));
+                throw new ProjectIdResolutionException(
+                        String.format("Failed to retrieve GitLab projectId for %s", remoteUrl));
             }
         } catch (URISyntaxException e) {
-            throw new ProjectIdResolutionException(String.format("Failed to retrieve GitLab projectId for %s", remoteUrl), e);
+            throw new ProjectIdResolutionException(
+                    String.format("Failed to retrieve GitLab projectId for %s", remoteUrl), e);
         }
     }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/ActionResolver.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/ActionResolver.java
@@ -1,5 +1,8 @@
 package com.dabsquared.gitlabjenkins.webhook;
 
+import static com.dabsquared.gitlabjenkins.util.LoggerUtil.toArray;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.dabsquared.gitlabjenkins.util.ACLUtil;
 import com.dabsquared.gitlabjenkins.util.JsonUtil;
 import com.dabsquared.gitlabjenkins.webhook.build.MergeRequestBuildAction;
@@ -17,12 +20,6 @@ import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.security.ACL;
 import hudson.util.HttpResponses;
-import jenkins.model.Jenkins;
-import jenkins.scm.api.SCMSourceOwner;
-import org.apache.commons.io.IOUtils;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
-
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -32,9 +29,11 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static com.dabsquared.gitlabjenkins.util.LoggerUtil.toArray;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import jenkins.model.Jenkins;
+import jenkins.scm.api.SCMSourceOwner;
+import org.apache.commons.io.IOUtils;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * @author Robin Müller
@@ -46,7 +45,9 @@ public class ActionResolver {
             Pattern.compile("^(refs/[^/]+/)?(commits|builds)/(?<sha1>[0-9a-fA-F]+)(?<statusJson>/status.json)?$");
 
     public WebHookAction resolve(final String projectName, StaplerRequest request) {
-        Iterator<String> restOfPathParts = Arrays.stream(request.getRestOfPath().split("/")).filter(s -> !s.isEmpty()).iterator();
+        Iterator<String> restOfPathParts = Arrays.stream(request.getRestOfPath().split("/"))
+                .filter(s -> !s.isEmpty())
+                .iterator();
         Item project = resolveProject(projectName, restOfPathParts);
         if (project == null) {
             throw HttpResponses.notFound();
@@ -155,11 +156,11 @@ public class ActionResolver {
         }
     }
 
-
     private String getRequestBody(StaplerRequest request) {
         String requestBody;
         try {
-            Charset charset = request.getCharacterEncoding() == null ?  UTF_8 : Charset.forName(request.getCharacterEncoding());
+            Charset charset =
+                    request.getCharacterEncoding() == null ? UTF_8 : Charset.forName(request.getCharacterEncoding());
             requestBody = IOUtils.toString(request.getInputStream(), charset);
         } catch (IOException e) {
             throw HttpResponses.error(500, "Failed to read request body");
@@ -173,7 +174,9 @@ public class ActionResolver {
                 final Jenkins jenkins = Jenkins.getInstance();
                 if (jenkins != null) {
                     Item item = jenkins.getItemByFullName(projectName);
-                    while (item instanceof ItemGroup<?> && !(item instanceof Job<?, ?> || item instanceof SCMSourceOwner) && restOfPathParts.hasNext()) {
+                    while (item instanceof ItemGroup<?>
+                            && !(item instanceof Job<?, ?> || item instanceof SCMSourceOwner)
+                            && restOfPathParts.hasNext()) {
                         item = jenkins.getItem(restOfPathParts.next(), (ItemGroup<?>) item);
                     }
                     if (item instanceof Job<?, ?> || item instanceof SCMSourceOwner) {
@@ -187,7 +190,6 @@ public class ActionResolver {
     }
 
     static class NoopAction implements WebHookAction {
-        public void execute(StaplerResponse response) {
-        }
+        public void execute(StaplerResponse response) {}
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/GitLabWebHook.java
@@ -3,21 +3,19 @@ package com.dabsquared.gitlabjenkins.webhook;
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
 import hudson.security.csrf.CrumbExclusion;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
-
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * @author Daniel Brooks
  */
-
 @Extension
 public class GitLabWebHook implements UnprotectedRootAction {
 
@@ -25,7 +23,7 @@ public class GitLabWebHook implements UnprotectedRootAction {
 
     private static final Logger LOGGER = Logger.getLogger(GitLabWebHook.class.getName());
 
-    private transient final ActionResolver actionResolver = new ActionResolver();
+    private final transient ActionResolver actionResolver = new ActionResolver();
 
     public String getIconFileName() {
         return null;
@@ -47,7 +45,8 @@ public class GitLabWebHook implements UnprotectedRootAction {
     @Extension
     public static class GitlabWebHookCrumbExclusion extends CrumbExclusion {
         @Override
-        public boolean process(HttpServletRequest req, HttpServletResponse resp, FilterChain chain) throws IOException, ServletException {
+        public boolean process(HttpServletRequest req, HttpServletResponse resp, FilterChain chain)
+                throws IOException, ServletException {
             String pathInfo = req.getPathInfo();
             if (pathInfo != null && pathInfo.startsWith('/' + WEBHOOK_URL + '/')) {
                 chain.doFilter(req, resp);

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/BuildWebHookAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/BuildWebHookAction.java
@@ -1,30 +1,28 @@
 package com.dabsquared.gitlabjenkins.webhook.build;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.logging.Logger;
-
+import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
+import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
+import com.dabsquared.gitlabjenkins.webhook.WebHookAction;
 import edu.umd.cs.findbugs.annotations.NonNull;
-
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.security.Permission;
 import hudson.util.HttpResponses;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerResponse;
-import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
-import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
-import com.dabsquared.gitlabjenkins.webhook.WebHookAction;
 
 /**
  * @author Xinran Xiao
  */
 abstract class BuildWebHookAction implements WebHookAction {
 
-    private final static Logger LOGGER = Logger.getLogger(BuildWebHookAction.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(BuildWebHookAction.class.getName());
 
     abstract void processForCompatibility();
 
@@ -71,7 +69,7 @@ abstract class BuildWebHookAction implements WebHookAction {
             }
 
             // assure the isEqual comparison compares same number of bytes
-            byte [] secretTokenBytes = tokenBytes.clone();
+            byte[] secretTokenBytes = tokenBytes.clone();
             // change last byte to assure the isEqual comparison will not match
             secretTokenBytes[secretTokenBytes.length - 1] ^= 1 << 3;
             return MessageDigest.isEqual(tokenBytes, secretTokenBytes);
@@ -90,9 +88,12 @@ abstract class BuildWebHookAction implements WebHookAction {
         }
 
         private void checkPermission(Permission permission, Item project) {
-            if (((GitLabConnectionConfig) Jenkins.get().getDescriptor(GitLabConnectionConfig.class)).isUseAuthenticatedEndpoint()) {
+            if (((GitLabConnectionConfig) Jenkins.get().getDescriptor(GitLabConnectionConfig.class))
+                    .isUseAuthenticatedEndpoint()) {
                 if (!project.getACL().hasPermission(authentication, permission)) {
-                    String message =  String.format("%s is missing the %s/%s permission", authentication.getName(), permission.group.title, permission.name);
+                    String message = String.format(
+                            "%s is missing the %s/%s permission",
+                            authentication.getName(), permission.group.title, permission.name);
                     LOGGER.finest("Unauthorized (Did you forget to add API Token to the web hook ?)");
                     throw HttpResponses.errorWithoutStack(403, message);
                 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildAction.java
@@ -1,5 +1,7 @@
 package com.dabsquared.gitlabjenkins.webhook.build;
 
+import static com.dabsquared.gitlabjenkins.util.JsonUtil.toPrettyPrint;
+
 import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.MergeRequestHook;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.MergeRequestObjectAttributes;
@@ -10,19 +12,16 @@ import hudson.model.Item;
 import hudson.model.Job;
 import hudson.security.ACL;
 import hudson.util.HttpResponses;
-import jenkins.model.Jenkins;
-
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static com.dabsquared.gitlabjenkins.util.JsonUtil.toPrettyPrint;
+import jenkins.model.Jenkins;
 
 /**
  * @author Robin Müller
  */
 public class MergeRequestBuildAction extends BuildWebHookAction {
 
-    private final static Logger LOGGER = Logger.getLogger(MergeRequestBuildAction.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(MergeRequestBuildAction.class.getName());
     private Item project;
     private MergeRequestHook mergeRequestHook;
     private final String secretToken;
@@ -57,7 +56,8 @@ public class MergeRequestBuildAction extends BuildWebHookAction {
                     source.setUrl(source.getHttpUrl());
                 }
                 if (source.getHomepage() == null) {
-                    source.setHomepage(source.getHttpUrl().substring(0, source.getHttpUrl().lastIndexOf(".git")));
+                    source.setHomepage(
+                            source.getHttpUrl().substring(0, source.getHttpUrl().lastIndexOf(".git")));
                 }
             }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/NoteBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/NoteBuildAction.java
@@ -1,5 +1,7 @@
 package com.dabsquared.gitlabjenkins.webhook.build;
 
+import static com.dabsquared.gitlabjenkins.util.JsonUtil.toPrettyPrint;
+
 import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.NoteHook;
 import com.dabsquared.gitlabjenkins.util.JsonUtil;
@@ -9,20 +11,17 @@ import hudson.model.Item;
 import hudson.model.Job;
 import hudson.security.ACL;
 import hudson.util.HttpResponses;
-import jenkins.model.Jenkins;
-import org.kohsuke.stapler.StaplerResponse;
-
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static com.dabsquared.gitlabjenkins.util.JsonUtil.toPrettyPrint;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * @author Nikolay Ustinov
  */
 public class NoteBuildAction implements WebHookAction {
 
-    private final static Logger LOGGER = Logger.getLogger(NoteBuildAction.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(NoteBuildAction.class.getName());
     private Item project;
     private NoteHook noteHook;
     private final String secretToken;
@@ -51,12 +50,13 @@ public class NoteBuildAction implements WebHookAction {
         if (!(project instanceof Job<?, ?>)) {
             throw HttpResponses.errorWithoutStack(409, "Note Hook is not supported for this project");
         }
-        ACL.impersonate(ACL.SYSTEM, new BuildWebHookAction.TriggerNotifier(project, secretToken, Jenkins.getAuthentication()) {
-            @Override
-            protected void performOnPost(GitLabPushTrigger trigger) {
-                trigger.onPost(noteHook);
-            }
-        });
+        ACL.impersonate(
+                ACL.SYSTEM, new BuildWebHookAction.TriggerNotifier(project, secretToken, Jenkins.getAuthentication()) {
+                    @Override
+                    protected void performOnPost(GitLabPushTrigger trigger) {
+                        trigger.onPost(noteHook);
+                    }
+                });
         throw HttpResponses.ok();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PipelineBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PipelineBuildAction.java
@@ -1,5 +1,7 @@
 package com.dabsquared.gitlabjenkins.webhook.build;
 
+import static com.dabsquared.gitlabjenkins.util.JsonUtil.toPrettyPrint;
+
 import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.*;
 import com.dabsquared.gitlabjenkins.util.JsonUtil;
@@ -8,22 +10,19 @@ import hudson.model.Item;
 import hudson.model.Job;
 import hudson.security.ACL;
 import hudson.util.HttpResponses;
-import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static com.dabsquared.gitlabjenkins.util.JsonUtil.toPrettyPrint;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * @author Milena Zachow
  */
 public class PipelineBuildAction extends BuildWebHookAction {
 
-    private final static Logger LOGGER = Logger.getLogger(PipelineBuildAction.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(PipelineBuildAction.class.getName());
     private Item project;
     private PipelineHook pipelineBuildHook;
     private final String secretToken;
@@ -49,7 +48,7 @@ public class PipelineBuildAction extends BuildWebHookAction {
     }
 
     void processForCompatibility() {
-        //if no project is defined, set it here
+        // if no project is defined, set it here
         if (this.pipelineBuildHook.getProject() == null && this.pipelineBuildHook.getRepository() != null) {
             try {
                 String path = new URL(this.pipelineBuildHook.getRepository().getGitHttpUrl()).getPath();
@@ -78,5 +77,4 @@ public class PipelineBuildAction extends BuildWebHookAction {
         });
         throw HttpResponses.ok();
     }
-
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
@@ -1,5 +1,8 @@
 package com.dabsquared.gitlabjenkins.webhook.build;
 
+import static com.dabsquared.gitlabjenkins.util.JsonUtil.toPrettyPrint;
+import static com.dabsquared.gitlabjenkins.util.LoggerUtil.toArray;
+
 import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.Project;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.PushHook;
@@ -9,6 +12,11 @@ import hudson.model.Item;
 import hudson.model.Job;
 import hudson.security.ACL;
 import hudson.util.HttpResponses;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.traits.IgnoreOnPushNotificationTrait;
@@ -18,21 +26,12 @@ import jenkins.scm.api.trait.SCMTrait;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.transport.URIish;
 
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import static com.dabsquared.gitlabjenkins.util.JsonUtil.toPrettyPrint;
-import static com.dabsquared.gitlabjenkins.util.LoggerUtil.toArray;
-
 /**
  * @author Robin Müller
  */
 public class PushBuildAction extends BuildWebHookAction {
 
-    private final static Logger LOGGER = Logger.getLogger(PushBuildAction.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(PushBuildAction.class.getName());
     private final Item project;
     private PushHook pushHook;
     private final String secretToken;
@@ -105,12 +104,16 @@ public class PushBuildAction extends BuildWebHookAction {
                     try {
                         if (new URIish(gitSCMSource.getRemote()).equals(new URIish(gitSCMSource.getRemote()))) {
                             if (SCMTrait.find(gitSCMSource.getTraits(), IgnoreOnPushNotificationTrait.class) == null) {
-                                LOGGER.log(Level.FINE, "Notify scmSourceOwner {0} about changes for {1}",
-                                           toArray(project.getName(), gitSCMSource.getRemote()));
+                                LOGGER.log(
+                                        Level.FINE,
+                                        "Notify scmSourceOwner {0} about changes for {1}",
+                                        toArray(project.getName(), gitSCMSource.getRemote()));
                                 ((SCMSourceOwner) project).onSCMSourceUpdated(scmSource);
                             } else {
-                                LOGGER.log(Level.FINE, "Ignore on push notification for scmSourceOwner {0} about changes for {1}",
-                                           toArray(project.getName(), gitSCMSource.getRemote()));
+                                LOGGER.log(
+                                        Level.FINE,
+                                        "Ignore on push notification for scmSourceOwner {0} about changes for {1}",
+                                        toArray(project.getName(), gitSCMSource.getRemote()));
                             }
                         }
                     } catch (URISyntaxException e) {
@@ -120,5 +123,4 @@ public class PushBuildAction extends BuildWebHookAction {
             }
         }
     }
-
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/BuildPageRedirectAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/BuildPageRedirectAction.java
@@ -3,10 +3,9 @@ package com.dabsquared.gitlabjenkins.webhook.status;
 import com.dabsquared.gitlabjenkins.webhook.WebHookAction;
 import hudson.model.Run;
 import hudson.util.HttpResponses;
+import java.io.IOException;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerResponse;
-
-import java.io.IOException;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/BuildStatusAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/BuildStatusAction.java
@@ -61,7 +61,12 @@ abstract class BuildStatusAction implements WebHookAction {
     }
 
     protected enum BuildStatus {
-        NOT_FOUND("not_found"), RUNNING("running"), CANCELED("canceled"), SUCCESS("success"), FAILED("failed"), UNSTABLE("failed");
+        NOT_FOUND("not_found"),
+        RUNNING("running"),
+        CANCELED("canceled"),
+        SUCCESS("success"),
+        FAILED("failed"),
+        UNSTABLE("failed");
 
         private String value;
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/StatusJsonAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/StatusJsonAction.java
@@ -4,11 +4,10 @@ import com.dabsquared.gitlabjenkins.util.BuildUtil;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.util.HttpResponses;
-import net.sf.json.JSONObject;
-import org.kohsuke.stapler.StaplerResponse;
-
 import java.io.IOException;
 import java.io.PrintWriter;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/StatusPngAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/status/StatusPngAction.java
@@ -3,10 +3,9 @@ package com.dabsquared.gitlabjenkins.webhook.status;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.util.HttpResponses;
+import java.io.InputStream;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.StaplerResponse;
-
-import java.io.InputStream;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/AcceptGitLabMergeRequestStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/AcceptGitLabMergeRequestStep.java
@@ -2,29 +2,24 @@ package com.dabsquared.gitlabjenkins.workflow;
 
 import static com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty.getClient;
 
+import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
+import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
+import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
-
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.*;
-
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.export.ExportedBean;
-
-import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
-import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
-import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
-
-import hudson.Extension;
-import hudson.model.Run;
-import hudson.model.TaskListener;
 
 /**
  * @author <a href="mailto:robin.mueller@1und1.de">Robin Müller</a>
@@ -36,13 +31,14 @@ public class AcceptGitLabMergeRequestStep extends Step {
 
     private String mergeCommitMessage;
 
-	private boolean useMRDescription;
+    private boolean useMRDescription;
 
-	private Boolean removeSourceBranch;
+    private Boolean removeSourceBranch;
 
     @Deprecated
-    public AcceptGitLabMergeRequestStep(String mergeCommitMessage,boolean useMRDescription, boolean removeSourceBranch) {
-		this.mergeCommitMessage = StringUtils.isEmpty(mergeCommitMessage) ? null : mergeCommitMessage;
+    public AcceptGitLabMergeRequestStep(
+            String mergeCommitMessage, boolean useMRDescription, boolean removeSourceBranch) {
+        this.mergeCommitMessage = StringUtils.isEmpty(mergeCommitMessage) ? null : mergeCommitMessage;
         this.useMRDescription = useMRDescription;
         this.removeSourceBranch = removeSourceBranch;
     }
@@ -50,11 +46,11 @@ public class AcceptGitLabMergeRequestStep extends Step {
     @DataBoundConstructor
     public AcceptGitLabMergeRequestStep() {}
 
-	@Override
-	public StepExecution start(StepContext context) throws Exception {
-		return new AcceptGitLabMergeRequestStepExecution(context, this);
-	}
-	
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new AcceptGitLabMergeRequestStepExecution(context, this);
+    }
+
     public String getMergeCommitMessage() {
         return mergeCommitMessage;
     }
@@ -63,15 +59,15 @@ public class AcceptGitLabMergeRequestStep extends Step {
     public void setMergeCommitMessage(String mergeCommitMessage) {
         this.mergeCommitMessage = StringUtils.isEmpty(mergeCommitMessage) ? null : mergeCommitMessage;
     }
-    
+
     @DataBoundSetter
     public void setUseMRDescription(boolean useMRDescription) {
-    	this.useMRDescription = useMRDescription;
+        this.useMRDescription = useMRDescription;
     }
-    
+
     @DataBoundSetter
     public void setRemoveSourceBranch(boolean removeSourceBranch) {
-    	this.removeSourceBranch = removeSourceBranch;
+        this.removeSourceBranch = removeSourceBranch;
     }
 
     public static class AcceptGitLabMergeRequestStepExecution extends AbstractSynchronousStepExecution<Void> {
@@ -86,7 +82,7 @@ public class AcceptGitLabMergeRequestStep extends Step {
             this.step = step;
             run = context.get(Run.class);
         }
-        
+
         @Override
         protected Void run() throws Exception {
             GitLabWebHookCause cause = run.getCause(GitLabWebHookCause.class);
@@ -98,10 +94,18 @@ public class AcceptGitLabMergeRequestStep extends Step {
                         println("No GitLab connection configured");
                     } else {
                         try {
-                            client.acceptMergeRequest(mergeRequest, getCommitMessage(mergeRequest), step.removeSourceBranch);
+                            client.acceptMergeRequest(
+                                    mergeRequest, getCommitMessage(mergeRequest), step.removeSourceBranch);
                         } catch (WebApplicationException | ProcessingException e) {
-                            printf("Failed to accept merge request for project '%s': %s%n", mergeRequest.getProjectId(), e.getMessage());
-                            LOGGER.log(Level.SEVERE, String.format("Failed to accept merge request for project '%s'", mergeRequest.getProjectId()), e);
+                            printf(
+                                    "Failed to accept merge request for project '%s': %s%n",
+                                    mergeRequest.getProjectId(), e.getMessage());
+                            LOGGER.log(
+                                    Level.SEVERE,
+                                    String.format(
+                                            "Failed to accept merge request for project '%s'",
+                                            mergeRequest.getProjectId()),
+                                    e);
                         }
                     }
                 }
@@ -110,17 +114,17 @@ public class AcceptGitLabMergeRequestStep extends Step {
         }
 
         private String getCommitMessage(MergeRequest mergeRequest) {
-        	if (!step.useMRDescription)
-        		return step.mergeCommitMessage;
-        	
-        	String message = "Merge branch '"+mergeRequest.getSourceBranch()+"' into '"+mergeRequest.getTargetBranch()+"'\n\n"+
-        		mergeRequest.getTitle()+"\n\n"+
-    			mergeRequest.getDescription()+"\n\n" +
-        		"See merge request !"+mergeRequest.getIid();
-			return message;
-		}
+            if (!step.useMRDescription) return step.mergeCommitMessage;
 
-		private void println(String message) {
+            String message = "Merge branch '" + mergeRequest.getSourceBranch() + "' into '"
+                    + mergeRequest.getTargetBranch() + "'\n\n" + mergeRequest.getTitle()
+                    + "\n\n" + mergeRequest.getDescription()
+                    + "\n\n" + "See merge request !"
+                    + mergeRequest.getIid();
+            return message;
+        }
+
+        private void println(String message) {
             TaskListener listener = getTaskListener();
             if (listener == null) {
                 LOGGER.log(Level.FINE, "failed to print message {0} due to null TaskListener", message);
@@ -132,7 +136,10 @@ public class AcceptGitLabMergeRequestStep extends Step {
         private void printf(String message, Object... args) {
             TaskListener listener = getTaskListener();
             if (listener == null) {
-                LOGGER.log(Level.FINE, "failed to print message {0} due to null TaskListener", String.format(message, args));
+                LOGGER.log(
+                        Level.FINE,
+                        "failed to print message {0} due to null TaskListener",
+                        String.format(message, args));
             } else {
                 listener.getLogger().printf(message, args);
             }
@@ -163,12 +170,12 @@ public class AcceptGitLabMergeRequestStep extends Step {
         public String getFunctionName() {
             return "acceptGitLabMR";
         }
-        
-		@Override
-		public Set<Class<?>> getRequiredContext() {
-			Set<Class<?>> context = new HashSet<>();
-			Collections.addAll(context, TaskListener.class, Run.class);
-			return Collections.unmodifiableSet(context);
-		}
+
+        @Override
+        public Set<Class<?>> getRequiredContext() {
+            Set<Class<?>> context = new HashSet<>();
+            Collections.addAll(context, TaskListener.class, Run.class);
+            return Collections.unmodifiableSet(context);
+        }
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabBranchBuild.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabBranchBuild.java
@@ -20,8 +20,7 @@ public class GitLabBranchBuild extends AbstractDescribableImpl<GitLabBranchBuild
     private GitLabConnectionProperty connection;
 
     @DataBoundConstructor
-    public GitLabBranchBuild() {
-    }
+    public GitLabBranchBuild() {}
 
     public GitLabBranchBuild(String projectId, String revisionHash) {
         this.name = null;

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabBuildsStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabBuildsStep.java
@@ -1,13 +1,16 @@
 package com.dabsquared.gitlabjenkins.workflow;
 
+import com.dabsquared.gitlabjenkins.gitlab.api.model.BuildState;
+import com.dabsquared.gitlabjenkins.util.CommitStatusUpdater;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 import org.jenkinsci.plugins.workflow.steps.BodyExecution;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
@@ -19,13 +22,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.export.ExportedBean;
 
-import com.dabsquared.gitlabjenkins.gitlab.api.model.BuildState;
-import com.dabsquared.gitlabjenkins.util.CommitStatusUpdater;
-
-import hudson.Extension;
-import hudson.model.Run;
-import hudson.model.TaskListener;
-
 /**
  * @author <a href="mailto:robin.mueller@1und1.de">Robin Müller</a>
  */
@@ -35,13 +31,12 @@ public class GitLabBuildsStep extends Step {
     private List<String> builds;
 
     @DataBoundConstructor
-    public GitLabBuildsStep() {
-    }
+    public GitLabBuildsStep() {}
 
-	@Override
-	public StepExecution start(StepContext context) throws Exception {
-		return new GitLabBuildStepExecution(context, this);
-	}
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new GitLabBuildStepExecution(context, this);
+    }
 
     @DataBoundSetter
     public void setBuilds(List<String> builds) {
@@ -75,44 +70,50 @@ public class GitLabBuildsStep extends Step {
             this.step = step;
             run = context.get(Run.class);
         }
-        
+
         @Override
         public boolean start() throws Exception {
-            body = getContext().newBodyInvoker()
-                .withCallback(new BodyExecutionCallback() {
-                    @Override
-                    public void onStart(StepContext context) {
-                        for (String name : step.builds) {
-                            CommitStatusUpdater.updateCommitStatus(run, getTaskListener(context), BuildState.pending, name);
-                        }
-                        run.addAction(new PendingBuildsAction(new ArrayList<>(step.builds)));
-                    }
-
-                    @Override
-                    public void onSuccess(StepContext context, Object result) {
-                        PendingBuildsAction action = run.getAction(PendingBuildsAction.class);
-                        if (action != null && !action.getBuilds().isEmpty()) {
-                            TaskListener taskListener = getTaskListener(context);
-                            if (taskListener != null) {
-                                taskListener.getLogger().println("There are still pending GitLab builds. Please check your configuration");
+            body = getContext()
+                    .newBodyInvoker()
+                    .withCallback(new BodyExecutionCallback() {
+                        @Override
+                        public void onStart(StepContext context) {
+                            for (String name : step.builds) {
+                                CommitStatusUpdater.updateCommitStatus(
+                                        run, getTaskListener(context), BuildState.pending, name);
                             }
+                            run.addAction(new PendingBuildsAction(new ArrayList<>(step.builds)));
                         }
-                        context.onSuccess(result);
-                    }
 
-                    @Override
-                    public void onFailure(StepContext context, Throwable t) {
-                        PendingBuildsAction action = run.getAction(PendingBuildsAction.class);
-                        if (action != null) {
-                            BuildState state = t instanceof FlowInterruptedException ? BuildState.canceled : BuildState.failed;
-                            for (String name : action.getBuilds()) {
-                                CommitStatusUpdater.updateCommitStatus(run, getTaskListener(context), state, name);
+                        @Override
+                        public void onSuccess(StepContext context, Object result) {
+                            PendingBuildsAction action = run.getAction(PendingBuildsAction.class);
+                            if (action != null && !action.getBuilds().isEmpty()) {
+                                TaskListener taskListener = getTaskListener(context);
+                                if (taskListener != null) {
+                                    taskListener
+                                            .getLogger()
+                                            .println(
+                                                    "There are still pending GitLab builds. Please check your configuration");
+                                }
                             }
+                            context.onSuccess(result);
                         }
-                        context.onFailure(t);
-                    }
-                })
-                .start();
+
+                        @Override
+                        public void onFailure(StepContext context, Throwable t) {
+                            PendingBuildsAction action = run.getAction(PendingBuildsAction.class);
+                            if (action != null) {
+                                BuildState state =
+                                        t instanceof FlowInterruptedException ? BuildState.canceled : BuildState.failed;
+                                for (String name : action.getBuilds()) {
+                                    CommitStatusUpdater.updateCommitStatus(run, getTaskListener(context), state, name);
+                                }
+                            }
+                            context.onFailure(t);
+                        }
+                    })
+                    .start();
             return false;
         }
 
@@ -159,11 +160,11 @@ public class GitLabBuildsStep extends Step {
             return true;
         }
 
-		@Override
-		public Set<Class<?>> getRequiredContext() {
-			Set<Class<?>> context = new HashSet<>();
-			Collections.addAll(context, TaskListener.class, Run.class);
-			return Collections.unmodifiableSet(context);
-		}
+        @Override
+        public Set<Class<?>> getRequiredContext() {
+            Set<Class<?>> context = new HashSet<>();
+            Collections.addAll(context, TaskListener.class, Run.class);
+            return Collections.unmodifiableSet(context);
+        }
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/PendingBuildsAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/PendingBuildsAction.java
@@ -1,8 +1,6 @@
 package com.dabsquared.gitlabjenkins.workflow;
 
-
 import hudson.model.Action;
-
 import java.io.Serializable;
 import java.util.List;
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/UpdateGitLabCommitStatusStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/UpdateGitLabCommitStatusStep.java
@@ -1,10 +1,15 @@
 package com.dabsquared.gitlabjenkins.workflow;
 
+import com.dabsquared.gitlabjenkins.gitlab.api.model.BuildState;
+import com.dabsquared.gitlabjenkins.util.CommitStatusUpdater;
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.ListBoxModel;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
-
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
 import org.jenkinsci.plugins.workflow.steps.Step;
@@ -14,14 +19,6 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.export.ExportedBean;
-
-import com.dabsquared.gitlabjenkins.gitlab.api.model.BuildState;
-import com.dabsquared.gitlabjenkins.util.CommitStatusUpdater;
-
-import hudson.Extension;
-import hudson.model.Run;
-import hudson.model.TaskListener;
-import hudson.util.ListBoxModel;
 
 /**
  * @author <a href="mailto:robin.mueller@1und1.de">Robin Müller</a>
@@ -37,11 +34,11 @@ public class UpdateGitLabCommitStatusStep extends Step {
         this.name = StringUtils.isEmpty(name) ? null : name;
         this.state = state;
     }
-    
-	@Override
-	public StepExecution start(StepContext context) throws Exception {
-		return new UpdateGitLabCommitStatusStepExecution(context, this);
-	}
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new UpdateGitLabCommitStatusStepExecution(context, this);
+    }
 
     public String getName() {
         return name;
@@ -73,7 +70,7 @@ public class UpdateGitLabCommitStatusStep extends Step {
             this.step = step;
             run = context.get(Run.class);
         }
-        
+
         @Override
         protected Void run() throws Exception {
             final String name = StringUtils.isEmpty(step.name) ? "jenkins" : step.name;
@@ -118,11 +115,11 @@ public class UpdateGitLabCommitStatusStep extends Step {
             return options;
         }
 
-		@Override
-		public Set<Class<?>> getRequiredContext() {
-			Set<Class<?>> context = new HashSet<>();
-			Collections.addAll(context, TaskListener.class, Run.class);
-			return Collections.unmodifiableSet(context);
-		}
+        @Override
+        public Set<Class<?>> getRequiredContext() {
+            Set<Class<?>> context = new HashSet<>();
+            Collections.addAll(context, TaskListener.class, Run.class);
+            return Collections.unmodifiableSet(context);
+        }
     }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfigAsCodeTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfigAsCodeTest.java
@@ -23,9 +23,9 @@ import org.junit.rules.RuleChain;
 
 public class GitLabConnectionConfigAsCodeTest {
     @Rule
-    public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables()
-        .set("BIND_TOKEN", "qwertyuiopasdfghjklzxcvbnm"))
-        .around(new JenkinsConfiguredWithCodeRule());
+    public RuleChain chain = RuleChain.outerRule(
+                    new EnvironmentVariables().set("BIND_TOKEN", "qwertyuiopasdfghjklzxcvbnm"))
+            .around(new JenkinsConfiguredWithCodeRule());
 
     @Test
     @ConfiguredWithCode("global-config.yml")
@@ -36,7 +36,8 @@ public class GitLabConnectionConfigAsCodeTest {
         final DomainCredentials gitLabCredential = domainCredentials.get(0);
         assertEquals(Domain.global(), gitLabCredential.getDomain());
         assertEquals(1, gitLabCredential.getCredentials().size());
-        final GitLabApiToken apiToken = (GitLabApiToken)gitLabCredential.getCredentials().get(0);
+        final GitLabApiToken apiToken =
+                (GitLabApiToken) gitLabCredential.getCredentials().get(0);
         assertEquals("gitlab_token", apiToken.getId());
         assertEquals("qwertyuiopasdfghjklzxcvbnm", apiToken.getApiToken().getPlainText());
         assertEquals("Gitlab Token", apiToken.getDescription());
@@ -48,7 +49,8 @@ public class GitLabConnectionConfigAsCodeTest {
         final Jenkins jenkins = Jenkins.get();
         final GitLabConnectionConfig gitLabConnections = jenkins.getDescriptorByType(GitLabConnectionConfig.class);
         assertEquals(1, gitLabConnections.getConnections().size());
-        final GitLabConnection gitLabConnection = gitLabConnections.getConnections().get(0);
+        final GitLabConnection gitLabConnection =
+                gitLabConnections.getConnections().get(0);
         assertEquals("gitlab_token", gitLabConnection.getApiTokenId());
         assertEquals("my_gitlab_server", gitLabConnection.getName());
         assertEquals("autodetect", gitLabConnection.getClientBuilderId());

--- a/src/test/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfigSSLTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfigSSLTest.java
@@ -80,8 +80,7 @@ public class GitLabConnectionConfigSSLTest {
         // the http configuration we configured above so it can get things like
         // the output buffer size, etc. We also set the port (8080) and
         // configure an idle timeout.
-        ServerConnector http = new ServerConnector(server,
-            new HttpConnectionFactory(http_config));
+        ServerConnector http = new ServerConnector(server, new HttpConnectionFactory(http_config));
         http.setPort(_http_port);
         http.setIdleTimeout(30000);
 
@@ -99,8 +98,8 @@ public class GitLabConnectionConfigSSLTest {
         // OPTIONAL: Un-comment the following to use Conscrypt for SSL instead of
         // the native JSSE implementation.
 
-        //Security.addProvider(new OpenSSLProvider());
-        //sslContextFactory.setProvider("Conscrypt");
+        // Security.addProvider(new OpenSSLProvider());
+        // sslContextFactory.setProvider("Conscrypt");
 
         // HTTPS Configuration
         // A new HttpConfiguration object is needed for the next connector and
@@ -119,19 +118,22 @@ public class GitLabConnectionConfigSSLTest {
         // We create a second ServerConnector, passing in the http configuration
         // we just made along with the previously created ssl context factory.
         // Next we set the port and a longer idle timeout.
-        ServerConnector https = new ServerConnector(server,
-            new SslConnectionFactory(sslContextFactory, HttpVersion.HTTP_1_1.asString()),
-            new HttpConnectionFactory(https_config));
+        ServerConnector https = new ServerConnector(
+                server,
+                new SslConnectionFactory(sslContextFactory, HttpVersion.HTTP_1_1.asString()),
+                new HttpConnectionFactory(https_config));
         https.setPort(port);
         https.setIdleTimeout(500000);
 
         // Set the connectors
-        server.setConnectors(new Connector[] { http, https });
+        server.setConnectors(new Connector[] {http, https});
 
         HandlerCollection handlerCollection = new HandlerCollection();
         handlerCollection.setHandlers(new Handler[] {
             new AbstractHandler() {
-                public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+                public void handle(
+                        String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+                        throws IOException, ServletException {
                     response.setStatus(HttpServletResponse.SC_OK);
                     baseRequest.setHandled(true);
                 }
@@ -139,8 +141,6 @@ public class GitLabConnectionConfigSSLTest {
         });
         server.setHandler(handlerCollection);
         server.start();
-
-
     }
 
     @AfterClass
@@ -153,17 +153,24 @@ public class GitLabConnectionConfigSSLTest {
         for (CredentialsStore credentialsStore : CredentialsProvider.lookupStores(Jenkins.getInstance())) {
             if (credentialsStore instanceof SystemCredentialsProvider.StoreImpl) {
                 List<Domain> domains = credentialsStore.getDomains();
-                credentialsStore.addCredentials(domains.get(0),
-                    new StringCredentialsImpl(CredentialsScope.SYSTEM, API_TOKEN_ID, "GitLab API Token", Secret.fromString(API_TOKEN_ID)));
+                credentialsStore.addCredentials(
+                        domains.get(0),
+                        new StringCredentialsImpl(
+                                CredentialsScope.SYSTEM,
+                                API_TOKEN_ID,
+                                "GitLab API Token",
+                                Secret.fromString(API_TOKEN_ID)));
             }
         }
     }
 
     @Test
     public void doCheckConnection_certificateError() throws IOException {
-        GitLabConnection.DescriptorImpl descriptor = (DescriptorImpl) jenkins.jenkins.getDescriptor(GitLabConnection.class);
+        GitLabConnection.DescriptorImpl descriptor =
+                (DescriptorImpl) jenkins.jenkins.getDescriptor(GitLabConnection.class);
 
-        FormValidation formValidation = descriptor.doTestConnection("https://localhost:" + port + "/gitlab", API_TOKEN_ID, "v3", false, 10, 10);
+        FormValidation formValidation =
+                descriptor.doTestConnection("https://localhost:" + port + "/gitlab", API_TOKEN_ID, "v3", false, 10, 10);
         assertThat(formValidation.getMessage(), containsString(Messages.connection_error("PKIX path building failed")));
     }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfigTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfigTest.java
@@ -61,8 +61,10 @@ public class GitLabConnectionConfigTest {
 
     @Rule
     public MockServerRule mockServer = new MockServerRule(this);
+
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
+
     private MockServerClient mockServerClient;
     private String gitLabUrl;
 
@@ -72,8 +74,13 @@ public class GitLabConnectionConfigTest {
         for (CredentialsStore credentialsStore : CredentialsProvider.lookupStores(Jenkins.getInstance())) {
             if (credentialsStore instanceof SystemCredentialsProvider.StoreImpl) {
                 List<Domain> domains = credentialsStore.getDomains();
-                credentialsStore.addCredentials(domains.get(0),
-                    new StringCredentialsImpl(CredentialsScope.SYSTEM, API_TOKEN_ID, "GitLab API Token", Secret.fromString(API_TOKEN)));
+                credentialsStore.addCredentials(
+                        domains.get(0),
+                        new StringCredentialsImpl(
+                                CredentialsScope.SYSTEM,
+                                API_TOKEN_ID,
+                                "GitLab API Token",
+                                Secret.fromString(API_TOKEN)));
             }
         }
     }
@@ -95,7 +102,8 @@ public class GitLabConnectionConfigTest {
     @Test
     public void doCheckConnection_proxy() {
         jenkins.getInstance().proxy = new ProxyConfiguration("0.0.0.0", 80);
-        GitLabConnection.DescriptorImpl descriptor = (DescriptorImpl) jenkins.jenkins.getDescriptor(GitLabConnection.class);
+        GitLabConnection.DescriptorImpl descriptor =
+                (DescriptorImpl) jenkins.jenkins.getDescriptor(GitLabConnection.class);
         FormValidation result = descriptor.doTestConnection(gitLabUrl, API_TOKEN_ID, "v3", false, 10, 10);
         assertThat(result.getMessage(), containsString("Connection refused"));
     }
@@ -106,17 +114,18 @@ public class GitLabConnectionConfigTest {
         assertThat(doCheckConnection("v3", Response.Status.OK), is(connection_success()));
     }
 
-
     private String doCheckConnection(String clientBuilderId, Response.Status status) {
-        HttpRequest request = request().withPath("/gitlab/api/" + clientBuilderId + "/.*").withHeader("PRIVATE-TOKEN", API_TOKEN);
+        HttpRequest request =
+                request().withPath("/gitlab/api/" + clientBuilderId + "/.*").withHeader("PRIVATE-TOKEN", API_TOKEN);
         mockServerClient.when(request).respond(response().withStatusCode(status.getStatusCode()));
 
-        GitLabConnection.DescriptorImpl descriptor = (DescriptorImpl) jenkins.jenkins.getDescriptor(GitLabConnection.class);
-        FormValidation formValidation = descriptor.doTestConnection(gitLabUrl, API_TOKEN_ID, clientBuilderId, false, 10, 10);
+        GitLabConnection.DescriptorImpl descriptor =
+                (DescriptorImpl) jenkins.jenkins.getDescriptor(GitLabConnection.class);
+        FormValidation formValidation =
+                descriptor.doTestConnection(gitLabUrl, API_TOKEN_ID, clientBuilderId, false, 10, 10);
         mockServerClient.verify(request);
         return formValidation.getMessage();
     }
-
 
     @Test
     public void authenticationEnabled_anonymous_forbidden() throws IOException {
@@ -152,7 +161,9 @@ public class GitLabConnectionConfigTest {
         HttpPost request = new HttpPost(jenkinsURL.toExternalForm() + "project/test");
         request.addHeader("X-Gitlab-Event", "Push Hook");
         String auth = username + ":" + username;
-        request.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(Charset.forName("ISO-8859-1"))));
+        request.addHeader(
+                HttpHeaders.AUTHORIZATION,
+                "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(Charset.forName("ISO-8859-1"))));
         request.setEntity(new StringEntity("{}"));
 
         CloseableHttpResponse response = client.execute(request);
@@ -179,8 +190,10 @@ public class GitLabConnectionConfigTest {
 
     @Test
     public void setConnectionsTest() {
-        GitLabConnection connection1 = new GitLabConnection("1", "http://localhost", null, new V3GitLabClientBuilder(), false, 10, 10);
-        GitLabConnection connection2 = new GitLabConnection("2", "http://localhost", null, new V3GitLabClientBuilder(), false, 10, 10);
+        GitLabConnection connection1 =
+                new GitLabConnection("1", "http://localhost", null, new V3GitLabClientBuilder(), false, 10, 10);
+        GitLabConnection connection2 =
+                new GitLabConnection("2", "http://localhost", null, new V3GitLabClientBuilder(), false, 10, 10);
         GitLabConnectionConfig config = jenkins.get(GitLabConnectionConfig.class);
         List<GitLabConnection> connectionList1 = new ArrayList<>();
         connectionList1.add(connection1);
@@ -201,7 +214,8 @@ public class GitLabConnectionConfigTest {
 
     @Test
     public void getClient_is_cached() {
-        GitLabConnection connection = new GitLabConnection("test", "http://localhost", API_TOKEN_ID, new V3GitLabClientBuilder(), false, 10, 10);
+        GitLabConnection connection = new GitLabConnection(
+                "test", "http://localhost", API_TOKEN_ID, new V3GitLabClientBuilder(), false, 10, 10);
         GitLabConnectionConfig config = jenkins.get(GitLabConnectionConfig.class);
         List<GitLabConnection> connectionList1 = new ArrayList<>();
         connectionList1.add(connection);

--- a/src/test/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionTest.java
@@ -3,9 +3,6 @@ package com.dabsquared.gitlabjenkins.connection;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
-import java.io.IOException;
-import java.util.List;
-
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
@@ -14,6 +11,8 @@ import com.cloudbees.plugins.credentials.domains.Domain;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.impl.V3GitLabClientBuilder;
 import hudson.util.Secret;
+import java.io.IOException;
+import java.util.List;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.junit.BeforeClass;
@@ -31,42 +30,30 @@ public class GitLabConnectionTest {
 
     private static GitLabConnection connection;
 
-
     @BeforeClass
     public static void setup() throws IOException {
         for (final CredentialsStore credentialsStore : CredentialsProvider.lookupStores(Jenkins.get())) {
             if (credentialsStore instanceof SystemCredentialsProvider.StoreImpl) {
                 final List<Domain> domains = credentialsStore.getDomains();
                 credentialsStore.addCredentials(
-                    domains.get(0),
-                    new StringCredentialsImpl(
-                        CredentialsScope.SYSTEM,
-                        API_TOKEN_ID,
-                        "GitLab API Token",
-                        Secret.fromString(API_TOKEN)
-                    )
-                );
+                        domains.get(0),
+                        new StringCredentialsImpl(
+                                CredentialsScope.SYSTEM,
+                                API_TOKEN_ID,
+                                "GitLab API Token",
+                                Secret.fromString(API_TOKEN)));
                 credentialsStore.addCredentials(
-                    domains.get(0),
-                    new StringCredentialsImpl(
-                        CredentialsScope.SYSTEM,
-                        API_TOKEN_ID_2,
-                        "GitLab API Token 2",
-                        Secret.fromString(API_TOKEN)
-                    )
-                );
+                        domains.get(0),
+                        new StringCredentialsImpl(
+                                CredentialsScope.SYSTEM,
+                                API_TOKEN_ID_2,
+                                "GitLab API Token 2",
+                                Secret.fromString(API_TOKEN)));
             }
         }
 
         connection = new GitLabConnection(
-            "test",
-            "http://localhost",
-            API_TOKEN_ID,
-            new V3GitLabClientBuilder(),
-            false,
-            10,
-            10
-        );
+                "test", "http://localhost", API_TOKEN_ID, new V3GitLabClientBuilder(), false, 10, 10);
     }
 
     @Test
@@ -82,7 +69,6 @@ public class GitLabConnectionTest {
         assertThat(client, notNullValue());
         assertThat(connection.getClient(null, API_TOKEN_ID), sameInstance(client));
     }
-
 
     @Test
     public void getClient_differentCredentialId_differentClient() {

--- a/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
@@ -57,13 +57,13 @@ public class GitLabEnvironmentContributorTest {
         GitLabWebHookCause cause = new GitLabWebHookCause(generateCauseData());
         // set up 2x2 matrix
         AxisList axes = new AxisList();
-        axes.add(new TextAxis("db","mysql","oracle"));
-        axes.add(new TextAxis("direction","north","south"));
+        axes.add(new TextAxis("db", "mysql", "oracle"));
+        axes.add(new TextAxis("direction", "north", "south"));
         p.setAxes(axes);
 
         MatrixBuild build = p.scheduleBuild2(0, cause).get();
         List<MatrixRun> runs = build.getRuns();
-        assertEquals(4,runs.size());
+        assertEquals(4, runs.size());
         for (MatrixRun run : runs) {
             env = run.getEnvironment(listener);
             assertNotNull(env.get("db"));

--- a/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClientBuilderTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClientBuilderTest.java
@@ -26,7 +26,9 @@ public class GitLabClientBuilderTest {
 
     @Test
     public void getGitLabClientBuilderById_success() {
-        assertThat(GitLabClientBuilder.getGitLabClientBuilderById(new V3GitLabClientBuilder().id()), instanceOf(V3GitLabClientBuilder.class));
+        assertThat(
+                GitLabClientBuilder.getGitLabClientBuilderById(new V3GitLabClientBuilder().id()),
+                instanceOf(V3GitLabClientBuilder.class));
     }
 
     @Test(expected = NoSuchElementException.class)

--- a/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClientTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClientTest.java
@@ -26,8 +26,10 @@ import org.mockserver.model.HttpRequest;
 public class AutodetectingGitLabClientTest {
     @Rule
     public MockServerRule mockServer = new MockServerRule(this);
+
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
+
     private MockServerClient mockServerClient;
     private String gitLabUrl;
     private GitLabClientBuilder clientBuilder;
@@ -40,7 +42,8 @@ public class AutodetectingGitLabClientTest {
         gitLabUrl = "http://localhost:" + mockServer.getPort() + "/gitlab";
         addGitLabApiToken();
 
-        List<GitLabClientBuilder> builders = Arrays.<GitLabClientBuilder>asList(new V3GitLabClientBuilder(), new V4GitLabClientBuilder());
+        List<GitLabClientBuilder> builders =
+                Arrays.<GitLabClientBuilder>asList(new V3GitLabClientBuilder(), new V4GitLabClientBuilder());
         api = new AutodetectingGitLabClient(builders, gitLabUrl, API_TOKEN, true, 10, 10);
 
         v3Request = versionRequest(V3GitLabApiProxy.ID);

--- a/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClientBuilderTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClientBuilderTest.java
@@ -14,6 +14,7 @@ import org.mockserver.junit.MockServerRule;
 public class ResteasyGitLabClientBuilderTest {
     @Rule
     public MockServerRule mockServer = new MockServerRule(this);
+
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
 
@@ -29,5 +30,4 @@ public class ResteasyGitLabClientBuilderTest {
         GitLabClientBuilder clientBuilder = new ResteasyGitLabClientBuilder("test", 0, V3GitLabApiProxy.class, null);
         assertNotNull(buildClientWithDefaults(clientBuilder, "http://localhost"));
     }
-
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/TestUtility.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/TestUtility.java
@@ -34,14 +34,22 @@ class TestUtility {
         for (CredentialsStore credentialsStore : CredentialsProvider.lookupStores(Jenkins.getInstance())) {
             if (credentialsStore instanceof SystemCredentialsProvider.StoreImpl) {
                 List<Domain> domains = credentialsStore.getDomains();
-                credentialsStore.addCredentials(domains.get(0),
-                    new StringCredentialsImpl(CredentialsScope.SYSTEM, API_TOKEN_ID, "GitLab API Token", Secret.fromString(API_TOKEN)));
+                credentialsStore.addCredentials(
+                        domains.get(0),
+                        new StringCredentialsImpl(
+                                CredentialsScope.SYSTEM,
+                                API_TOKEN_ID,
+                                "GitLab API Token",
+                                Secret.fromString(API_TOKEN)));
             }
         }
     }
 
     static HttpRequest versionRequest(String id) {
-        return request().withMethod(HttpMethod.GET).withPath("/gitlab/api/" + id + "/.*").withHeader("PRIVATE-TOKEN", API_TOKEN);
+        return request()
+                .withMethod(HttpMethod.GET)
+                .withPath("/gitlab/api/" + id + "/.*")
+                .withHeader("PRIVATE-TOKEN", API_TOKEN);
     }
 
     static HttpResponse responseOk() {
@@ -66,11 +74,14 @@ class TestUtility {
         assertThat(apiField.get(client), instanceOf(apiImplClass));
     }
 
-    static void assertApiImpl(AutodetectingGitLabClient api, Class<? extends GitLabApiProxy> apiImplClass) throws Exception {
+    static void assertApiImpl(AutodetectingGitLabClient api, Class<? extends GitLabApiProxy> apiImplClass)
+            throws Exception {
         Field delegate = api.getClass().getDeclaredField("delegate");
         delegate.setAccessible(true);
         assertApiImpl((GitLabClient) delegate.get(api), apiImplClass);
     }
 
-    private TestUtility() { /* utility class */ }
+    private TestUtility() {
+        /* utility class */
+    }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabAcceptMergeRequestPublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabAcceptMergeRequestPublisherTest.java
@@ -69,8 +69,8 @@ public class GitLabAcceptMergeRequestPublisherTest {
         publish(mockSimpleBuild(GITLAB_CONNECTION_V4, Result.SUCCESS));
 
         mockServerClient.verify(
-            prepareAcceptMergeRequestWithSuccessResponse("v3", MERGE_REQUEST_ID, null),
-            prepareAcceptMergeRequestWithSuccessResponse("v4", MERGE_REQUEST_IID, null));
+                prepareAcceptMergeRequestWithSuccessResponse("v3", MERGE_REQUEST_ID, null),
+                prepareAcceptMergeRequestWithSuccessResponse("v4", MERGE_REQUEST_IID, null));
     }
 
     @Test
@@ -86,20 +86,22 @@ public class GitLabAcceptMergeRequestPublisherTest {
         publisher.perform(build, null, listener);
     }
 
-    private HttpRequest prepareAcceptMergeRequestWithSuccessResponse(String apiLevel, int mergeRequestId, Boolean shouldRemoveSourceBranch) throws UnsupportedEncodingException {
+    private HttpRequest prepareAcceptMergeRequestWithSuccessResponse(
+            String apiLevel, int mergeRequestId, Boolean shouldRemoveSourceBranch) throws UnsupportedEncodingException {
         HttpRequest updateCommitStatus = prepareAcceptMergeRequest(apiLevel, mergeRequestId, shouldRemoveSourceBranch);
         mockServerClient.when(updateCommitStatus).respond(response().withStatusCode(200));
         return updateCommitStatus;
     }
 
-    private HttpRequest prepareAcceptMergeRequest(String apiLevel, int mergeRequestId, Boolean removeSourceBranch) throws UnsupportedEncodingException {
+    private HttpRequest prepareAcceptMergeRequest(String apiLevel, int mergeRequestId, Boolean removeSourceBranch)
+            throws UnsupportedEncodingException {
         String body = "merge_commit_message=Merge+Request+accepted+by+jenkins+build+success";
-        if (removeSourceBranch != null)
-        {
+        if (removeSourceBranch != null) {
             body += "&should_remove_source_branch=" + removeSourceBranch;
         }
         return request()
-                .withPath("/gitlab/api/" + apiLevel + "/projects/" + PROJECT_ID + "/merge_requests/" + mergeRequestId + "/merge")
+                .withPath("/gitlab/api/" + apiLevel + "/projects/" + PROJECT_ID + "/merge_requests/" + mergeRequestId
+                        + "/merge")
                 .withMethod("PUT")
                 .withHeader("PRIVATE-TOKEN", "secret")
                 .withBody(body);

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
@@ -112,7 +112,6 @@ public class GitLabCommitStatusPublisherTest {
         prebuildAndVerify(build, listener, requests);
     }
 
-
     @Test
     public void runningWithLibrary() throws UnsupportedEncodingException {
         AbstractBuild build = mockBuildWithLibrary(GITLAB_CONNECTION_V4, null, "test/project.git");
@@ -120,7 +119,6 @@ public class GitLabCommitStatusPublisherTest {
 
         prebuildAndVerify(build, listener, requests);
     }
-
 
     @Test
     public void runningWithDotInProjectId() throws IOException {
@@ -166,7 +164,6 @@ public class GitLabCommitStatusPublisherTest {
         performAndVerify(build, false, requests);
     }
 
-
     @Test
     public void success_v4() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, Result.SUCCESS, "test/project.git");
@@ -182,7 +179,7 @@ public class GitLabCommitStatusPublisherTest {
 
         performAndVerify(build, false, requests);
     }
-    
+
     @Test
     public void failed_v3() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V3, Result.FAILURE, "test/project.git");
@@ -206,7 +203,7 @@ public class GitLabCommitStatusPublisherTest {
 
         performAndVerify(build, false, requests);
     }
-    
+
     @Test
     public void unstable() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, Result.UNSTABLE, "test/project.git");
@@ -222,7 +219,7 @@ public class GitLabCommitStatusPublisherTest {
 
         performAndVerify(build, false, requests);
     }
-    
+
     @Test
     public void unstableAsSuccess() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, Result.UNSTABLE, "test/project.git");
@@ -247,7 +244,8 @@ public class GitLabCommitStatusPublisherTest {
     @Test
     public void running_commitNotExists() throws UnsupportedEncodingException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, null, "test/project.git");
-        HttpRequest updateCommitStatus = prepareUpdateCommitStatusWithSuccessResponse("v4", "test/project", build, BuildState.running);
+        HttpRequest updateCommitStatus =
+                prepareUpdateCommitStatusWithSuccessResponse("v4", "test/project", build, BuildState.running);
 
         new GitLabCommitStatusPublisher("jenkins", false).prebuild(build, listener);
         mockServerClient.verify(updateCommitStatus, VerificationTimes.exactly(0));
@@ -266,7 +264,10 @@ public class GitLabCommitStatusPublisherTest {
         mockServerClient.when(updateCommitStatus).respond(response().withStatusCode(403));
 
         prebuildAndVerify(build, buildListener, updateCommitStatus);
-        assertThat(outputStream.toString(), CoreMatchers.containsString("Failed to update Gitlab commit status for project 'test/project': HTTP 403 Forbidden"));
+        assertThat(
+                outputStream.toString(),
+                CoreMatchers.containsString(
+                        "Failed to update Gitlab commit status for project 'test/project': HTTP 403 Forbidden"));
     }
 
     private void prebuildAndVerify(AbstractBuild build, BuildListener listener, HttpRequest... requests) {
@@ -274,34 +275,43 @@ public class GitLabCommitStatusPublisherTest {
         mockServerClient.verify(requests);
     }
 
-    private void performAndVerify(AbstractBuild build, boolean markUnstableAsSuccess, HttpRequest... requests) throws InterruptedException, IOException {
+    private void performAndVerify(AbstractBuild build, boolean markUnstableAsSuccess, HttpRequest... requests)
+            throws InterruptedException, IOException {
         new GitLabCommitStatusPublisher("jenkins", markUnstableAsSuccess).perform(build, null, listener);
         mockServerClient.verify(requests);
     }
 
-    private HttpRequest[] prepareCheckCommitAndUpdateStatusRequests(String apiLevel, Run<?, ?> build, BuildState buildState) throws UnsupportedEncodingException {
+    private HttpRequest[] prepareCheckCommitAndUpdateStatusRequests(
+            String apiLevel, Run<?, ?> build, BuildState buildState) throws UnsupportedEncodingException {
         return new HttpRequest[] {
             prepareExistsCommitWithSuccessResponse(apiLevel, "test/project"),
             prepareUpdateCommitStatusWithSuccessResponse(apiLevel, "test/project", build, buildState)
         };
     }
 
-    private HttpRequest prepareUpdateCommitStatusWithSuccessResponse(String apiLevel, String projectName, Run<?, ?> build, BuildState state) throws UnsupportedEncodingException {
+    private HttpRequest prepareUpdateCommitStatusWithSuccessResponse(
+            String apiLevel, String projectName, Run<?, ?> build, BuildState state)
+            throws UnsupportedEncodingException {
         HttpRequest updateCommitStatus = prepareUpdateCommitStatus(apiLevel, projectName, build, state);
         mockServerClient.when(updateCommitStatus).respond(response().withStatusCode(200));
         return updateCommitStatus;
     }
 
-
-    private HttpRequest prepareUpdateCommitStatus(final String apiLevel, String projectName, Run<?, ?> build, BuildState state) throws UnsupportedEncodingException {
+    private HttpRequest prepareUpdateCommitStatus(
+            final String apiLevel, String projectName, Run<?, ?> build, BuildState state)
+            throws UnsupportedEncodingException {
         return request()
-                .withPath("/gitlab/api/" + apiLevel + "/projects/" + URLEncoder.encode(projectName, "UTF-8") + "/statuses/" + SHA1)
+                .withPath("/gitlab/api/" + apiLevel + "/projects/" + URLEncoder.encode(projectName, "UTF-8")
+                        + "/statuses/" + SHA1)
                 .withMethod("POST")
                 .withHeader("PRIVATE-TOKEN", "secret")
-                .withBody("state=" + URLEncoder.encode(state.name(), "UTF-8") + "&context=jenkins&" + "target_url=" + URLEncoder.encode(DisplayURLProvider.get().getRunURL(build), "UTF-8") + "&description=" + URLEncoder.encode(state.name(), "UTF-8"));
+                .withBody("state=" + URLEncoder.encode(state.name(), "UTF-8") + "&context=jenkins&" + "target_url="
+                        + URLEncoder.encode(DisplayURLProvider.get().getRunURL(build), "UTF-8") + "&description="
+                        + URLEncoder.encode(state.name(), "UTF-8"));
     }
 
-    private HttpRequest prepareExistsCommitWithSuccessResponse(String apiLevel, String projectName) throws UnsupportedEncodingException {
+    private HttpRequest prepareExistsCommitWithSuccessResponse(String apiLevel, String projectName)
+            throws UnsupportedEncodingException {
         HttpRequest existsCommit = prepareExistsCommit(apiLevel, projectName);
         mockServerClient.when(existsCommit).respond(response().withStatusCode(200));
         return existsCommit;
@@ -309,18 +319,20 @@ public class GitLabCommitStatusPublisherTest {
 
     private HttpRequest prepareExistsCommit(String apiLevel, String projectName) throws UnsupportedEncodingException {
         return request()
-                .withPath("/gitlab/api/" + apiLevel + "/projects/" + URLEncoder.encode(projectName, "UTF-8") + "/repository/commits/" + SHA1)
+                .withPath("/gitlab/api/" + apiLevel + "/projects/" + URLEncoder.encode(projectName, "UTF-8")
+                        + "/repository/commits/" + SHA1)
                 .withMethod("GET")
                 .withHeader("PRIVATE-TOKEN", "secret");
     }
 
     private HttpRequest prepareGetProjectResponse(String projectName) throws IOException {
-        HttpRequest request= request()
-                     .withPath("/gitlab/api/v4/projects/" + URLEncoder.encode(projectName, "UTF-8"))
-                     .withMethod("GET")
-                     .withHeader("PRIVATE-TOKEN", "secret");
+        HttpRequest request = request()
+                .withPath("/gitlab/api/v4/projects/" + URLEncoder.encode(projectName, "UTF-8"))
+                .withMethod("GET")
+                .withHeader("PRIVATE-TOKEN", "secret");
 
-        HttpResponse response = response().withBody(getSingleProjectJson("GetSingleProject.json", projectName, PROJECT_ID));
+        HttpResponse response =
+                response().withBody(getSingleProjectJson("GetSingleProject.json", projectName, PROJECT_ID));
 
         response.withHeader("Content-Type", "application/json");
         mockServerClient.when(request).respond(response.withStatusCode(200));
@@ -345,7 +357,8 @@ public class GitLabCommitStatusPublisherTest {
         when(build.getResult()).thenReturn(result);
         when(build.getUrl()).thenReturn(BUILD_URL);
         AbstractProject<?, ?> project = mock(AbstractProject.class);
-        when(project.getProperty(GitLabConnectionProperty.class)).thenReturn(new GitLabConnectionProperty(gitLabConnection));
+        when(project.getProperty(GitLabConnectionProperty.class))
+                .thenReturn(new GitLabConnectionProperty(gitLabConnection));
         doReturn(project).when(build).getParent();
         doReturn(project).when(build).getProject();
         EnvVars environment = mock(EnvVars.class);
@@ -369,11 +382,11 @@ public class GitLabCommitStatusPublisherTest {
         BuildData buildData = mock(BuildData.class);
         SCMRevisionAction scmRevisionAction = mock(SCMRevisionAction.class);
         AbstractGitSCMSource.SCMRevisionImpl revisionImpl = mock(AbstractGitSCMSource.SCMRevisionImpl.class);
-        
+
         when(build.getAction(SCMRevisionAction.class)).thenReturn(scmRevisionAction);
         when(scmRevisionAction.getRevision()).thenReturn(revisionImpl);
         when(revisionImpl.getHash()).thenReturn(SHA1);
-        
+
         Revision revision = mock(Revision.class);
         when(revision.getSha1String()).thenReturn(SHA1);
         when(buildData.getLastBuiltRevision()).thenReturn(revision);
@@ -388,8 +401,8 @@ public class GitLabCommitStatusPublisherTest {
         buildsByBranchName.put("develop", gitBuild);
         when(buildData.getBuildsByBranchName()).thenReturn(buildsByBranchName);
         buildDatas.add(buildData);
-        
-        //Second build data (@librabry)
+
+        // Second build data (@librabry)
         BuildData buildDataLib = mock(BuildData.class);
         Revision revisionLib = mock(Revision.class);
         when(revisionLib.getSha1String()).thenReturn("SHALIB");
@@ -398,13 +411,14 @@ public class GitLabCommitStatusPublisherTest {
         when(gitBuildLib.getMarked()).thenReturn(revisionLib);
         when(buildDataLib.getLastBuild(any(ObjectId.class))).thenReturn(gitBuildLib);
         buildDatas.add(buildDataLib);
-        
+
         when(build.getActions(BuildData.class)).thenReturn(buildDatas);
         when(build.getResult()).thenReturn(result);
         when(build.getUrl()).thenReturn(BUILD_URL);
 
         AbstractProject<?, ?> project = mock(AbstractProject.class);
-        when(project.getProperty(GitLabConnectionProperty.class)).thenReturn(new GitLabConnectionProperty(gitLabConnection));
+        when(project.getProperty(GitLabConnectionProperty.class))
+                .thenReturn(new GitLabConnectionProperty(gitLabConnection));
         doReturn(project).when(build).getParent();
         doReturn(project).when(build).getProject();
         EnvVars environment = mock(EnvVars.class);
@@ -422,12 +436,13 @@ public class GitLabCommitStatusPublisherTest {
         return build;
     }
 
-    private String getSingleProjectJson(String name,String projectNameWithNamespace, int projectId) throws IOException {
+    private String getSingleProjectJson(String name, String projectNameWithNamespace, int projectId)
+            throws IOException {
         String nameSpace = projectNameWithNamespace.split("/")[0];
         String projectName = projectNameWithNamespace.split("/")[1];
         return IOUtils.toString(getClass().getResourceAsStream(name))
-                 .replace("${projectId}", projectId + "")
-                 .replace("${nameSpace}", nameSpace)
-                 .replace("${projectName}", projectName);
+                .replace("${projectId}", projectId + "")
+                .replace("${nameSpace}", nameSpace)
+                .replace("${projectName}", projectName);
     }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabMessagePublisherTest.java
@@ -83,43 +83,69 @@ public class GitLabMessagePublisherTest {
     @Test
     public void canceled_v3() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V3, Result.ABORTED);
-        String defaultNote = formatNote(build, ":point_up: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
+        String defaultNote =
+                formatNote(build, ":point_up: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
 
         performAndVerify(
-            build, defaultNote, false, false, false, false, false,
-            prepareSendMessageWithSuccessResponse("v3", MERGE_REQUEST_ID, defaultNote));
+                build,
+                defaultNote,
+                false,
+                false,
+                false,
+                false,
+                false,
+                prepareSendMessageWithSuccessResponse("v3", MERGE_REQUEST_ID, defaultNote));
     }
 
     @Test
     public void canceled_v4() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, Result.ABORTED);
-        String defaultNote = formatNote(build, ":point_up: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
+        String defaultNote =
+                formatNote(build, ":point_up: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
 
         performAndVerify(
-            build, defaultNote, false, false, false, false, false,
-            prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
+                build,
+                defaultNote,
+                false,
+                false,
+                false,
+                false,
+                false,
+                prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
     }
-
 
     @Test
     public void success_v3() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V3, Result.SUCCESS);
-        String defaultNote = formatNote(build, ":white_check_mark: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
+        String defaultNote = formatNote(
+                build, ":white_check_mark: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
 
         performAndVerify(
-            build, defaultNote, false, false, false, false, false,
-            prepareSendMessageWithSuccessResponse("v3", MERGE_REQUEST_ID, defaultNote));
+                build,
+                defaultNote,
+                false,
+                false,
+                false,
+                false,
+                false,
+                prepareSendMessageWithSuccessResponse("v3", MERGE_REQUEST_ID, defaultNote));
     }
-
 
     @Test
     public void success_v4() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, Result.SUCCESS);
-        String defaultNote = formatNote(build, ":white_check_mark: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
+        String defaultNote = formatNote(
+                build, ":white_check_mark: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
 
         performAndVerify(
-            build, defaultNote, false, false, false, false, false,
-            prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
+                build,
+                defaultNote,
+                false,
+                false,
+                false,
+                false,
+                false,
+                prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
     }
 
     @Test
@@ -132,32 +158,52 @@ public class GitLabMessagePublisherTest {
     @Test
     public void failed_v3() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V3, Result.FAILURE);
-        String defaultNote = formatNote(build, ":x: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
+        String defaultNote =
+                formatNote(build, ":x: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
 
         performAndVerify(
-            build, defaultNote, false, false, false, false, false,
-            prepareSendMessageWithSuccessResponse("v3", MERGE_REQUEST_ID, defaultNote));
+                build,
+                defaultNote,
+                false,
+                false,
+                false,
+                false,
+                false,
+                prepareSendMessageWithSuccessResponse("v3", MERGE_REQUEST_ID, defaultNote));
     }
 
     @Test
     public void failed_v4() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, Result.FAILURE);
-        String defaultNote = formatNote(build, ":x: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
+        String defaultNote =
+                formatNote(build, ":x: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
 
         performAndVerify(
-            build, defaultNote, false, false, false, false, false,
-            prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
+                build,
+                defaultNote,
+                false,
+                false,
+                false,
+                false,
+                false,
+                prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
     }
-
 
     @Test
     public void failed_withOnlyForFailed() throws IOException, InterruptedException {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, Result.FAILURE);
-        String defaultNote = formatNote(build, ":x: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
+        String defaultNote =
+                formatNote(build, ":x: Jenkins Build {0}\n\nResults available at: [Jenkins [{1} #{2}]]({3})");
 
         performAndVerify(
-            build, defaultNote, true, false, false, false, false,
-            prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
+                build,
+                defaultNote,
+                true,
+                false,
+                false,
+                false,
+                false,
+                prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
     }
 
     @Test
@@ -166,8 +212,14 @@ public class GitLabMessagePublisherTest {
         String defaultNote = "abort";
 
         performAndVerify(
-            build, defaultNote, false, false, false, true, false,
-            prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
+                build,
+                defaultNote,
+                false,
+                false,
+                false,
+                true,
+                false,
+                prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
     }
 
     @Test
@@ -176,8 +228,14 @@ public class GitLabMessagePublisherTest {
         String defaultNote = "success";
 
         performAndVerify(
-            build, defaultNote, false, true, false, false, false,
-            prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
+                build,
+                defaultNote,
+                false,
+                true,
+                false,
+                false,
+                false,
+                prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
     }
 
     @Test
@@ -186,8 +244,14 @@ public class GitLabMessagePublisherTest {
         String defaultNote = "failure";
 
         performAndVerify(
-            build, defaultNote, false, false, true, false, false,
-            prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
+                build,
+                defaultNote,
+                false,
+                false,
+                true,
+                false,
+                false,
+                prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
     }
 
     @Test
@@ -196,16 +260,42 @@ public class GitLabMessagePublisherTest {
         String defaultNote = "unstable";
 
         performAndVerify(
-            build, defaultNote, false, false, false, false, true,
-            prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
+                build,
+                defaultNote,
+                false,
+                false,
+                false,
+                false,
+                true,
+                prepareSendMessageWithSuccessResponse("v4", MERGE_REQUEST_IID, defaultNote));
     }
 
-    private void performAndVerify(AbstractBuild build, String note, boolean onlyForFailure, boolean replaceSuccessNote, boolean replaceFailureNote, boolean replaceAbortNote, boolean replaceUnstableNote, HttpRequest... requests) throws InterruptedException, IOException {
+    private void performAndVerify(
+            AbstractBuild build,
+            String note,
+            boolean onlyForFailure,
+            boolean replaceSuccessNote,
+            boolean replaceFailureNote,
+            boolean replaceAbortNote,
+            boolean replaceUnstableNote,
+            HttpRequest... requests)
+            throws InterruptedException, IOException {
         String successNoteText = replaceSuccessNote ? note : null;
         String failureNoteText = replaceFailureNote ? note : null;
         String abortNoteText = replaceAbortNote ? note : null;
         String unstableNoteText = replaceUnstableNote ? note : null;
-        GitLabMessagePublisher publisher = preparePublisher(new GitLabMessagePublisher(onlyForFailure, replaceSuccessNote, replaceFailureNote, replaceAbortNote, replaceUnstableNote, successNoteText, failureNoteText, abortNoteText, unstableNoteText), build);
+        GitLabMessagePublisher publisher = preparePublisher(
+                new GitLabMessagePublisher(
+                        onlyForFailure,
+                        replaceSuccessNote,
+                        replaceFailureNote,
+                        replaceAbortNote,
+                        replaceUnstableNote,
+                        successNoteText,
+                        failureNoteText,
+                        abortNoteText,
+                        unstableNoteText),
+                build);
         publisher.perform(build, null, listener);
 
         if (requests.length > 0) {
@@ -215,15 +305,18 @@ public class GitLabMessagePublisherTest {
         }
     }
 
-    private HttpRequest prepareSendMessageWithSuccessResponse(String apiLevel, int mergeRequestId, String body) throws UnsupportedEncodingException {
+    private HttpRequest prepareSendMessageWithSuccessResponse(String apiLevel, int mergeRequestId, String body)
+            throws UnsupportedEncodingException {
         HttpRequest updateCommitStatus = prepareSendMessageStatus(apiLevel, mergeRequestId, body);
         mockServerClient.when(updateCommitStatus).respond(response().withStatusCode(200));
         return updateCommitStatus;
     }
 
-    private HttpRequest prepareSendMessageStatus(final String apiLevel, int mergeRequestId, String body) throws UnsupportedEncodingException {
+    private HttpRequest prepareSendMessageStatus(final String apiLevel, int mergeRequestId, String body)
+            throws UnsupportedEncodingException {
         return request()
-                .withPath("/gitlab/api/" + apiLevel + "/projects/" + PROJECT_ID + "/merge_requests/" + mergeRequestId + "/notes")
+                .withPath("/gitlab/api/" + apiLevel + "/projects/" + PROJECT_ID + "/merge_requests/" + mergeRequestId
+                        + "/notes")
                 .withMethod("POST")
                 .withHeader("PRIVATE-TOKEN", "secret")
                 .withBody("body=" + URLEncoder.encode(body, "UTF-8"));
@@ -240,7 +333,8 @@ public class GitLabMessagePublisherTest {
         when(build.getNumber()).thenReturn(BUILD_NUMBER);
 
         AbstractProject<?, ?> project = mock(AbstractProject.class);
-        when(project.getProperty(GitLabConnectionProperty.class)).thenReturn(new GitLabConnectionProperty(gitLabConnection));
+        when(project.getProperty(GitLabConnectionProperty.class))
+                .thenReturn(new GitLabConnectionProperty(gitLabConnection));
         doReturn(project).when(build).getParent();
         doReturn(project).when(build).getProject();
         EnvVars environment = mock(EnvVars.class);

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabVotePublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabVotePublisherTest.java
@@ -95,40 +95,41 @@ public class GitLabVotePublisherTest {
 
         // THEN
         mockServerClient.verify(prepareSendMessageWithSuccessResponse(build, "v4", MERGE_REQUEST_IID, "thumbsdown"));
-        mockServerClient.verify(awardEmojiRequest("v4", MERGE_REQUEST_IID, "POST")
-            .withQueryStringParameter("name", "thumbsdown"));
+        mockServerClient.verify(
+                awardEmojiRequest("v4", MERGE_REQUEST_IID, "POST").withQueryStringParameter("name", "thumbsdown"));
     }
 
-    private void performAndVerify(AbstractBuild build, String apiLevel, int mergeRequestId, String defaultNote) throws InterruptedException, IOException {
+    private void performAndVerify(AbstractBuild build, String apiLevel, int mergeRequestId, String defaultNote)
+            throws InterruptedException, IOException {
         GitLabVotePublisher publisher = preparePublisher(new GitLabVotePublisher(), build);
         publisher.perform(build, null, listener);
 
         mockServerClient.verify(prepareSendMessageWithSuccessResponse(build, apiLevel, mergeRequestId, defaultNote));
     }
 
-    private HttpRequest prepareSendMessageWithSuccessResponse(AbstractBuild build, String apiLevel, int mergeRequestId, String body) {
+    private HttpRequest prepareSendMessageWithSuccessResponse(
+            AbstractBuild build, String apiLevel, int mergeRequestId, String body) {
         HttpRequest updateCommitStatus = prepareSendMessageStatus(apiLevel, mergeRequestId, formatNote(build, body));
         mockServerClient.when(updateCommitStatus).respond(response().withStatusCode(200));
         return updateCommitStatus;
     }
 
     private HttpRequest prepareSendMessageStatus(final String apiLevel, int mergeRequestId, String name) {
-        return awardEmojiRequest(apiLevel, mergeRequestId, "POST")
-                .withQueryStringParameter("name", name);
+        return awardEmojiRequest(apiLevel, mergeRequestId, "POST").withQueryStringParameter("name", name);
     }
 
     private HttpRequest awardEmojiRequest(final String apiLevel, int mergeRequestId, String type) {
         return request()
-                .withPath("/gitlab/api/" + apiLevel + "/projects/" + PROJECT_ID + "/merge_requests/" + mergeRequestId + "/award_emoji")
+                .withPath("/gitlab/api/" + apiLevel + "/projects/" + PROJECT_ID + "/merge_requests/" + mergeRequestId
+                        + "/award_emoji")
                 .withMethod(type)
                 .withHeader("PRIVATE-TOKEN", "secret");
     }
 
     private void mockUser(final int id, final String username) {
-        String sb = ("{\"id\": " + id) +
-                     ",\"username\": \"" + username + "\"" +
-                     ",\"email\": \"jenkins@jenkins.io\"" +
-                     ",\"name\": \"Ms Jenkins\"}";
+        String sb = ("{\"id\": " + id) + ",\"username\": \""
+                + username + "\"" + ",\"email\": \"jenkins@jenkins.io\""
+                + ",\"name\": \"Ms Jenkins\"}";
         mockServerClient.when(prepareUserQuery()).respond(response(sb));
     }
 
@@ -147,6 +148,8 @@ public class GitLabVotePublisherTest {
         sb.append(",\"User\": ");
         sb.append("  { \"id\": 1 }");
         sb.append("}");
-        mockServerClient.when(awardEmojiRequest(apiLevel, mergeRequestId, "GET")).respond(response(sb.toString()));
+        mockServerClient
+                .when(awardEmojiRequest(apiLevel, mergeRequestId, "GET"))
+                .respond(response(sb.toString()));
     }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/TestUtility.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/TestUtility.java
@@ -57,24 +57,45 @@ final class TestUtility {
         for (CredentialsStore credentialsStore : CredentialsProvider.lookupStores(Jenkins.getInstance())) {
             if (credentialsStore instanceof SystemCredentialsProvider.StoreImpl) {
                 List<Domain> domains = credentialsStore.getDomains();
-                credentialsStore.addCredentials(domains.get(0),
-                    new StringCredentialsImpl(CredentialsScope.SYSTEM, apiTokenId, "GitLab API Token", Secret.fromString(TestUtility.API_TOKEN)));
+                credentialsStore.addCredentials(
+                        domains.get(0),
+                        new StringCredentialsImpl(
+                                CredentialsScope.SYSTEM,
+                                apiTokenId,
+                                "GitLab API Token",
+                                Secret.fromString(TestUtility.API_TOKEN)));
             }
         }
-        connectionConfig.addConnection(new GitLabConnection(TestUtility.GITLAB_CONNECTION_V3, "http://localhost:" + mockServer.getPort() + "/gitlab", apiTokenId, new V3GitLabClientBuilder(), false, 10, 10));
-        connectionConfig.addConnection(new GitLabConnection(TestUtility.GITLAB_CONNECTION_V4, "http://localhost:" + mockServer.getPort() + "/gitlab", apiTokenId, new V4GitLabClientBuilder(), false, 10, 10));
-
+        connectionConfig.addConnection(new GitLabConnection(
+                TestUtility.GITLAB_CONNECTION_V3,
+                "http://localhost:" + mockServer.getPort() + "/gitlab",
+                apiTokenId,
+                new V3GitLabClientBuilder(),
+                false,
+                10,
+                10));
+        connectionConfig.addConnection(new GitLabConnection(
+                TestUtility.GITLAB_CONNECTION_V4,
+                "http://localhost:" + mockServer.getPort() + "/gitlab",
+                apiTokenId,
+                new V4GitLabClientBuilder(),
+                false,
+                10,
+                10));
     }
 
-    static <T extends Notifier & MatrixAggregatable> void verifyMatrixAggregatable(Class<T> publisherClass, BuildListener listener) throws InterruptedException, IOException {
+    static <T extends Notifier & MatrixAggregatable> void verifyMatrixAggregatable(
+            Class<T> publisherClass, BuildListener listener) throws InterruptedException, IOException {
         AbstractBuild build = mock(AbstractBuild.class);
         AbstractProject project = mock(MatrixConfiguration.class);
         Notifier publisher = mock(publisherClass);
         MatrixBuild parentBuild = mock(MatrixBuild.class);
 
         when(build.getParent()).thenReturn(project);
-        when(((MatrixAggregatable) publisher).createAggregator(any(MatrixBuild.class), any(), any(BuildListener.class))).thenCallRealMethod();
-        when(publisher.perform(any(AbstractBuild.class), any(Launcher.class), any(BuildListener.class))).thenReturn(true);
+        when(((MatrixAggregatable) publisher).createAggregator(any(MatrixBuild.class), any(), any(BuildListener.class)))
+                .thenCallRealMethod();
+        when(publisher.perform(any(AbstractBuild.class), any(Launcher.class), any(BuildListener.class)))
+                .thenReturn(true);
 
         MatrixAggregator aggregator = ((MatrixAggregatable) publisher).createAggregator(parentBuild, null, listener);
         aggregator.startBuild();
@@ -93,7 +114,8 @@ final class TestUtility {
         when(build.getNumber()).thenReturn(BUILD_NUMBER);
 
         AbstractProject<?, ?> project = mock(AbstractProject.class);
-        when(project.getProperty(GitLabConnectionProperty.class)).thenReturn(new GitLabConnectionProperty(gitLabConnection));
+        when(project.getProperty(GitLabConnectionProperty.class))
+                .thenReturn(new GitLabConnectionProperty(gitLabConnection));
         doReturn(project).when(build).getParent();
         doReturn(project).when(build).getProject();
         return build;
@@ -102,15 +124,19 @@ final class TestUtility {
     @SuppressWarnings("ConstantConditions")
     static String formatNote(AbstractBuild build, String note) {
         String buildUrl = Jenkins.getInstance().getRootUrl() + build.getUrl();
-        return MessageFormat.format(note, build.getResult(), build.getParent().getDisplayName(), BUILD_NUMBER, buildUrl);
+        return MessageFormat.format(
+                note, build.getResult(), build.getParent().getDisplayName(), BUILD_NUMBER, buildUrl);
     }
 
     static <P extends MergeRequestNotifier> P preparePublisher(P publisher, AbstractBuild build) {
         P spyPublisher = spy(publisher);
-        MergeRequest mergeRequest = new MergeRequest(MERGE_REQUEST_ID, MERGE_REQUEST_IID, "", "", "", PROJECT_ID, PROJECT_ID, "", "");
+        MergeRequest mergeRequest =
+                new MergeRequest(MERGE_REQUEST_ID, MERGE_REQUEST_IID, "", "", "", PROJECT_ID, PROJECT_ID, "", "");
         doReturn(mergeRequest).when(spyPublisher).getMergeRequest(build);
         return spyPublisher;
     }
 
-    private TestUtility() { /* contains only static utility-methods */ }
+    private TestUtility() {
+        /* contains only static utility-methods */
+    }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabClientStub.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabClientStub.java
@@ -80,15 +80,13 @@ class GitLabClientStub implements GitLabClient {
     }
 
     /************** no implementation below ********************************/
-
     @Override
     public List<Group> getGroups() {
         return null;
     }
 
     @Override
-    public List<Group> getGroups(Boolean allAvailable, Boolean topLevelOnly, OrderType orderBy,
-            SortType sort) {
+    public List<Group> getGroups(Boolean allAvailable, Boolean topLevelOnly, OrderType orderBy, SortType sort) {
         return null;
     }
 
@@ -98,8 +96,12 @@ class GitLabClientStub implements GitLabClient {
     }
 
     @Override
-    public List<Project> getGroupProjects(String groupId, Boolean includeSubgroups, ProjectVisibilityType visibility,
-            OrderType orderBy, SortType sort) {
+    public List<Project> getGroupProjects(
+            String groupId,
+            Boolean includeSubgroups,
+            ProjectVisibilityType visibility,
+            OrderType orderBy,
+            SortType sort) {
         return null;
     }
 
@@ -124,9 +126,7 @@ class GitLabClientStub implements GitLabClient {
     }
 
     @Override
-    public void deleteProject(String projectId) {
-
-    }
+    public void deleteProject(String projectId) {}
 
     @Override
     public List<ProjectHook> getProjectHooks(String projectName) {
@@ -134,31 +134,43 @@ class GitLabClientStub implements GitLabClient {
     }
 
     @Override
-    public void addProjectHook(String projectId, String url, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents) {
-
-    }
-
-    @Override
-    public void addProjectHook(String projectId, String url, String secretToken, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents) {
-
-    }
+    public void addProjectHook(
+            String projectId, String url, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents) {}
 
     @Override
-    public void changeBuildStatus(String projectId, String sha, BuildState state, String ref, String context, String targetUrl, String description) {
-
-    }
+    public void addProjectHook(
+            String projectId,
+            String url,
+            String secretToken,
+            Boolean pushEvents,
+            Boolean mergeRequestEvents,
+            Boolean noteEvents) {}
 
     @Override
-    public void changeBuildStatus(Integer projectId, String sha, BuildState state, String ref, String context, String targetUrl, String description) {
+    public void changeBuildStatus(
+            String projectId,
+            String sha,
+            BuildState state,
+            String ref,
+            String context,
+            String targetUrl,
+            String description) {}
 
-    }
+    @Override
+    public void changeBuildStatus(
+            Integer projectId,
+            String sha,
+            BuildState state,
+            String ref,
+            String context,
+            String targetUrl,
+            String description) {}
 
     @Override
     public void getCommit(String projectId, String sha) {}
 
     @Override
-    public void acceptMergeRequest(
-            MergeRequest mr, String mergeCommitMessage, Boolean shouldRemoveSourceBranch) {}
+    public void acceptMergeRequest(MergeRequest mr, String mergeCommitMessage, Boolean shouldRemoveSourceBranch) {}
 
     @Override
     public void createMergeRequestNote(MergeRequest mr, String body) {}

--- a/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabProjectBranchesServiceTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabProjectBranchesServiceTest.java
@@ -14,7 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class GitLabProjectBranchesServiceTest {
-    private final static List<String> BRANCH_NAMES_PROJECT_B = Arrays.asList("master", "B-branch-1", "B-branch-2");
+    private static final List<String> BRANCH_NAMES_PROJECT_B = Arrays.asList("master", "B-branch-1", "B-branch-2");
 
     private GitLabProjectBranchesService branchesService;
 
@@ -25,7 +25,6 @@ public class GitLabProjectBranchesServiceTest {
         clientStub = new GitLabClientStub();
         clientStub.addBranches("groupOne/A", convert(Arrays.asList("master", "A-branch-1")));
         clientStub.addBranches("groupOne/B", convert(BRANCH_NAMES_PROJECT_B));
-
 
         // never expire cache for tests
         branchesService = new GitLabProjectBranchesService();

--- a/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabProjectLabelsServiceTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabProjectLabelsServiceTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 public class GitLabProjectLabelsServiceTest {
 
-    private final static List<String> LABELS_PROJECT_B = Arrays.asList("label1", "label2", "label3");
+    private static final List<String> LABELS_PROJECT_B = Arrays.asList("label1", "label2", "label3");
 
     private GitLabProjectLabelsService labelsService;
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples_7_10_5_489b413.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples_7_10_5_489b413.java
@@ -43,7 +43,8 @@ public class GitLabPushRequestSamples_7_10_5_489b413 implements GitLabPushReques
                         .withHomepage("http://gitlabserver.example.com/test-group/test-repo")
                         .build())
                 .withRef("refs/heads/test-new-branch1")
-                .withBefore(ZERO_SHA).withAfter(COMMIT_7A)
+                .withBefore(ZERO_SHA)
+                .withAfter(COMMIT_7A)
                 // no commit on new branches
                 .build();
     }
@@ -61,7 +62,8 @@ public class GitLabPushRequestSamples_7_10_5_489b413 implements GitLabPushReques
                 .withRef("refs/heads/test-new-branch1")
                 .withBefore(COMMIT_7A)
                 .withAfter(COMMIT_21)
-                .withCommits(Collections.singletonList(commit().withId(COMMIT_21).build()))
+                .withCommits(
+                        Collections.singletonList(commit().withId(COMMIT_21).build()))
                 .build();
     }
 
@@ -80,9 +82,9 @@ public class GitLabPushRequestSamples_7_10_5_489b413 implements GitLabPushReques
                 .withAfter(COMMIT_9d)
                 .withCommits(Arrays.asList(
                         commit().withId(COMMIT_21).build(),
-                        commit().withId("c04c8822d1df397fb7e6dd3dd133018a0af567a8").build(),
-                        commit().withId(COMMIT_9d).build())
-                )
+                        commit().withId("c04c8822d1df397fb7e6dd3dd133018a0af567a8")
+                                .build(),
+                        commit().withId(COMMIT_9d).build()))
                 .build();
     }
 
@@ -99,7 +101,8 @@ public class GitLabPushRequestSamples_7_10_5_489b413 implements GitLabPushReques
                 .withRef("refs/tags/test-tag-1")
                 .withBefore(ZERO_SHA)
                 .withAfter(COMMIT_21)
-                .withCommits(Collections.singletonList(commit().withId(COMMIT_21).build()))
+                .withCommits(
+                        Collections.singletonList(commit().withId(COMMIT_21).build()))
                 .build();
     }
 
@@ -114,8 +117,8 @@ public class GitLabPushRequestSamples_7_10_5_489b413 implements GitLabPushReques
                         .withHomepage("http://gitlabserver.example.com/test-group/test-repo")
                         .build())
                 .withRef("refs/heads/test-branch-3-delete")
-                .withBefore("c34984ff6ed9935b3d843237947adbaaa85fc5f9").withAfter(ZERO_SHA)
+                .withBefore("c34984ff6ed9935b3d843237947adbaaa85fc5f9")
+                .withAfter(ZERO_SHA)
                 .build();
     }
-
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples_7_5_1_36679b5.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples_7_5_1_36679b5.java
@@ -60,12 +60,14 @@ public class GitLabPushRequestSamples_7_5_1_36679b5 implements GitLabPushRequest
                 .withBefore("2bf4170829aedd706d7485d40091a01637b9abf4")
                 .withAfter("4bf0fcd937085dc2f69dcbe31f2ef960ec9ca7eb")
                 // no checkout_sha
-                .withCommits(Collections.singletonList(commit().withId("4bf0fcd937085dc2f69dcbe31f2ef960ec9ca7eb").build()))
+                .withCommits(Collections.singletonList(commit().withId("4bf0fcd937085dc2f69dcbe31f2ef960ec9ca7eb")
+                        .build()))
                 .build();
     }
 
     public PushHook mergePushRequest() {
-        return pushHook().withRef("refs/heads/master")
+        return pushHook()
+                .withRef("refs/heads/master")
                 .withUserId(123)
                 .withUserName("admin@example")
                 .withProjectId(345)
@@ -78,10 +80,12 @@ public class GitLabPushRequestSamples_7_5_1_36679b5 implements GitLabPushRequest
                 .withAfter("3ebb6927ad4afbe8a11830938b3584cdaf4d657b")
                 // no checkout_sha
                 .withCommits(Arrays.asList(
-                        commit().withId("4bf0fcd937085dc2f69dcbe31f2ef960ec9ca7eb").build(),
-                        commit().withId("be473fcc670b920cc9795581a5cd8f00fa7afddd").build(),
-                        commit().withId("3ebb6927ad4afbe8a11830938b3584cdaf4d657b").build())
-                )
+                        commit().withId("4bf0fcd937085dc2f69dcbe31f2ef960ec9ca7eb")
+                                .build(),
+                        commit().withId("be473fcc670b920cc9795581a5cd8f00fa7afddd")
+                                .build(),
+                        commit().withId("3ebb6927ad4afbe8a11830938b3584cdaf4d657b")
+                                .build()))
                 .build();
         // and afterwards the "delete branch" request comes in
     }
@@ -97,7 +101,8 @@ public class GitLabPushRequestSamples_7_5_1_36679b5 implements GitLabPushRequest
                         .withHomepage("http://gitlabserver.example.com/test-group/test-repo")
                         .build())
                 .withRef("refs/tags/test-tag-2")
-                .withBefore(ZERO_SHA).withAfter("f10d9d7b648e5a3e55fe8fe865aba5aa7404df7c")
+                .withBefore(ZERO_SHA)
+                .withAfter("f10d9d7b648e5a3e55fe8fe865aba5aa7404df7c")
                 // no checkout_sha and no commit on new branches
                 .build();
     }
@@ -113,7 +118,8 @@ public class GitLabPushRequestSamples_7_5_1_36679b5 implements GitLabPushRequest
                         .withHomepage("http://gitlabserver.example.com/test-group/test-repo")
                         .build())
                 .withRef("refs/heads/test-branch-delete-1")
-                .withBefore("3ebb6927ad4afbe8a11830938b3584cdaf4d657b").withAfter(ZERO_SHA)
+                .withBefore("3ebb6927ad4afbe8a11830938b3584cdaf4d657b")
+                .withAfter(ZERO_SHA)
                 // no checkout_sha and no commit on new branches
                 .build();
     }

--- a/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples_8_1_2_8c8af7b.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testhelpers/GitLabPushRequestSamples_8_1_2_8c8af7b.java
@@ -65,7 +65,8 @@ public class GitLabPushRequestSamples_8_1_2_8c8af7b implements GitLabPushRequest
                 .withRef("refs/heads/test-new-branch1")
                 .withBefore(COMMIT_25)
                 .withAfter(COMMIT_74)
-                .withCommits(Collections.singletonList(commit().withId(COMMIT_74).build()))
+                .withCommits(
+                        Collections.singletonList(commit().withId(COMMIT_74).build()))
                 .build();
     }
 
@@ -84,9 +85,9 @@ public class GitLabPushRequestSamples_8_1_2_8c8af7b implements GitLabPushRequest
                 .withAfter(COMMIT_E5)
                 .withCommits(Arrays.asList(
                         commit().withId(COMMIT_74).build(),
-                        commit().withId("ab569fa9c51fa80d6509b277a6b587faf8e7cb72").build(),
-                        commit().withId(COMMIT_E5).build())
-                )
+                        commit().withId("ab569fa9c51fa80d6509b277a6b587faf8e7cb72")
+                                .build(),
+                        commit().withId(COMMIT_E5).build()))
                 .build();
 
         // and afterwards the "delete branch" request comes in
@@ -105,7 +106,8 @@ public class GitLabPushRequestSamples_8_1_2_8c8af7b implements GitLabPushRequest
                 .withRef("refs/tags/test-tag-2")
                 .withBefore(ZERO_SHA)
                 .withAfter(COMMIT_64)
-                .withCommits(Collections.singletonList(commit().withId(COMMIT_64).build()))
+                .withCommits(
+                        Collections.singletonList(commit().withId(COMMIT_64).build()))
                 .build();
     }
 
@@ -124,5 +126,4 @@ public class GitLabPushRequestSamples_8_1_2_8c8af7b implements GitLabPushRequest
                 .withAfter(ZERO_SHA)
                 .build();
     }
-
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/testing/gitlab/rule/GitLabRule.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testing/gitlab/rule/GitLabRule.java
@@ -68,8 +68,14 @@ public class GitLabRule implements TestRule {
     public String createProject(ProjectRequest request) {
         Project project = client().createProject(request.getName());
         projectIds.add(project.getId().toString());
-        if (request.getWebHookUrl() != null && (request.isPushHook() || request.isMergeRequestHook() || request.isNoteHook())) {
-            client().addProjectHook(project.getId().toString(), request.getWebHookUrl(), request.isPushHook(), request.isMergeRequestHook(), request.isNoteHook());
+        if (request.getWebHookUrl() != null
+                && (request.isPushHook() || request.isMergeRequestHook() || request.isNoteHook())) {
+            client().addProjectHook(
+                            project.getId().toString(),
+                            request.getWebHookUrl(),
+                            request.isPushHook(),
+                            request.isMergeRequestHook(),
+                            request.isNoteHook());
         }
         return project.getHttpUrlToRepo();
     }
@@ -78,22 +84,26 @@ public class GitLabRule implements TestRule {
         for (CredentialsStore credentialsStore : CredentialsProvider.lookupStores(Jenkins.getInstance())) {
             if (credentialsStore instanceof SystemCredentialsProvider.StoreImpl) {
                 List<Domain> domains = credentialsStore.getDomains();
-                credentialsStore.addCredentials(domains.get(0),
-                    new StringCredentialsImpl(CredentialsScope.SYSTEM, API_TOKEN_ID, "GitLab API Token", Secret.fromString(getApiToken())));
+                credentialsStore.addCredentials(
+                        domains.get(0),
+                        new StringCredentialsImpl(
+                                CredentialsScope.SYSTEM,
+                                API_TOKEN_ID,
+                                "GitLab API Token",
+                                Secret.fromString(getApiToken())));
             }
         }
 
         GitLabConnectionConfig config = Jenkins.getInstance().getDescriptorByType(GitLabConnectionConfig.class);
-        GitLabConnection connection = new GitLabConnection("test", url, API_TOKEN_ID, new V3GitLabClientBuilder(), true,10, 10);
+        GitLabConnection connection =
+                new GitLabConnection("test", url, API_TOKEN_ID, new V3GitLabClientBuilder(), true, 10, 10);
         config.addConnection(connection);
         config.save();
         return new GitLabConnectionProperty(connection.getName());
     }
 
-    public MergeRequest createMergeRequest(final Integer projectId,
-                                           final String sourceBranch,
-                                           final String targetBranch,
-                                           final String title) {
+    public MergeRequest createMergeRequest(
+            final Integer projectId, final String sourceBranch, final String targetBranch, final String title) {
         return client().createMergeRequest(projectId, sourceBranch, targetBranch, title);
     }
 
@@ -121,8 +131,11 @@ public class GitLabRule implements TestRule {
     private String getApiToken() {
         try {
             Class.forName("org.postgresql.Driver");
-            try (Connection connection = DriverManager.getConnection("jdbc:postgresql://localhost:" + postgresPort + "/gitlabhq_production", "gitlab", "password")) {
-                ResultSet resultSet = connection.createStatement().executeQuery("SELECT authentication_token FROM users WHERE username = 'root'");
+            try (Connection connection = DriverManager.getConnection(
+                    "jdbc:postgresql://localhost:" + postgresPort + "/gitlabhq_production", "gitlab", "password")) {
+                ResultSet resultSet = connection
+                        .createStatement()
+                        .executeQuery("SELECT authentication_token FROM users WHERE username = 'root'");
                 resultSet.next();
                 return resultSet.getString("authentication_token");
             }

--- a/src/test/java/com/dabsquared/gitlabjenkins/testing/gitlab/rule/ProjectRequest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testing/gitlab/rule/ProjectRequest.java
@@ -15,8 +15,13 @@ public class ProjectRequest {
     private final boolean pipelineHook;
 
     @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-    public ProjectRequest(String name, String webHookUrl, boolean pushHook, boolean mergeRequestHook, boolean noteHook,
-                          boolean pipelineHook) {
+    public ProjectRequest(
+            String name,
+            String webHookUrl,
+            boolean pushHook,
+            boolean mergeRequestHook,
+            boolean noteHook,
+            boolean pipelineHook) {
         this.name = name;
         this.webHookUrl = webHookUrl;
         this.pushHook = pushHook;

--- a/src/test/java/com/dabsquared/gitlabjenkins/testing/integration/GitLabIT.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testing/integration/GitLabIT.java
@@ -53,7 +53,8 @@ public class GitLabIT {
     private static final String GITLAB_URL = "http://localhost:" + System.getProperty("gitlab.http.port", "10080");
 
     @Rule
-    public GitLabRule gitlab = new GitLabRule(GITLAB_URL, Integer.parseInt(System.getProperty("postgres.port", "5432")));
+    public GitLabRule gitlab =
+            new GitLabRule(GITLAB_URL, Integer.parseInt(System.getProperty("postgres.port", "5432")));
 
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
@@ -65,42 +66,49 @@ public class GitLabIT {
     public void buildOnPush() throws IOException, InterruptedException, GitAPIException {
         final OneShotEvent buildTriggered = new OneShotEvent();
         FreeStyleProject project = jenkins.createFreeStyleProject("test");
-        GitLabPushTrigger trigger = gitLabPushTrigger().withTriggerOnPush(true).withBranchFilterType(BranchFilterType.All).build();
+        GitLabPushTrigger trigger = gitLabPushTrigger()
+                .withTriggerOnPush(true)
+                .withBranchFilterType(BranchFilterType.All)
+                .build();
         project.addTrigger(trigger);
         trigger.start(project, true);
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildTriggered.signal();
                 return true;
             }
         });
         project.setQuietPeriod(0);
 
-        createGitLabProject(false,true, true, false);
+        createGitLabProject(false, true, true, false);
 
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
-
     @Test
     public void buildOnMergeRequest() throws IOException, InterruptedException, GitAPIException {
         final OneShotEvent buildTriggered = new OneShotEvent();
         FreeStyleProject project = jenkins.createFreeStyleProject("test");
-        GitLabPushTrigger trigger = gitLabPushTrigger().withTriggerOnMergeRequest(true).withBranchFilterType(BranchFilterType.All).build();
+        GitLabPushTrigger trigger = gitLabPushTrigger()
+                .withTriggerOnMergeRequest(true)
+                .withBranchFilterType(BranchFilterType.All)
+                .build();
         project.addTrigger(trigger);
         trigger.start(project, true);
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildTriggered.signal();
                 return true;
             }
         });
         project.setQuietPeriod(0);
 
-        Pair<Integer, String> gitlabData = createGitLabProject(true,false, false, true);
+        Pair<Integer, String> gitlabData = createGitLabProject(true, false, false, true);
 
         gitlab.createMergeRequest(gitlabData.getLeft(), "feature", "master", "Merge feature branch to master.");
 
@@ -113,12 +121,14 @@ public class GitLabIT {
         final OneShotEvent buildTriggered = new OneShotEvent();
         FreeStyleProject project = jenkins.createFreeStyleProject("test");
         GitLabPushTrigger trigger = gitLabPushTrigger()
-            .withTriggerOnNoteRequest(true)
-            .withNoteRegex(".*test.*")
-            .withBranchFilterType(BranchFilterType.All).build();
+                .withTriggerOnNoteRequest(true)
+                .withNoteRegex(".*test.*")
+                .withBranchFilterType(BranchFilterType.All)
+                .build();
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildTriggered.signal();
                 return true;
             }
@@ -128,7 +138,8 @@ public class GitLabIT {
         Pair<Integer, String> gitlabData = createGitLabProject(true, false, true, false);
 
         // create merge-request
-        MergeRequest mr = gitlab.createMergeRequest(gitlabData.getLeft(), "feature", "master", "Merge feature branch to master.");
+        MergeRequest mr =
+                gitlab.createMergeRequest(gitlabData.getLeft(), "feature", "master", "Merge feature branch to master.");
 
         // add trigger after push/merge-request so it may only receive the note-hook
         project.addTrigger(trigger);
@@ -146,9 +157,9 @@ public class GitLabIT {
         final OneShotEvent buildReported = new OneShotEvent();
 
         GitLabPushTrigger trigger = gitLabPushTrigger()
-            .withTriggerOnPush(true)
-            .withBranchFilterType(BranchFilterType.All)
-            .build();
+                .withTriggerOnPush(true)
+                .withBranchFilterType(BranchFilterType.All)
+                .build();
 
         FreeStyleProject project = jenkins.createFreeStyleProject("test");
         project.addProperty(gitlab.createGitLabConnectionProperty());
@@ -156,7 +167,8 @@ public class GitLabIT {
 
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildTriggered.signal();
                 return true;
             }
@@ -167,7 +179,8 @@ public class GitLabIT {
         publishers.add(new GitLabCommitStatusPublisher("integration-test", false));
         publishers.add(new TestNotifier() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildReported.signal();
                 return true;
             }
@@ -175,8 +188,7 @@ public class GitLabIT {
         trigger.start(project, true);
         project.setQuietPeriod(0);
 
-
-        Pair<Integer, String> gitlabData = createGitLabProject(false,true, true, false);
+        Pair<Integer, String> gitlabData = createGitLabProject(false, true, true, false);
         assertThat(gitlab.getPipelines(gitlabData.getLeft()), empty());
 
         buildTriggered.block(20000);
@@ -199,17 +211,20 @@ public class GitLabIT {
         assertEquals(status, pipeline.getStatus());
     }
 
-    private Pair<Integer, String> createGitLabProject(boolean addFeatureBranch, boolean withPushHook, boolean withNoteHook, boolean withMergeRequestHook) throws IOException, GitAPIException {
+    private Pair<Integer, String> createGitLabProject(
+            boolean addFeatureBranch, boolean withPushHook, boolean withNoteHook, boolean withMergeRequestHook)
+            throws IOException, GitAPIException {
         // check for clean slate
         assertTrue(gitlab.getProjectIds().isEmpty());
 
         String url = gitlab.createProject(projectRequest()
-            .withName("test")
-            .withWebHookUrl("http://" + getDocker0Ip() + ":" + jenkins.getURL().getPort() + "/jenkins/project/test")
-            .withPushHook(withPushHook)
-            .withNoteHook(withNoteHook)
-            .withMergeRequestHook(withMergeRequestHook)
-            .build());
+                .withName("test")
+                .withWebHookUrl(
+                        "http://" + getDocker0Ip() + ":" + jenkins.getURL().getPort() + "/jenkins/project/test")
+                .withPushHook(withPushHook)
+                .withNoteHook(withNoteHook)
+                .withMergeRequestHook(withMergeRequestHook)
+                .build());
 
         String sha = initGitLabProject(url, addFeatureBranch);
 
@@ -237,17 +252,23 @@ public class GitLabIT {
         git.add().addFilepattern("test");
         RevCommit commit = git.commit().setMessage("test").call();
         git.push()
-            .setRemote("origin").add("master")
-            .setCredentialsProvider(new UsernamePasswordCredentialsProvider(gitlab.getUsername(), gitlab.getPassword()))
-            .call();
+                .setRemote("origin")
+                .add("master")
+                .setCredentialsProvider(
+                        new UsernamePasswordCredentialsProvider(gitlab.getUsername(), gitlab.getPassword()))
+                .call();
 
         if (addFeatureBranch) {
             // Setup remote feature branch
             git.checkout().setName("feature").setCreateBranch(true).call();
             tmp.newFile("feature");
             commit = git.commit().setMessage("feature").call();
-            git.push().setRemote("origin").add("feature").setCredentialsProvider(new UsernamePasswordCredentialsProvider(gitlab.getUsername(), gitlab.getPassword()))
-                .call();
+            git.push()
+                    .setRemote("origin")
+                    .add("feature")
+                    .setCredentialsProvider(
+                            new UsernamePasswordCredentialsProvider(gitlab.getUsername(), gitlab.getPassword()))
+                    .call();
         }
 
         return commit.getName();
@@ -255,7 +276,8 @@ public class GitLabIT {
 
     private String getDocker0Ip() {
         try {
-            Enumeration<InetAddress> docker0Addresses = NetworkInterface.getByName("docker0").getInetAddresses();
+            Enumeration<InetAddress> docker0Addresses =
+                    NetworkInterface.getByName("docker0").getInetAddresses();
             while (docker0Addresses.hasMoreElements()) {
                 InetAddress inetAddress = docker0Addresses.nextElement();
                 if (inetAddress instanceof Inet4Address && !inetAddress.isLoopbackAddress()) {

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/filter/MergeRequestLabelFilterImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/filter/MergeRequestLabelFilterImplTest.java
@@ -33,7 +33,8 @@ public class MergeRequestLabelFilterImplTest {
 
     @Test
     public void includeAndExcludeLabels() {
-        MergeRequestLabelFilterImpl mergeRequestLabelFilter = new MergeRequestLabelFilterImpl("include, include2", "exclude, exclude2");
+        MergeRequestLabelFilterImpl mergeRequestLabelFilter =
+                new MergeRequestLabelFilterImpl("include, include2", "exclude, exclude2");
 
         assertThat(mergeRequestLabelFilter.isMergeRequestAllowed(Collections.singleton("include")), is(true));
         assertThat(mergeRequestLabelFilter.isMergeRequestAllowed(Collections.singleton("include2")), is(true));

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/filter/NameBasedFilterTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/filter/NameBasedFilterTest.java
@@ -10,55 +10,55 @@ import org.junit.Test;
  */
 public class NameBasedFilterTest {
 
-	@Test
-	public void includeBranches() {
-		NameBasedFilter nameBasedFilter = new NameBasedFilter("master, develop", "");
+    @Test
+    public void includeBranches() {
+        NameBasedFilter nameBasedFilter = new NameBasedFilter("master, develop", "");
 
-		assertThat(nameBasedFilter.isBranchAllowed(null, "master"), is(true));
-		assertThat(nameBasedFilter.isBranchAllowed(null, "develop"), is(true));
-		assertThat(nameBasedFilter.isBranchAllowed(null, "not-included-branch"), is(false));
-	}
+        assertThat(nameBasedFilter.isBranchAllowed(null, "master"), is(true));
+        assertThat(nameBasedFilter.isBranchAllowed(null, "develop"), is(true));
+        assertThat(nameBasedFilter.isBranchAllowed(null, "not-included-branch"), is(false));
+    }
 
-	@Test
-	public void excludeBranches() {
-		NameBasedFilter nameBasedFilter = new NameBasedFilter("", "master, develop");
+    @Test
+    public void excludeBranches() {
+        NameBasedFilter nameBasedFilter = new NameBasedFilter("", "master, develop");
 
-		assertThat(nameBasedFilter.isBranchAllowed(null, "master"), is(false));
-		assertThat(nameBasedFilter.isBranchAllowed(null, "develop"), is(false));
-		assertThat(nameBasedFilter.isBranchAllowed(null, "not-excluded-branch"), is(true));
-	}
+        assertThat(nameBasedFilter.isBranchAllowed(null, "master"), is(false));
+        assertThat(nameBasedFilter.isBranchAllowed(null, "develop"), is(false));
+        assertThat(nameBasedFilter.isBranchAllowed(null, "not-excluded-branch"), is(true));
+    }
 
-	@Test
-	public void includeAndExcludeBranches() {
-		NameBasedFilter nameBasedFilter = new NameBasedFilter("master", "develop");
+    @Test
+    public void includeAndExcludeBranches() {
+        NameBasedFilter nameBasedFilter = new NameBasedFilter("master", "develop");
 
-		assertThat(nameBasedFilter.isBranchAllowed(null, "master"), is(true));
-		assertThat(nameBasedFilter.isBranchAllowed(null, "develop"), is(false));
-		assertThat(nameBasedFilter.isBranchAllowed(null, "not-excluded-and-not-included-branch"), is(false));
-	}
+        assertThat(nameBasedFilter.isBranchAllowed(null, "master"), is(true));
+        assertThat(nameBasedFilter.isBranchAllowed(null, "develop"), is(false));
+        assertThat(nameBasedFilter.isBranchAllowed(null, "not-excluded-and-not-included-branch"), is(false));
+    }
 
-	@Test
-	public void allowIncludeAndExcludeToBeNull() {
-		NameBasedFilter nameBasedFilter = new NameBasedFilter(null, null);
+    @Test
+    public void allowIncludeAndExcludeToBeNull() {
+        NameBasedFilter nameBasedFilter = new NameBasedFilter(null, null);
 
-		assertThat(nameBasedFilter.isBranchAllowed(null, "master"), is(true));
-	}
+        assertThat(nameBasedFilter.isBranchAllowed(null, "master"), is(true));
+    }
 
-	@Test
-	public void allowIncludeToBeNull() {
-		NameBasedFilter nameBasedFilter = new NameBasedFilter(null, "master, develop");
+    @Test
+    public void allowIncludeToBeNull() {
+        NameBasedFilter nameBasedFilter = new NameBasedFilter(null, "master, develop");
 
-		assertThat(nameBasedFilter.isBranchAllowed(null, "master"), is(false));
-		assertThat(nameBasedFilter.isBranchAllowed(null, "develop"), is(false));
-		assertThat(nameBasedFilter.isBranchAllowed(null, "not-excluded-branch"), is(true));
-	}
+        assertThat(nameBasedFilter.isBranchAllowed(null, "master"), is(false));
+        assertThat(nameBasedFilter.isBranchAllowed(null, "develop"), is(false));
+        assertThat(nameBasedFilter.isBranchAllowed(null, "not-excluded-branch"), is(true));
+    }
 
-	@Test
-	public void allowExcludeToBeNull() {
-		NameBasedFilter nameBasedFilter = new NameBasedFilter("master, develop", null);
+    @Test
+    public void allowExcludeToBeNull() {
+        NameBasedFilter nameBasedFilter = new NameBasedFilter("master, develop", null);
 
-		assertThat(nameBasedFilter.isBranchAllowed(null, "master"), is(true));
-		assertThat(nameBasedFilter.isBranchAllowed(null, "develop"), is(true));
-		assertThat(nameBasedFilter.isBranchAllowed(null, "not-included-branch"), is(false));
-	}
+        assertThat(nameBasedFilter.isBranchAllowed(null, "master"), is(true));
+        assertThat(nameBasedFilter.isBranchAllowed(null, "develop"), is(true));
+        assertThat(nameBasedFilter.isBranchAllowed(null, "not-included-branch"), is(false));
+    }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/filter/RegexBasedFilterTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/filter/RegexBasedFilterTest.java
@@ -15,23 +15,23 @@ import org.junit.runner.RunWith;
 @RunWith(Theories.class)
 public class RegexBasedFilterTest {
 
-	@DataPoints("matching-branches")
-	public static String[] matchingBranchNames = {"feature/test", "feature/awesome-feature"};
+    @DataPoints("matching-branches")
+    public static String[] matchingBranchNames = {"feature/test", "feature/awesome-feature"};
 
-	@DataPoints("not-matching-branches")
-	public static String[] notMatchingBranchNames = {"hotfix/test", "hotfix/awesome-feature", "master", "develop"};
+    @DataPoints("not-matching-branches")
+    public static String[] notMatchingBranchNames = {"hotfix/test", "hotfix/awesome-feature", "master", "develop"};
 
-	@Theory
-	public void isRegexBranchAllowed(@FromDataPoints("matching-branches") String branchName) {
-		RegexBasedFilter featureBranches = new RegexBasedFilter(null, "feature/.*");
+    @Theory
+    public void isRegexBranchAllowed(@FromDataPoints("matching-branches") String branchName) {
+        RegexBasedFilter featureBranches = new RegexBasedFilter(null, "feature/.*");
 
-		assertThat(featureBranches.isBranchAllowed(null, branchName), is(true));
-	}
+        assertThat(featureBranches.isBranchAllowed(null, branchName), is(true));
+    }
 
-	@Theory
-	public void isRegexBranchNotAllowed(@FromDataPoints("not-matching-branches") String branchName) {
-		RegexBasedFilter featureBranches = new RegexBasedFilter(null, "feature/.*");
+    @Theory
+    public void isRegexBranchNotAllowed(@FromDataPoints("not-matching-branches") String branchName) {
+        RegexBasedFilter featureBranches = new RegexBasedFilter(null, "feature/.*");
 
-		assertThat(featureBranches.isBranchAllowed(null, branchName), is(false));
-	}
+        assertThat(featureBranches.isBranchAllowed(null, branchName), is(false));
+    }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/PendingBuildsHandlerTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/PendingBuildsHandlerTest.java
@@ -76,14 +76,22 @@ public class PendingBuildsHandlerTest {
 
     @Test
     public void projectCanBeConfiguredToSendPendingBuildStatusWhenTriggered() throws IOException {
-        Project project = freestyleProject("freestyleProject1", new GitLabCommitStatusPublisher(GITLAB_BUILD_NAME, false));
+        Project project =
+                freestyleProject("freestyleProject1", new GitLabCommitStatusPublisher(GITLAB_BUILD_NAME, false));
 
         GitLabPushTrigger gitLabPushTrigger = gitLabPushTrigger(project);
 
         gitLabPushTrigger.onPost(pushHook(1, "branch1", "commit1"));
 
-        verify(gitLabClient).changeBuildStatus(eq(1), eq("commit1"), eq(BuildState.pending), eq("branch1"), eq(GITLAB_BUILD_NAME),
-            contains("/freestyleProject1/"), eq(BuildState.pending.name()));
+        verify(gitLabClient)
+                .changeBuildStatus(
+                        eq(1),
+                        eq("commit1"),
+                        eq(BuildState.pending),
+                        eq("branch1"),
+                        eq(GITLAB_BUILD_NAME),
+                        contains("/freestyleProject1/"),
+                        eq(BuildState.pending.name()));
         verifyNoMoreInteractions(gitLabClient);
     }
 
@@ -91,13 +99,20 @@ public class PendingBuildsHandlerTest {
     public void workflowJobCanConfiguredToSendToPendingBuildStatusWhenTriggered() throws IOException {
         WorkflowJob workflowJob = workflowJob();
 
-        GitLabPushTrigger gitLabPushTrigger =  gitLabPushTrigger(workflowJob);
+        GitLabPushTrigger gitLabPushTrigger = gitLabPushTrigger(workflowJob);
         gitLabPushTrigger.setPendingBuildName(GITLAB_BUILD_NAME);
 
         gitLabPushTrigger.onPost(mergeRequestHook(1, "branch1", "commit1"));
 
-        verify(gitLabClient).changeBuildStatus(eq(1), eq("commit1"), eq(BuildState.pending), eq("branch1"), eq(GITLAB_BUILD_NAME),
-            contains("/workflowJob/"), eq(BuildState.pending.name()));
+        verify(gitLabClient)
+                .changeBuildStatus(
+                        eq(1),
+                        eq("commit1"),
+                        eq(BuildState.pending),
+                        eq("branch1"),
+                        eq(GITLAB_BUILD_NAME),
+                        contains("/workflowJob/"),
+                        eq(BuildState.pending.name()));
         verifyNoMoreInteractions(gitLabClient);
     }
 
@@ -116,10 +131,24 @@ public class PendingBuildsHandlerTest {
         gitLabPushTrigger.onPost(mergeRequestHook(1, "anotherBranch", "commit4"));
         gitLabPushTrigger.onPost(mergeRequestHook(2, "sourceBranch", "commit5"));
 
-        verify(gitLabClient).changeBuildStatus(eq(1), eq("commit1"), eq(BuildState.canceled), eq("sourceBranch"),
-            eq("Jenkins"), contains("project1"), eq(BuildState.canceled.name()));
-        verify(gitLabClient).changeBuildStatus(eq(1), eq("commit2"), eq(BuildState.canceled), eq("sourceBranch"),
-            eq("Jenkins"), contains("project1"), eq(BuildState.canceled.name()));
+        verify(gitLabClient)
+                .changeBuildStatus(
+                        eq(1),
+                        eq("commit1"),
+                        eq(BuildState.canceled),
+                        eq("sourceBranch"),
+                        eq("Jenkins"),
+                        contains("project1"),
+                        eq(BuildState.canceled.name()));
+        verify(gitLabClient)
+                .changeBuildStatus(
+                        eq(1),
+                        eq("commit2"),
+                        eq(BuildState.canceled),
+                        eq("sourceBranch"),
+                        eq("Jenkins"),
+                        contains("project1"),
+                        eq(BuildState.canceled.name()));
 
         assertThat(jenkins.getInstance().getQueue().getItems().length, is(3));
     }
@@ -150,65 +179,67 @@ public class PendingBuildsHandlerTest {
 
     private MergeRequestHook mergeRequestHook(int projectId, String branch, String commitId) {
         return MergeRequestHookBuilder.mergeRequestHook()
-            .withObjectAttributes(mergeRequestObjectAttributes()
-                .withAction(Action.update)
-                .withState(State.updated)
-                .withIid(1)
-                .withTitle("test")
-                .withTargetProjectId(1)
-                .withTargetBranch("targetBranch")
-                .withSourceBranch(branch)
-                .withSourceProjectId(projectId)
-                .withLastCommit(commit().withAuthor(user().withName("author").build()).withId(commitId).build())
-                .withSource(ProjectBuilder.project()
-                    .withName("test")
-                    .withNamespace("test-namespace")
-                    .withHomepage("https://gitlab.org/test")
-                    .withUrl("git@gitlab.org:test.git")
-                    .withSshUrl("git@gitlab.org:test.git")
-                    .withHttpUrl("https://gitlab.org/test.git")
-                    .build())
-                .withTarget(ProjectBuilder.project()
-                    .withName("test")
-                    .withNamespace("test-namespace")
-                    .withHomepage("https://gitlab.org/test")
-                    .withUrl("git@gitlab.org:test.git")
-                    .withSshUrl("git@gitlab.org:test.git")
-                    .withHttpUrl("https://gitlab.org/test.git")
-                    .build())
-                .build())
-            .withProject(ProjectBuilder.project()
-                .withWebUrl("https://gitlab.org/test.git")
-                .build()
-            )
-            .build();
+                .withObjectAttributes(mergeRequestObjectAttributes()
+                        .withAction(Action.update)
+                        .withState(State.updated)
+                        .withIid(1)
+                        .withTitle("test")
+                        .withTargetProjectId(1)
+                        .withTargetBranch("targetBranch")
+                        .withSourceBranch(branch)
+                        .withSourceProjectId(projectId)
+                        .withLastCommit(
+                                commit().withAuthor(user().withName("author").build())
+                                        .withId(commitId)
+                                        .build())
+                        .withSource(ProjectBuilder.project()
+                                .withName("test")
+                                .withNamespace("test-namespace")
+                                .withHomepage("https://gitlab.org/test")
+                                .withUrl("git@gitlab.org:test.git")
+                                .withSshUrl("git@gitlab.org:test.git")
+                                .withHttpUrl("https://gitlab.org/test.git")
+                                .build())
+                        .withTarget(ProjectBuilder.project()
+                                .withName("test")
+                                .withNamespace("test-namespace")
+                                .withHomepage("https://gitlab.org/test")
+                                .withUrl("git@gitlab.org:test.git")
+                                .withSshUrl("git@gitlab.org:test.git")
+                                .withHttpUrl("https://gitlab.org/test.git")
+                                .build())
+                        .build())
+                .withProject(ProjectBuilder.project()
+                        .withWebUrl("https://gitlab.org/test.git")
+                        .build())
+                .build();
     }
 
     private PushHook pushHook(int projectId, String branch, String commitId) {
-        User user = new UserBuilder()
-            .withName("username")
-            .build();
+        User user = new UserBuilder().withName("username").build();
 
         Repository repository = new RepositoryBuilder()
-            .withName("repository")
-            .withGitSshUrl("sshUrl")
-            .withGitHttpUrl("httpUrl")
-            .build();
+                .withName("repository")
+                .withGitSshUrl("sshUrl")
+                .withGitHttpUrl("httpUrl")
+                .build();
 
         return new PushHookBuilder()
-            .withProjectId(projectId)
-            .withRef(branch)
-            .withAfter(commitId)
-            .withRepository(new Repository())
-            .withProject(ProjectBuilder.project().withNamespace("namespace").build())
-            .withCommits(Arrays.asList(CommitBuilder.commit().withId(commitId).withAuthor(user).build()))
-            .withRepository(repository)
-            .withObjectKind("push")
-            .withUserName("username")
-            .build();
+                .withProjectId(projectId)
+                .withRef(branch)
+                .withAfter(commitId)
+                .withRepository(new Repository())
+                .withProject(ProjectBuilder.project().withNamespace("namespace").build())
+                .withCommits(Arrays.asList(
+                        CommitBuilder.commit().withId(commitId).withAuthor(user).build()))
+                .withRepository(repository)
+                .withObjectKind("push")
+                .withUserName("username")
+                .build();
     }
 
-    private Project freestyleProject(String name, GitLabCommitStatusPublisher gitLabCommitStatusPublisher) throws IOException {
+    private Project freestyleProject(String name, GitLabCommitStatusPublisher gitLabCommitStatusPublisher)
+            throws IOException {
         FreeStyleProject project = jenkins.createFreeStyleProject(name);
         project.setQuietPeriod(5000);
         project.getPublishersList().add(gitLabCommitStatusPublisher);

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
@@ -74,302 +74,325 @@ public class MergeRequestHookTriggerHandlerImplTest {
 
     @Test
     public void mergeRequest_ciSkip() throws IOException, InterruptedException {
-        assertThat(ciSkipTestHelper("enable build","enable build"), is(true));
-        assertThat(ciSkipTestHelper("garbage [ci-skip] garbage","enable build"), is(false));
-        assertThat(ciSkipTestHelper("enable build","garbage [ci-skip] garbage"), is(false));
+        assertThat(ciSkipTestHelper("enable build", "enable build"), is(true));
+        assertThat(ciSkipTestHelper("garbage [ci-skip] garbage", "enable build"), is(false));
+        assertThat(ciSkipTestHelper("enable build", "garbage [ci-skip] garbage"), is(false));
     }
 
     @Test
-    public void mergeRequest_build_when_opened_with_source() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_when_opened_with_source()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
-            .build();
+                .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.opened);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_build_when_opened_with_both() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_when_opened_with_both()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
-            .build();
+                .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.opened);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_build_when_opened_with_never() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_when_opened_with_never()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.never)
-            .build();
+                .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.never)
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.opened, Action.update);
 
         assertThat(buildTriggered.isSignaled(), is(false));
     }
 
     @Test
-    public void mergeRequest_build_when_reopened() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .build();
+    public void mergeRequest_build_when_reopened()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler =
+                withConfig().build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.reopened);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_build_when_opened_with_approved_action_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_when_opened_with_approved_action_enabled()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnApprovedMergeRequest(true)
-            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
-            .build();
+                .setTriggerOnApprovedMergeRequest(true)
+                .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.opened);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_build_when_accepted() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnAcceptedMergeRequest(true)
-            .build();
+    public void mergeRequest_build_when_accepted()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler =
+                withConfig().setTriggerOnAcceptedMergeRequest(true).build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.merged, Action.merge);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_build_when_accepted_with_approved_action_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_when_accepted_with_approved_action_enabled()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnAcceptedMergeRequest(true)
-            .setTriggerOnApprovedMergeRequest(true)
-            .build();
+                .setTriggerOnAcceptedMergeRequest(true)
+                .setTriggerOnApprovedMergeRequest(true)
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.merged, Action.merge);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
-
     @Test
-    public void mergeRequest_build_when_closed() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnClosedMergeRequest(true)
-            .build();
+    public void mergeRequest_build_when_closed()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler =
+                withConfig().setTriggerOnClosedMergeRequest(true).build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.closed, Action.close);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_build_when_close() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnClosedMergeRequest(true)
-            .build();
+    public void mergeRequest_build_when_close()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler =
+                withConfig().setTriggerOnClosedMergeRequest(true).build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, Action.close);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_build_when_closed_with_actions_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_when_closed_with_actions_enabled()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnClosedMergeRequest(true)
-            .setTriggerOnApprovedMergeRequest(true)
-            .build();
+                .setTriggerOnClosedMergeRequest(true)
+                .setTriggerOnApprovedMergeRequest(true)
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.closed, Action.close);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_do_not_build_for_accepted_when_nothing_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_do_not_build_for_accepted_when_nothing_enabled()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         do_not_build_for_state_when_nothing_enabled(State.merged);
     }
 
     @Test
-    public void mergeRequest_do_not_build_for_updated_when_nothing_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_do_not_build_for_updated_when_nothing_enabled()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         do_not_build_for_state_when_nothing_enabled(State.updated);
     }
 
     @Test
-    public void mergeRequest_do_not_build_for_reopened_when_nothing_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_do_not_build_for_reopened_when_nothing_enabled()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         do_not_build_for_state_when_nothing_enabled(State.reopened);
     }
 
     @Test
-    public void mergeRequest_do_not_build_for_opened_when_nothing_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_do_not_build_for_opened_when_nothing_enabled()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         do_not_build_for_state_when_nothing_enabled(State.opened);
     }
 
     @Test
-    public void mergeRequest_do_not_build_when_accepted_some_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_do_not_build_when_accepted_some_enabled()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
-            .setTriggerOnApprovedMergeRequest(true)
-            .build();
+                .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
+                .setTriggerOnApprovedMergeRequest(true)
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.merged);
 
         assertThat(buildTriggered.isSignaled(), is(false));
     }
 
     @Test
-    public void mergeRequest_build_for_accepted_state_when_approved_action_triggered() throws IOException, InterruptedException, GitAPIException {
+    public void mergeRequest_build_for_accepted_state_when_approved_action_triggered()
+            throws IOException, InterruptedException, GitAPIException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnApprovedMergeRequest(true)
-            .setTriggerOnAcceptedMergeRequest(true)
-            .build();
+                .setTriggerOnApprovedMergeRequest(true)
+                .setTriggerOnAcceptedMergeRequest(true)
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.merged, Action.approved);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_do_not_build_when_closed() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_do_not_build_when_closed()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
-            .setTriggerOnApprovedMergeRequest(true)
-            .build();
+                .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
+                .setTriggerOnApprovedMergeRequest(true)
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.closed);
 
         assertThat(buildTriggered.isSignaled(), is(false));
     }
 
     @Test
-    public void mergeRequest_do_not_build_for_updated_state_and_approved_action_when_both_not_enabled() throws IOException, InterruptedException, GitAPIException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .build();
-        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
-
-        assertThat(buildTriggered.isSignaled(), is(false));
-    }
-
-    @Test
-    public void mergeRequest_do_not_build_for_updated_state_and_approved_action_when_updated_enabled_but_approved_not() throws IOException, InterruptedException, GitAPIException {
+    public void mergeRequest_do_not_build_for_updated_state_and_approved_action_when_both_not_enabled()
+            throws IOException, InterruptedException, GitAPIException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler =
-            withConfig()
+                withConfig().build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
+
+        assertThat(buildTriggered.isSignaled(), is(false));
+    }
+
+    @Test
+    public void mergeRequest_do_not_build_for_updated_state_and_approved_action_when_updated_enabled_but_approved_not()
+            throws IOException, InterruptedException, GitAPIException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler =
+                withConfig().build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
+
+        assertThat(buildTriggered.isSignaled(), is(false));
+    }
+
+    @Test
+    public void mergeRequest_build_for_update_state_when_updated_state_and_approved_action_enabled()
+            throws IOException, InterruptedException, GitAPIException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler =
+                withConfig().setTriggerOnApprovedMergeRequest(true).build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
+
+        assertThat(buildTriggered.isSignaled(), is(true));
+    }
+
+    @Test
+    public void mergeRequest_build_for_update_state_and_action_when_updated_state_and_approved_action_enabled()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+                .setTriggerOnApprovedMergeRequest(true)
+                .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
                 .build();
-        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
-
-        assertThat(buildTriggered.isSignaled(), is(false));
-    }
-
-    @Test
-    public void mergeRequest_build_for_update_state_when_updated_state_and_approved_action_enabled() throws IOException, InterruptedException, GitAPIException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnApprovedMergeRequest(true)
-            .build();
-        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
-
-        assertThat(buildTriggered.isSignaled(), is(true));
-    }
-
-    @Test
-    public void mergeRequest_build_for_update_state_and_action_when_updated_state_and_approved_action_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnApprovedMergeRequest(true)
-            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
-            .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.update);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_do_not_build_for_update_state_and_action_when_opened_state_and_approved_action_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnApprovedMergeRequest(true)
-            .build();
+    public void mergeRequest_do_not_build_for_update_state_and_action_when_opened_state_and_approved_action_enabled()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler =
+                withConfig().setTriggerOnApprovedMergeRequest(true).build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.update);
 
         assertThat(buildTriggered.isSignaled(), is(false));
     }
 
     @Test
-    public void mergeRequest_build_for_update_state_when_updated_state_and_merge_action() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnAcceptedMergeRequest(true)
-            .build();
+    public void mergeRequest_build_for_update_state_when_updated_state_and_merge_action()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler =
+                withConfig().setTriggerOnAcceptedMergeRequest(true).build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.merge);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_build_for_approved_action_when_opened_state_and_approved_action_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnApprovedMergeRequest(true)
-            .build();
+    public void mergeRequest_build_for_approved_action_when_opened_state_and_approved_action_enabled()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler =
+                withConfig().setTriggerOnApprovedMergeRequest(true).build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_build_for_approved_action_when_only_approved_enabled() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_for_approved_action_when_only_approved_enabled()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnMergeRequest(false)
-            .setTriggerOnApprovedMergeRequest(true)
-            .build();
+                .setTriggerOnMergeRequest(false)
+                .setTriggerOnApprovedMergeRequest(true)
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.approved);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_build_when_new_commits_were_pushed_state_opened_action_open() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_when_new_commits_were_pushed_state_opened_action_open()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnMergeRequest(true)
-            .setTriggerOnlyIfNewCommitsPushed(true)
-            .build();
+                .setTriggerOnMergeRequest(true)
+                .setTriggerOnlyIfNewCommitsPushed(true)
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.opened, Action.open);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_build_when_new_commits_were_pushed_state_reopened_action_reopen() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_when_new_commits_were_pushed_state_reopened_action_reopen()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnMergeRequest(true)
-            .setTriggerOnlyIfNewCommitsPushed(true)
-            .build();
+                .setTriggerOnMergeRequest(true)
+                .setTriggerOnlyIfNewCommitsPushed(true)
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.reopened, Action.reopen);
 
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void mergeRequest_build_when_new_commits_were_pushed_do_not_build_without_commits() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_when_new_commits_were_pushed_do_not_build_without_commits()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnMergeRequest(true)
-            .setTriggerOnlyIfNewCommitsPushed(true)
-            .build();
+                .setTriggerOnMergeRequest(true)
+                .setTriggerOnlyIfNewCommitsPushed(true)
+                .build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, State.updated, Action.update);
 
         assertThat(buildTriggered.isSignaled(), is(false));
     }
 
     @Test
-    public void mergeRequest_build_only_when_approved_and_not_when_updated() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_only_when_approved_and_not_when_updated()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         mergeRequest_build_only_when_approved(Action.update);
     }
 
     @Test
-    public void mergeRequest_build_only_when_approved_and_not_when_opened() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_only_when_approved_and_not_when_opened()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         mergeRequest_build_only_when_approved(Action.open);
     }
 
     @Test
-    public void mergeRequest_build_only_when_approved_and_not_when_merge() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_only_when_approved_and_not_when_merge()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         mergeRequest_build_only_when_approved(Action.merge);
     }
 
     @Test
-    public void mergeRequest_build_only_when_state_modified()throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void mergeRequest_build_only_when_state_modified()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnAcceptedMergeRequest(true)
-            .setTriggerOnClosedMergeRequest(true)
-            .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
-            .build();
+                .setTriggerOnAcceptedMergeRequest(true)
+                .setTriggerOnClosedMergeRequest(true)
+                .setTriggerOpenMergeRequest(TriggerOpenMergeRequest.source)
+                .build();
         Git.init().setDirectory(tmp.getRoot()).call();
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());
@@ -383,80 +406,108 @@ public class MergeRequestHookTriggerHandlerImplTest {
         project.setScm(new GitSCM(repositoryUrl));
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildTriggered.signal();
                 return true;
             }
         });
         project.setQuietPeriod(0);
-        MergeRequestObjectAttributesBuilder objectAttributes = defaultMergeRequestObjectAttributes().withAction(Action.update);
-        mergeRequestHookTriggerHandler.handle(project, mergeRequestHook()
-                .withObjectAttributes(objectAttributes
-                    .withTargetBranch("refs/heads/" + git.nameRev().add(head).call().get(head))
-                    .withLastCommit(commit().withAuthor(user().withName("test").build()).withId(commit.getName()).build())
-                    .build())
-                .withProject(project()
-                    .withWebUrl("https://gitlab.org/test.git")
-                    .build()
-                )
-                .build(), true, BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-            newMergeRequestLabelFilter(null));
+        MergeRequestObjectAttributesBuilder objectAttributes =
+                defaultMergeRequestObjectAttributes().withAction(Action.update);
+        mergeRequestHookTriggerHandler.handle(
+                project,
+                mergeRequestHook()
+                        .withObjectAttributes(objectAttributes
+                                .withTargetBranch("refs/heads/"
+                                        + git.nameRev().add(head).call().get(head))
+                                .withLastCommit(commit().withAuthor(
+                                                user().withName("test").build())
+                                        .withId(commit.getName())
+                                        .build())
+                                .build())
+                        .withProject(project()
+                                .withWebUrl("https://gitlab.org/test.git")
+                                .build())
+                        .build(),
+                true,
+                BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
 
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(true));
-        MergeRequestObjectAttributesBuilder objectAttributes2 = defaultMergeRequestObjectAttributes().withState(State.merged).withAction(Action.merge);
-        mergeRequestHookTriggerHandler.handle(project, mergeRequestHook()
-                .withObjectAttributes(objectAttributes2
-                    .withTargetBranch("refs/heads/" + git.nameRev().add(head).call().get(head))
-                    .withLastCommit(commit().withAuthor(user().withName("test").build()).withId(commit.getName()).build())
-                    .build())
-                .withProject(project()
-                    .withWebUrl("https://gitlab.org/test.git")
-                    .build()
-                )
-                .build(), true, BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-            newMergeRequestLabelFilter(null));
+        MergeRequestObjectAttributesBuilder objectAttributes2 =
+                defaultMergeRequestObjectAttributes().withState(State.merged).withAction(Action.merge);
+        mergeRequestHookTriggerHandler.handle(
+                project,
+                mergeRequestHook()
+                        .withObjectAttributes(objectAttributes2
+                                .withTargetBranch("refs/heads/"
+                                        + git.nameRev().add(head).call().get(head))
+                                .withLastCommit(commit().withAuthor(
+                                                user().withName("test").build())
+                                        .withId(commit.getName())
+                                        .build())
+                                .build())
+                        .withProject(project()
+                                .withWebUrl("https://gitlab.org/test.git")
+                                .build())
+                        .build(),
+                true,
+                BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
 
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
-    private void do_not_build_for_state_when_nothing_enabled(State state) throws IOException, InterruptedException, GitAPIException, ExecutionException {
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnMergeRequest(false)
-            .build();
+    private void do_not_build_for_state_when_nothing_enabled(State state)
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler =
+                withConfig().setTriggerOnMergeRequest(false).build();
         OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, state);
 
         assertThat(buildTriggered.isSignaled(), is(false));
     }
 
-	private void mergeRequest_build_only_when_approved(Action action)
-			throws GitAPIException, IOException, InterruptedException {
-		MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
-            .setTriggerOnMergeRequest(false)
-            .setTriggerOnApprovedMergeRequest(true)
-            .build();
-	    OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, action);
+    private void mergeRequest_build_only_when_approved(Action action)
+            throws GitAPIException, IOException, InterruptedException {
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = withConfig()
+                .setTriggerOnMergeRequest(false)
+                .setTriggerOnApprovedMergeRequest(true)
+                .build();
+        OneShotEvent buildTriggered = doHandle(mergeRequestHookTriggerHandler, action);
 
-	    assertThat(buildTriggered.isSignaled(), is(false));
-	}
-
-    private OneShotEvent doHandle(MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler, Action action) throws GitAPIException, IOException, InterruptedException {
-        return doHandle(mergeRequestHookTriggerHandler, defaultMergeRequestObjectAttributes().withAction(action));
+        assertThat(buildTriggered.isSignaled(), is(false));
     }
 
-    private OneShotEvent doHandle(MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler, State state) throws GitAPIException, IOException, InterruptedException {
-        return doHandle(mergeRequestHookTriggerHandler, defaultMergeRequestObjectAttributes().withState(state));
+    private OneShotEvent doHandle(MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler, Action action)
+            throws GitAPIException, IOException, InterruptedException {
+        return doHandle(
+                mergeRequestHookTriggerHandler,
+                defaultMergeRequestObjectAttributes().withAction(action));
     }
 
-    private OneShotEvent doHandle(MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler, State state, Action action) throws GitAPIException, IOException, InterruptedException {
-        return doHandle(mergeRequestHookTriggerHandler, defaultMergeRequestObjectAttributes().withState(state).withAction(action));
+    private OneShotEvent doHandle(MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler, State state)
+            throws GitAPIException, IOException, InterruptedException {
+        return doHandle(
+                mergeRequestHookTriggerHandler,
+                defaultMergeRequestObjectAttributes().withState(state));
     }
 
-	private OneShotEvent doHandle(MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler,
-			MergeRequestObjectAttributesBuilder objectAttributes) throws GitAPIException, IOException,
-            InterruptedException {
-		Git.init().setDirectory(tmp.getRoot()).call();
+    private OneShotEvent doHandle(
+            MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler, State state, Action action)
+            throws GitAPIException, IOException, InterruptedException {
+        return doHandle(
+                mergeRequestHookTriggerHandler,
+                defaultMergeRequestObjectAttributes().withState(state).withAction(action));
+    }
+
+    private OneShotEvent doHandle(
+            MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler,
+            MergeRequestObjectAttributesBuilder objectAttributes)
+            throws GitAPIException, IOException, InterruptedException {
+        Git.init().setDirectory(tmp.getRoot()).call();
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());
         git.add().addFilepattern("test");
@@ -469,76 +520,97 @@ public class MergeRequestHookTriggerHandlerImplTest {
         project.setScm(new GitSCM(repositoryUrl));
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildTriggered.signal();
                 return true;
             }
         });
         project.setQuietPeriod(0);
-		mergeRequestHookTriggerHandler.handle(project, mergeRequestHook()
-                .withObjectAttributes(objectAttributes
-            		    .withTargetBranch("refs/heads/" + git.nameRev().add(head).call().get(head))
-            		    .withLastCommit(commit().withAuthor(user().withName("test").build()).withId(commit.getName()).build())
-                    .build())
-                .withProject(project()
-                    .withWebUrl("https://gitlab.org/test.git")
-                    .build()
-                )
-                .build(), true, BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-            newMergeRequestLabelFilter(null));
+        mergeRequestHookTriggerHandler.handle(
+                project,
+                mergeRequestHook()
+                        .withObjectAttributes(objectAttributes
+                                .withTargetBranch("refs/heads/"
+                                        + git.nameRev().add(head).call().get(head))
+                                .withLastCommit(commit().withAuthor(
+                                                user().withName("test").build())
+                                        .withId(commit.getName())
+                                        .build())
+                                .build())
+                        .withProject(project()
+                                .withWebUrl("https://gitlab.org/test.git")
+                                .build())
+                        .build(),
+                true,
+                BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
 
         buildTriggered.block(10000);
         return buildTriggered;
-	}
+    }
 
-    private boolean ciSkipTestHelper(String MRDescription, String lastCommitMsg) throws IOException, InterruptedException {
+    private boolean ciSkipTestHelper(String MRDescription, String lastCommitMsg)
+            throws IOException, InterruptedException {
         final OneShotEvent buildTriggered = new OneShotEvent();
         FreeStyleProject project = jenkins.createFreeStyleProject();
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildTriggered.signal();
                 return true;
             }
         });
         project.setQuietPeriod(0);
-        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(Arrays.asList(State.opened, State.reopened), Arrays.asList(Action.approved), false, false, false);
-        mergeRequestHookTriggerHandler.handle(project, mergeRequestHook()
-                .withObjectAttributes(defaultMergeRequestObjectAttributes().withDescription(MRDescription).withLastCommit(commit().withMessage(lastCommitMsg).withAuthor(user().withName("test").build()).withId("testid").build()).build())
-                .build(), true, BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-            newMergeRequestLabelFilter(null));
+        MergeRequestHookTriggerHandler mergeRequestHookTriggerHandler = new MergeRequestHookTriggerHandlerImpl(
+                Arrays.asList(State.opened, State.reopened), Arrays.asList(Action.approved), false, false, false);
+        mergeRequestHookTriggerHandler.handle(
+                project,
+                mergeRequestHook()
+                        .withObjectAttributes(defaultMergeRequestObjectAttributes()
+                                .withDescription(MRDescription)
+                                .withLastCommit(commit().withMessage(lastCommitMsg)
+                                        .withAuthor(user().withName("test").build())
+                                        .withId("testid")
+                                        .build())
+                                .build())
+                        .build(),
+                true,
+                BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
 
         buildTriggered.block(10000);
         return buildTriggered.isSignaled();
     }
 
-	private MergeRequestObjectAttributesBuilder defaultMergeRequestObjectAttributes() {
-		return mergeRequestObjectAttributes()
-		    .withIid(1)
-            .withAction(Action.open)
-            .withState(State.opened)
-		    .withTitle("test")
-		    .withTargetProjectId(1)
-		    .withSourceProjectId(1)
-		    .withSourceBranch("feature")
-		    .withTargetBranch("master")
-		    .withSource(project()
-		        .withName("test")
-		        .withNamespace("test-namespace")
-		        .withHomepage("https://gitlab.org/test")
-		        .withUrl("git@gitlab.org:test.git")
-		        .withSshUrl("git@gitlab.org:test.git")
-		        .withHttpUrl("https://gitlab.org/test.git")
-		        .build())
-		    .withTarget(project()
-		        .withName("test")
-		        .withNamespace("test-namespace")
-		        .withHomepage("https://gitlab.org/test")
-		        .withUrl("git@gitlab.org:test.git")
-		        .withSshUrl("git@gitlab.org:test.git")
-		        .withHttpUrl("https://gitlab.org/test.git")
-		        .build());
-	}
+    private MergeRequestObjectAttributesBuilder defaultMergeRequestObjectAttributes() {
+        return mergeRequestObjectAttributes()
+                .withIid(1)
+                .withAction(Action.open)
+                .withState(State.opened)
+                .withTitle("test")
+                .withTargetProjectId(1)
+                .withSourceProjectId(1)
+                .withSourceBranch("feature")
+                .withTargetBranch("master")
+                .withSource(project()
+                        .withName("test")
+                        .withNamespace("test-namespace")
+                        .withHomepage("https://gitlab.org/test")
+                        .withUrl("git@gitlab.org:test.git")
+                        .withSshUrl("git@gitlab.org:test.git")
+                        .withHttpUrl("https://gitlab.org/test.git")
+                        .build())
+                .withTarget(project()
+                        .withName("test")
+                        .withNamespace("test-namespace")
+                        .withHomepage("https://gitlab.org/test")
+                        .withUrl("git@gitlab.org:test.git")
+                        .withSshUrl("git@gitlab.org:test.git")
+                        .withHttpUrl("https://gitlab.org/test.git")
+                        .build());
+    }
 
     @After
     public void after() {

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImplTest.java
@@ -60,26 +60,33 @@ public class NoteHookTriggerHandlerImplTest {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildTriggered.signal();
                 return true;
             }
         });
         Date currentDate = new Date();
         project.setQuietPeriod(0);
-        noteHookTriggerHandler.handle(project, noteHook()
-                .withObjectAttributes(noteObjectAttributes()
-                    .withId(1)
-                    .withNote("ci-run")
-                    .withAuthorId(1)
-                    .withProjectId(1)
-                    .withCreatedAt(currentDate)
-                    .withUpdatedAt(currentDate)
-                    .withUrl("https://gitlab.org/test/merge_requests/1#note_1")
-                    .build())
-                .withMergeRequest(mergeRequestObjectAttributes().withDescription("[ci-skip]").build())
-                .build(), true, BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-                                      newMergeRequestLabelFilter(null));
+        noteHookTriggerHandler.handle(
+                project,
+                noteHook()
+                        .withObjectAttributes(noteObjectAttributes()
+                                .withId(1)
+                                .withNote("ci-run")
+                                .withAuthorId(1)
+                                .withProjectId(1)
+                                .withCreatedAt(currentDate)
+                                .withUpdatedAt(currentDate)
+                                .withUrl("https://gitlab.org/test/merge_requests/1#note_1")
+                                .build())
+                        .withMergeRequest(mergeRequestObjectAttributes()
+                                .withDescription("[ci-skip]")
+                                .build())
+                        .build(),
+                true,
+                BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
 
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(false));
@@ -100,53 +107,62 @@ public class NoteHookTriggerHandlerImplTest {
         project.setScm(new GitSCM(repositoryUrl));
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildTriggered.signal();
                 return true;
             }
         });
         Date currentDate = new Date();
         project.setQuietPeriod(0);
-        noteHookTriggerHandler.handle(project, noteHook()
-                .withObjectAttributes(noteObjectAttributes()
-                    .withId(1)
-                    .withNote("ci-run")
-                    .withAuthorId(1)
-                    .withProjectId(1)
-                    .withCreatedAt(currentDate)
-                    .withUpdatedAt(currentDate)
-                    .withUrl("https://gitlab.org/test/merge_requests/1#note_1")
-                    .build())
-                .withMergeRequest(mergeRequestObjectAttributes()
-                    .withTargetBranch("refs/heads/" + git.nameRev().add(head).call().get(head))
-                    .withState(State.opened)
-                    .withIid(1)
-                    .withTitle("test")
-                    .withTargetProjectId(1)
-                    .withSourceProjectId(1)
-                    .withSourceBranch("feature")
-                    .withTargetBranch("master")
-                    .withLastCommit(commit().withAuthor(user().withName("test").build()).withId(commit.getName()).build())
-                    .withSource(project()
-                        .withName("test")
-                        .withNamespace("test-namespace")
-                        .withHomepage("https://gitlab.org/test")
-                        .withUrl("git@gitlab.org:test.git")
-                        .withSshUrl("git@gitlab.org:test.git")
-                        .withHttpUrl("https://gitlab.org/test.git")
-                        .build())
-                    .withTarget(project()
-                        .withName("test")
-                        .withNamespace("test-namespace")
-                        .withHomepage("https://gitlab.org/test")
-                        .withUrl("git@gitlab.org:test.git")
-                        .withSshUrl("git@gitlab.org:test.git")
-                        .withHttpUrl("https://gitlab.org/test.git")
-                        .withWebUrl("https://gitlab.org/test.git")
-                        .build())
-                    .build())
-                .build(), true, BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-                                      newMergeRequestLabelFilter(null));
+        noteHookTriggerHandler.handle(
+                project,
+                noteHook()
+                        .withObjectAttributes(noteObjectAttributes()
+                                .withId(1)
+                                .withNote("ci-run")
+                                .withAuthorId(1)
+                                .withProjectId(1)
+                                .withCreatedAt(currentDate)
+                                .withUpdatedAt(currentDate)
+                                .withUrl("https://gitlab.org/test/merge_requests/1#note_1")
+                                .build())
+                        .withMergeRequest(mergeRequestObjectAttributes()
+                                .withTargetBranch("refs/heads/"
+                                        + git.nameRev().add(head).call().get(head))
+                                .withState(State.opened)
+                                .withIid(1)
+                                .withTitle("test")
+                                .withTargetProjectId(1)
+                                .withSourceProjectId(1)
+                                .withSourceBranch("feature")
+                                .withTargetBranch("master")
+                                .withLastCommit(commit().withAuthor(
+                                                user().withName("test").build())
+                                        .withId(commit.getName())
+                                        .build())
+                                .withSource(project()
+                                        .withName("test")
+                                        .withNamespace("test-namespace")
+                                        .withHomepage("https://gitlab.org/test")
+                                        .withUrl("git@gitlab.org:test.git")
+                                        .withSshUrl("git@gitlab.org:test.git")
+                                        .withHttpUrl("https://gitlab.org/test.git")
+                                        .build())
+                                .withTarget(project()
+                                        .withName("test")
+                                        .withNamespace("test-namespace")
+                                        .withHomepage("https://gitlab.org/test")
+                                        .withUrl("git@gitlab.org:test.git")
+                                        .withSshUrl("git@gitlab.org:test.git")
+                                        .withHttpUrl("https://gitlab.org/test.git")
+                                        .withWebUrl("https://gitlab.org/test.git")
+                                        .build())
+                                .build())
+                        .build(),
+                true,
+                BranchFilterFactory.newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
 
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(true));

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImplTest.java
@@ -69,28 +69,27 @@ public class PipelineHookTriggerHandlerImplTest {
 
         pipelineHookTriggerHandler = new PipelineHookTriggerHandlerImpl(allowedStates);
         pipelineHook = pipelineHook()
-            .withUser(user)
-            .withRepository(repository()
-                .withName("test")
-                .withHomepage("https://gitlab.org/test")
-                .withUrl("git@gitlab.org:test.git")
-                .withGitSshUrl("git@gitlab.org:test.git")
-                .withGitHttpUrl("https://gitlab.org/test.git")
-                .build())
-            .withProject(project()
-                .withNamespace("test-namespace")
-                .withWebUrl("https://gitlab.org/test")
-                .withId(1)
-                .build())
-            .withObjectAttributes(pipelineEventObjectAttributes()
-                .withId(1)
-                .withStatus("success")
-                .withSha("bcbb5ec396a2c0f828686f14fac9b80b780504f2")
-                .withStages(new ArrayList<String>())
-                .withRef("refs/heads/" + git.nameRev().add(head).call().get(head))
-                .build())
-
-            .build();
+                .withUser(user)
+                .withRepository(repository()
+                        .withName("test")
+                        .withHomepage("https://gitlab.org/test")
+                        .withUrl("git@gitlab.org:test.git")
+                        .withGitSshUrl("git@gitlab.org:test.git")
+                        .withGitHttpUrl("https://gitlab.org/test.git")
+                        .build())
+                .withProject(project()
+                        .withNamespace("test-namespace")
+                        .withWebUrl("https://gitlab.org/test")
+                        .withId(1)
+                        .build())
+                .withObjectAttributes(pipelineEventObjectAttributes()
+                        .withId(1)
+                        .withStatus("success")
+                        .withSha("bcbb5ec396a2c0f828686f14fac9b80b780504f2")
+                        .withStages(new ArrayList<String>())
+                        .withRef("refs/heads/" + git.nameRev().add(head).call().get(head))
+                        .build())
+                .build();
         git.close();
     }
 
@@ -103,14 +102,19 @@ public class PipelineHookTriggerHandlerImplTest {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildTriggered.signal();
                 return true;
             }
         });
         project.setQuietPeriod(0);
-        pipelineHookTriggerHandler.handle(project, pipelineHook , true, newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-            newMergeRequestLabelFilter(null));
+        pipelineHookTriggerHandler.handle(
+                project,
+                pipelineHook,
+                true,
+                newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
 
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(true));
@@ -123,15 +127,20 @@ public class PipelineHookTriggerHandlerImplTest {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildTriggered.signal();
                 return true;
             }
         });
         project.setQuietPeriod(0);
 
-        pipelineHookTriggerHandler.handle(project, pipelineHook, false, newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-            newMergeRequestLabelFilter(null));
+        pipelineHookTriggerHandler.handle(
+                project,
+                pipelineHook,
+                false,
+                newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
 
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(true));

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerGitlabServerTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerGitlabServerTest.java
@@ -32,19 +32,21 @@ public class PushHookTriggerHandlerGitlabServerTest {
 
     @DataPoints
     public static GitLabPushRequestSamples[] samples = {
-            new GitLabPushRequestSamples_7_5_1_36679b5(),
-            new GitLabPushRequestSamples_7_10_5_489b413(),
-            new GitLabPushRequestSamples_8_1_2_8c8af7b()
+        new GitLabPushRequestSamples_7_5_1_36679b5(),
+        new GitLabPushRequestSamples_7_10_5_489b413(),
+        new GitLabPushRequestSamples_8_1_2_8c8af7b()
     };
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
     @Theory
-    public void createRevisionParameterAction_pushBrandNewMasterBranchRequest(GitLabPushRequestSamples samples) throws Exception {
+    public void createRevisionParameterAction_pushBrandNewMasterBranchRequest(GitLabPushRequestSamples samples)
+            throws Exception {
         PushHook hook = samples.pushBrandNewMasterBranchRequest();
 
-        RevisionParameterAction revisionParameterAction = new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, null);
+        RevisionParameterAction revisionParameterAction =
+                new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, null);
 
         assertThat(revisionParameterAction, is(notNullValue()));
         assertThat(revisionParameterAction.commit, is(hook.getAfter()));
@@ -52,10 +54,12 @@ public class PushHookTriggerHandlerGitlabServerTest {
     }
 
     @Theory
-    public void createRevisionParameterAction_mergeRequestMergePushRequest(GitLabPushRequestSamples samples) throws Exception {
+    public void createRevisionParameterAction_mergeRequestMergePushRequest(GitLabPushRequestSamples samples)
+            throws Exception {
         PushHook hook = samples.mergePushRequest();
 
-        RevisionParameterAction revisionParameterAction = new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, null);
+        RevisionParameterAction revisionParameterAction =
+                new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, null);
 
         assertThat(revisionParameterAction, is(notNullValue()));
         assertThat(revisionParameterAction.commit, is(hook.getAfter()));
@@ -66,7 +70,8 @@ public class PushHookTriggerHandlerGitlabServerTest {
     public void createRevisionParameterAction_pushCommitRequest(GitLabPushRequestSamples samples) throws Exception {
         PushHook hook = samples.pushCommitRequest();
 
-        RevisionParameterAction revisionParameterAction = new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, null);
+        RevisionParameterAction revisionParameterAction =
+                new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, null);
 
         assertThat(revisionParameterAction, is(notNullValue()));
         assertThat(revisionParameterAction.commit, is(hook.getAfter()));
@@ -77,7 +82,8 @@ public class PushHookTriggerHandlerGitlabServerTest {
     public void createRevisionParameterAction_pushNewBranchRequest(GitLabPushRequestSamples samples) throws Exception {
         PushHook hook = samples.pushNewBranchRequest();
 
-        RevisionParameterAction revisionParameterAction = new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, null);
+        RevisionParameterAction revisionParameterAction =
+                new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, null);
 
         assertThat(revisionParameterAction, is(notNullValue()));
         assertThat(revisionParameterAction.commit, is(hook.getAfter()));
@@ -88,7 +94,8 @@ public class PushHookTriggerHandlerGitlabServerTest {
     public void createRevisionParameterAction_pushNewTagRequest(GitLabPushRequestSamples samples) throws Exception {
         PushHook hook = samples.pushNewTagRequest();
 
-        RevisionParameterAction revisionParameterAction = new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, null);
+        RevisionParameterAction revisionParameterAction =
+                new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, null);
 
         assertThat(revisionParameterAction, is(notNullValue()));
         assertThat(revisionParameterAction.commit, is(hook.getAfter()));
@@ -96,7 +103,8 @@ public class PushHookTriggerHandlerGitlabServerTest {
     }
 
     @Theory
-    public void doNotCreateRevisionParameterAction_deleteBranchRequest(GitLabPushRequestSamples samples) throws Exception {
+    public void doNotCreateRevisionParameterAction_deleteBranchRequest(GitLabPushRequestSamples samples)
+            throws Exception {
         PushHook hook = samples.deleteBranchRequest();
 
         exception.expect(NoRevisionToBuildException.class);
@@ -108,18 +116,21 @@ public class PushHookTriggerHandlerGitlabServerTest {
         PushHook hook = samples.deleteBranchRequest();
 
         exception.expect(NoRevisionToBuildException.class);
-        RevisionParameterAction revisionParameterAction = new PushHookTriggerHandlerImpl(true).createRevisionParameter(hook, null);
+        RevisionParameterAction revisionParameterAction =
+                new PushHookTriggerHandlerImpl(true).createRevisionParameter(hook, null);
         assertThat(revisionParameterAction, is(notNullValue()));
         assertThat(revisionParameterAction.commit, is(hook.getAfter()));
         assertFalse(revisionParameterAction.canOriginateFrom(new ArrayList<RemoteConfig>()));
     }
 
     @Theory
-    public void createRevisionParameterAction_pushCommitRequestWithGitScm(GitLabPushRequestSamples samples) throws Exception {
+    public void createRevisionParameterAction_pushCommitRequestWithGitScm(GitLabPushRequestSamples samples)
+            throws Exception {
         PushHook hook = samples.pushCommitRequest();
 
         GitSCM gitSCM = new GitSCM("git@test.tld:test.git");
-        RevisionParameterAction revisionParameterAction = new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, gitSCM);
+        RevisionParameterAction revisionParameterAction =
+                new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, gitSCM);
 
         assertThat(revisionParameterAction, is(notNullValue()));
         assertThat(revisionParameterAction.commit, is(hook.getRef().replaceFirst("^refs/heads", "remotes/origin")));
@@ -127,15 +138,22 @@ public class PushHookTriggerHandlerGitlabServerTest {
     }
 
     @Theory
-    public void createRevisionParameterAction_pushCommitRequestWith2Remotes(GitLabPushRequestSamples samples) throws Exception {
+    public void createRevisionParameterAction_pushCommitRequestWith2Remotes(GitLabPushRequestSamples samples)
+            throws Exception {
         PushHook hook = samples.pushCommitRequest();
 
-        GitSCM gitSCM = new GitSCM(Arrays.asList(new UserRemoteConfig("git@test.tld:test.git", null, null, null),
-                                                 new UserRemoteConfig("git@test.tld:fork.git", "fork", null, null)),
-                                   Collections.singletonList(new BranchSpec("")),
-                                   false, Collections.<SubmoduleConfig>emptyList(),
-                                   null, null, null);
-        RevisionParameterAction revisionParameterAction = new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, gitSCM);
+        GitSCM gitSCM = new GitSCM(
+                Arrays.asList(
+                        new UserRemoteConfig("git@test.tld:test.git", null, null, null),
+                        new UserRemoteConfig("git@test.tld:fork.git", "fork", null, null)),
+                Collections.singletonList(new BranchSpec("")),
+                false,
+                Collections.<SubmoduleConfig>emptyList(),
+                null,
+                null,
+                null);
+        RevisionParameterAction revisionParameterAction =
+                new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, gitSCM);
 
         assertThat(revisionParameterAction, is(notNullValue()));
         assertThat(revisionParameterAction.commit, is(hook.getAfter()));

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImplTest.java
@@ -61,17 +61,23 @@ public class PushHookTriggerHandlerImplTest {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildTriggered.signal();
                 return true;
             }
         });
         project.setQuietPeriod(0);
-        pushHookTriggerHandler.handle(project, pushHook()
-                .withCommits(Arrays.asList(commit().withMessage("some message").build(),
-                    commit().withMessage("[ci-skip]").build()))
-                .build(), true, newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-            newMergeRequestLabelFilter(null));
+        pushHookTriggerHandler.handle(
+                project,
+                pushHook()
+                        .withCommits(Arrays.asList(
+                                commit().withMessage("some message").build(),
+                                commit().withMessage("[ci-skip]").build()))
+                        .build(),
+                true,
+                newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
 
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(false));
@@ -92,39 +98,45 @@ public class PushHookTriggerHandlerImplTest {
         project.setScm(new GitSCM(repositoryUrl));
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildTriggered.signal();
                 return true;
             }
         });
         project.setQuietPeriod(0);
-        pushHookTriggerHandler.handle(project, pushHook()
-                .withBefore("0000000000000000000000000000000000000000")
-                .withProjectId(1)
-                .withUserName("test")
-                .withObjectKind("tag_push")
-                .withRepository(repository()
-                    .withName("test")
-                    .withHomepage("https://gitlab.org/test")
-                    .withUrl("git@gitlab.org:test.git")
-                    .withGitSshUrl("git@gitlab.org:test.git")
-                    .withGitHttpUrl("https://gitlab.org/test.git")
-                    .build())
-                .withProject(project()
-                    .withNamespace("test-namespace")
-                    .withWebUrl("https://gitlab.org/test")
-                    .build())
-                .withAfter(commit.name())
-                .withRef("refs/heads/" + git.nameRev().add(head).call().get(head))
-                .build(), true, newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-            newMergeRequestLabelFilter(null));
+        pushHookTriggerHandler.handle(
+                project,
+                pushHook()
+                        .withBefore("0000000000000000000000000000000000000000")
+                        .withProjectId(1)
+                        .withUserName("test")
+                        .withObjectKind("tag_push")
+                        .withRepository(repository()
+                                .withName("test")
+                                .withHomepage("https://gitlab.org/test")
+                                .withUrl("git@gitlab.org:test.git")
+                                .withGitSshUrl("git@gitlab.org:test.git")
+                                .withGitHttpUrl("https://gitlab.org/test.git")
+                                .build())
+                        .withProject(project()
+                                .withNamespace("test-namespace")
+                                .withWebUrl("https://gitlab.org/test")
+                                .build())
+                        .withAfter(commit.name())
+                        .withRef("refs/heads/" + git.nameRev().add(head).call().get(head))
+                        .build(),
+                true,
+                newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
 
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(true));
     }
 
     @Test
-    public void push_build2DifferentBranchesButSameCommit() throws IOException, InterruptedException, GitAPIException, ExecutionException {
+    public void push_build2DifferentBranchesButSameCommit()
+            throws IOException, InterruptedException, GitAPIException, ExecutionException {
         Git.init().setDirectory(tmp.getRoot()).call();
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());
@@ -140,7 +152,8 @@ public class PushHookTriggerHandlerImplTest {
         project.setScm(new GitSCM(repositoryUrl));
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 int count = buildCount.incrementAndGet();
                 if (count == 2) {
                     buildTriggered.signal();
@@ -150,28 +163,38 @@ public class PushHookTriggerHandlerImplTest {
         });
         project.setQuietPeriod(0);
         PushHookBuilder pushHookBuilder = pushHook()
-            .withBefore("0000000000000000000000000000000000000000")
-            .withProjectId(1)
-            .withUserName("test")
-            .withObjectKind("push")
-            .withRepository(repository()
-                .withName("test")
-                .withHomepage("https://gitlab.org/test")
-                .withUrl("git@gitlab.org:test.git")
-                .withGitSshUrl("git@gitlab.org:test.git")
-                .withGitHttpUrl("https://gitlab.org/test.git")
-                .build())
-            .withProject(project()
-                .withNamespace("test-namespace")
-                .withWebUrl("https://gitlab.org/test")
-                .build())
-            .withAfter(commit.name())
-            .withRef("refs/heads/" + git.nameRev().add(head).call().get(head));
-        pushHookTriggerHandler.handle(project, pushHookBuilder.build(), true, newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
-            newMergeRequestLabelFilter(null));
-        pushHookTriggerHandler.handle(project, pushHookBuilder
-                .but().withRef("refs/heads/" + git.nameRev().add(head).call().get(head) + "-2").build(), true,
-            newBranchFilter(branchFilterConfig().build(BranchFilterType.All)), newMergeRequestLabelFilter(null));
+                .withBefore("0000000000000000000000000000000000000000")
+                .withProjectId(1)
+                .withUserName("test")
+                .withObjectKind("push")
+                .withRepository(repository()
+                        .withName("test")
+                        .withHomepage("https://gitlab.org/test")
+                        .withUrl("git@gitlab.org:test.git")
+                        .withGitSshUrl("git@gitlab.org:test.git")
+                        .withGitHttpUrl("https://gitlab.org/test.git")
+                        .build())
+                .withProject(project()
+                        .withNamespace("test-namespace")
+                        .withWebUrl("https://gitlab.org/test")
+                        .build())
+                .withAfter(commit.name())
+                .withRef("refs/heads/" + git.nameRev().add(head).call().get(head));
+        pushHookTriggerHandler.handle(
+                project,
+                pushHookBuilder.build(),
+                true,
+                newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
+        pushHookTriggerHandler.handle(
+                project,
+                pushHookBuilder
+                        .but()
+                        .withRef("refs/heads/" + git.nameRev().add(head).call().get(head) + "-2")
+                        .build(),
+                true,
+                newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
         buildTriggered.block(10000);
         assertThat(buildTriggered.isSignaled(), is(true));
         assertThat(buildCount.intValue(), is(2));

--- a/src/test/java/com/dabsquared/gitlabjenkins/util/BuildUtilTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/util/BuildUtilTest.java
@@ -25,111 +25,110 @@ import org.junit.Test;
 /**
  * @author Joshua Barker
  */
-
 public class BuildUtilTest {
 
-  private static final String SHA1 = "0616d12a3a24068691027a1e113147e3c1cfa2f4";
-  private static final String SHALIB = "a53131154f6dfc0d1642451679fb977c5ecf31c0";
-  private static final String WRONGSHA = "5f106d47c2ce17dd65774c12c0826785d16b26f7";
+    private static final String SHA1 = "0616d12a3a24068691027a1e113147e3c1cfa2f4";
+    private static final String SHALIB = "a53131154f6dfc0d1642451679fb977c5ecf31c0";
+    private static final String WRONGSHA = "5f106d47c2ce17dd65774c12c0826785d16b26f7";
 
-  public void getBuildBySHA1WithoutMergeBuilds_sha_found(){
-    Job<?,?> project = createProject(SHA1);
+    public void getBuildBySHA1WithoutMergeBuilds_sha_found() {
+        Job<?, ?> project = createProject(SHA1);
 
-    Run<?, ?> build = BuildUtil.getBuildBySHA1WithoutMergeBuilds(project, SHA1);
-    assertThat(build, is(notNullValue()));
-  }
-
-  @Test
-  public void getBuildBySHA1WithoutMergeBuilds_sha_missing(){
-    Job<?,?> project = createProject(SHA1);
-
-    Run<?, ?> build = BuildUtil.getBuildBySHA1WithoutMergeBuilds(project, WRONGSHA);
-    assertThat(build, is(nullValue()));
-  }
-
-  @Test
-  public void getBuildBySHA1WithoutMergeBuilds_libraryFirst(){
-    Job<?,?> project = createProject(SHA1, SHALIB);
-
-    Run<?, ?> build = BuildUtil.getBuildBySHA1WithoutMergeBuilds(project, SHA1);
-    assertThat(build, is(notNullValue()));
-  }
-
-  @Test
-  public void getBuildBySHA1WithoutMergeBuilds_libraryLast(){
-    Job<?,?> project = createProject(SHA1, SHALIB);
-
-    Run<?, ?> build = BuildUtil.getBuildBySHA1WithoutMergeBuilds(project, SHA1);
-    assertThat(build, is(notNullValue()));
-  }
-
-  @Test
-  public void getBuildBySHA1IncludingMergeBuilds_sha_found(){
-    Job<?,?> project = createProject(SHA1);
-
-    Run<?, ?> build = BuildUtil.getBuildBySHA1IncludingMergeBuilds(project, SHA1);
-    assertThat(build, is(notNullValue()));
-  }
-
-  @Test
-  public void getBuildBySHA1IncludingMergeBuilds_sha_missing(){
-    Job<?,?> project = createProject(SHA1);
-
-    Run<?, ?> build = BuildUtil.getBuildBySHA1IncludingMergeBuilds(project, WRONGSHA);
-    assertThat(build, is(nullValue()));
-  }
-  
-  @Test
-  public void getBuildBySHA1IncludingMergeBuilds_libraryFirst(){
-    Job<?,?> project = createProject(SHA1, SHALIB);
-
-    Run<?, ?> build = BuildUtil.getBuildBySHA1IncludingMergeBuilds(project, SHA1);
-    assertThat(build, is(notNullValue()));
-  }
-
-  @Test
-  public void getBuildBySHA1IncludingMergeBuilds_libraryLast(){
-    Job<?,?> project = createProject(SHA1, SHALIB);
-
-    Run<?, ?> build = BuildUtil.getBuildBySHA1IncludingMergeBuilds(project, SHA1);
-    assertThat(build, is(notNullValue()));
-  }
-
-  private AbstractProject<?,?> createProject(String... shas) {
-    AbstractBuild build = mock(AbstractBuild.class);
-    List<BuildData> buildDatas = new ArrayList<BuildData>();
-    for(String sha : shas) {
-      BuildData buildData = createBuildData(sha);
-      buildDatas.add(buildData);
+        Run<?, ?> build = BuildUtil.getBuildBySHA1WithoutMergeBuilds(project, SHA1);
+        assertThat(build, is(notNullValue()));
     }
 
-    when(build.getAction(BuildData.class)).thenReturn(buildDatas.get(0));
-    when(build.getActions(BuildData.class)).thenReturn(buildDatas);
+    @Test
+    public void getBuildBySHA1WithoutMergeBuilds_sha_missing() {
+        Job<?, ?> project = createProject(SHA1);
 
-    AbstractProject<?, ?> project = mock(AbstractProject.class);
-    when(build.getProject()).thenReturn(project);
+        Run<?, ?> build = BuildUtil.getBuildBySHA1WithoutMergeBuilds(project, WRONGSHA);
+        assertThat(build, is(nullValue()));
+    }
 
-    RunList list = mock(RunList.class);
-    when(list.iterator()).thenReturn(Arrays.asList(build).iterator());
-    when(project.getBuilds()).thenReturn(list);
+    @Test
+    public void getBuildBySHA1WithoutMergeBuilds_libraryFirst() {
+        Job<?, ?> project = createProject(SHA1, SHALIB);
 
-    return project;
-  }
+        Run<?, ?> build = BuildUtil.getBuildBySHA1WithoutMergeBuilds(project, SHA1);
+        assertThat(build, is(notNullValue()));
+    }
 
-  private BuildData createBuildData(String sha) {
-    
-    BuildData buildData = mock(BuildData.class);
-    Revision revision = mock(Revision.class);
-    when(revision.getSha1String()).thenReturn(sha);
-    when(buildData.getLastBuiltRevision()).thenReturn(revision);
+    @Test
+    public void getBuildBySHA1WithoutMergeBuilds_libraryLast() {
+        Job<?, ?> project = createProject(SHA1, SHALIB);
 
-    Build gitBuild = mock(Build.class);
-    when(gitBuild.getMarked()).thenReturn(revision);
-    when(buildData.getLastBuild(any(ObjectId.class))).thenReturn(gitBuild);
-    when(gitBuild.getRevision()).thenReturn(revision);
-    when(gitBuild.isFor(sha)).thenReturn(true);
-    buildData.lastBuild = gitBuild;
+        Run<?, ?> build = BuildUtil.getBuildBySHA1WithoutMergeBuilds(project, SHA1);
+        assertThat(build, is(notNullValue()));
+    }
 
-    return buildData;
-  }
+    @Test
+    public void getBuildBySHA1IncludingMergeBuilds_sha_found() {
+        Job<?, ?> project = createProject(SHA1);
+
+        Run<?, ?> build = BuildUtil.getBuildBySHA1IncludingMergeBuilds(project, SHA1);
+        assertThat(build, is(notNullValue()));
+    }
+
+    @Test
+    public void getBuildBySHA1IncludingMergeBuilds_sha_missing() {
+        Job<?, ?> project = createProject(SHA1);
+
+        Run<?, ?> build = BuildUtil.getBuildBySHA1IncludingMergeBuilds(project, WRONGSHA);
+        assertThat(build, is(nullValue()));
+    }
+
+    @Test
+    public void getBuildBySHA1IncludingMergeBuilds_libraryFirst() {
+        Job<?, ?> project = createProject(SHA1, SHALIB);
+
+        Run<?, ?> build = BuildUtil.getBuildBySHA1IncludingMergeBuilds(project, SHA1);
+        assertThat(build, is(notNullValue()));
+    }
+
+    @Test
+    public void getBuildBySHA1IncludingMergeBuilds_libraryLast() {
+        Job<?, ?> project = createProject(SHA1, SHALIB);
+
+        Run<?, ?> build = BuildUtil.getBuildBySHA1IncludingMergeBuilds(project, SHA1);
+        assertThat(build, is(notNullValue()));
+    }
+
+    private AbstractProject<?, ?> createProject(String... shas) {
+        AbstractBuild build = mock(AbstractBuild.class);
+        List<BuildData> buildDatas = new ArrayList<BuildData>();
+        for (String sha : shas) {
+            BuildData buildData = createBuildData(sha);
+            buildDatas.add(buildData);
+        }
+
+        when(build.getAction(BuildData.class)).thenReturn(buildDatas.get(0));
+        when(build.getActions(BuildData.class)).thenReturn(buildDatas);
+
+        AbstractProject<?, ?> project = mock(AbstractProject.class);
+        when(build.getProject()).thenReturn(project);
+
+        RunList list = mock(RunList.class);
+        when(list.iterator()).thenReturn(Arrays.asList(build).iterator());
+        when(project.getBuilds()).thenReturn(list);
+
+        return project;
+    }
+
+    private BuildData createBuildData(String sha) {
+
+        BuildData buildData = mock(BuildData.class);
+        Revision revision = mock(Revision.class);
+        when(revision.getSha1String()).thenReturn(sha);
+        when(buildData.getLastBuiltRevision()).thenReturn(revision);
+
+        Build gitBuild = mock(Build.class);
+        when(gitBuild.getMarked()).thenReturn(revision);
+        when(buildData.getLastBuild(any(ObjectId.class))).thenReturn(gitBuild);
+        when(gitBuild.getRevision()).thenReturn(revision);
+        when(gitBuild.isFor(sha)).thenReturn(true);
+        buildData.lastBuild = gitBuild;
+
+        return buildData;
+    }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdaterTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdaterTest.java
@@ -44,69 +44,100 @@ import org.mockito.MockitoAnnotations;
  */
 public class CommitStatusUpdaterTest {
 
-	private static final int PROJECT_ID = 1;
+    private static final int PROJECT_ID = 1;
     private static final String BUILD_URL = "job/Test-Job";
     private static final String STAGE = "test";
     private static final String REVISION = "1111111";
     private static final String JENKINS_URL = "https://gitlab.org/jenkins/";
 
-    @Mock Run<?, ?> build;
-	@Mock TaskListener taskListener;
-	@Mock GitLabConnectionConfig gitLabConnectionConfig;
-	@Mock GitLabClient client;
-	@Mock GitLabWebHookCause gitlabCause;
-	@Mock BuildData action;
-	@Mock Revision lastBuiltRevision;
-	@Mock Build lastBuild;
-	@Mock Revision revision;
-	@Mock EnvVars environment;
-	@Mock UpstreamCause upCauseLevel1;
-	@Mock UpstreamCause upCauseLevel2;
-	@Mock Jenkins jenkins;
-	@Mock GitLabConnectionProperty connection;
+    @Mock
+    Run<?, ?> build;
 
-	private AutoCloseable closeable;
-	private MockedStatic<Jenkins> mockedJenkins;
-	private MockedStatic<GitLabConnectionProperty> mockedGitLabConnectionProperty;
-	private MockedStatic<DisplayURLProvider> mockedDisplayURLProvider;
+    @Mock
+    TaskListener taskListener;
 
-	CauseData causeData;
+    @Mock
+    GitLabConnectionConfig gitLabConnectionConfig;
 
-	@Before
-	public void setUp() throws Exception {
-	    closeable = MockitoAnnotations.openMocks(this);
-	    mockedJenkins = Mockito.mockStatic(Jenkins.class);
-	    mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
-	    mockedJenkins.when(Jenkins::getActiveInstance).thenReturn(jenkins);
-	    when(jenkins.getRootUrl()).thenReturn(JENKINS_URL);
-	    when(jenkins.getDescriptor(GitLabConnectionConfig.class)).thenReturn(gitLabConnectionConfig);
-	    mockedGitLabConnectionProperty = Mockito.mockStatic(GitLabConnectionProperty.class);
-	    mockedGitLabConnectionProperty.when(() -> GitLabConnectionProperty.getClient(any(Run.class))).thenReturn(client);
-	    when(gitLabConnectionConfig.getClient(any(String.class), any(Item.class), any(String.class))).thenReturn(client);
+    @Mock
+    GitLabClient client;
+
+    @Mock
+    GitLabWebHookCause gitlabCause;
+
+    @Mock
+    BuildData action;
+
+    @Mock
+    Revision lastBuiltRevision;
+
+    @Mock
+    Build lastBuild;
+
+    @Mock
+    Revision revision;
+
+    @Mock
+    EnvVars environment;
+
+    @Mock
+    UpstreamCause upCauseLevel1;
+
+    @Mock
+    UpstreamCause upCauseLevel2;
+
+    @Mock
+    Jenkins jenkins;
+
+    @Mock
+    GitLabConnectionProperty connection;
+
+    private AutoCloseable closeable;
+    private MockedStatic<Jenkins> mockedJenkins;
+    private MockedStatic<GitLabConnectionProperty> mockedGitLabConnectionProperty;
+    private MockedStatic<DisplayURLProvider> mockedDisplayURLProvider;
+
+    CauseData causeData;
+
+    @Before
+    public void setUp() throws Exception {
+        closeable = MockitoAnnotations.openMocks(this);
+        mockedJenkins = Mockito.mockStatic(Jenkins.class);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+        mockedJenkins.when(Jenkins::getActiveInstance).thenReturn(jenkins);
+        when(jenkins.getRootUrl()).thenReturn(JENKINS_URL);
+        when(jenkins.getDescriptor(GitLabConnectionConfig.class)).thenReturn(gitLabConnectionConfig);
+        mockedGitLabConnectionProperty = Mockito.mockStatic(GitLabConnectionProperty.class);
+        mockedGitLabConnectionProperty
+                .when(() -> GitLabConnectionProperty.getClient(any(Run.class)))
+                .thenReturn(client);
+        when(gitLabConnectionConfig.getClient(any(String.class), any(Item.class), any(String.class)))
+                .thenReturn(client);
         when(connection.getClient()).thenReturn(client);
-	    when(build.getAction(BuildData.class)).thenReturn(action);
-	    when(action.getLastBuiltRevision()).thenReturn(lastBuiltRevision);
-	    when(action.getLastBuild(any(ObjectId.class))).thenReturn(lastBuild);
-	    when(lastBuild.getMarked()).thenReturn(revision);
-	    when(revision.getSha1String()).thenReturn(REVISION);
-	    when(build.getUrl()).thenReturn(BUILD_URL);
-	    when(build.getEnvironment(any(TaskListener.class))).thenReturn(environment);
-	    when(build.getCauses()).thenReturn(new ArrayList<Cause>(Collections.singletonList(upCauseLevel1)));
-	    when(upCauseLevel1.getUpstreamCauses()).thenReturn(new ArrayList<Cause>(Collections.singletonList(upCauseLevel2)));
-	    when(upCauseLevel2.getUpstreamCauses()).thenReturn(new ArrayList<Cause>(Collections.singletonList(gitlabCause)));
-	    if(Functions.isWindows()) {
-	        when(taskListener.getLogger()).thenReturn(new PrintStream("nul"));
-	    } else {
-	        when(taskListener.getLogger()).thenReturn(new PrintStream("/dev/null"));
-	    }
-	    mockedDisplayURLProvider = Mockito.mockStatic(DisplayURLProvider.class);
-	    DisplayURLProvider urlProvider = mock(DisplayURLProvider.class);
-	    mockedDisplayURLProvider.when(DisplayURLProvider::get).thenReturn(urlProvider);
-	    String url = JENKINS_URL+ Util.encode(build.getUrl());
-	    when(urlProvider.getRunURL(any())).thenReturn(url);
+        when(build.getAction(BuildData.class)).thenReturn(action);
+        when(action.getLastBuiltRevision()).thenReturn(lastBuiltRevision);
+        when(action.getLastBuild(any(ObjectId.class))).thenReturn(lastBuild);
+        when(lastBuild.getMarked()).thenReturn(revision);
+        when(revision.getSha1String()).thenReturn(REVISION);
+        when(build.getUrl()).thenReturn(BUILD_URL);
+        when(build.getEnvironment(any(TaskListener.class))).thenReturn(environment);
+        when(build.getCauses()).thenReturn(new ArrayList<Cause>(Collections.singletonList(upCauseLevel1)));
+        when(upCauseLevel1.getUpstreamCauses())
+                .thenReturn(new ArrayList<Cause>(Collections.singletonList(upCauseLevel2)));
+        when(upCauseLevel2.getUpstreamCauses())
+                .thenReturn(new ArrayList<Cause>(Collections.singletonList(gitlabCause)));
+        if (Functions.isWindows()) {
+            when(taskListener.getLogger()).thenReturn(new PrintStream("nul"));
+        } else {
+            when(taskListener.getLogger()).thenReturn(new PrintStream("/dev/null"));
+        }
+        mockedDisplayURLProvider = Mockito.mockStatic(DisplayURLProvider.class);
+        DisplayURLProvider urlProvider = mock(DisplayURLProvider.class);
+        mockedDisplayURLProvider.when(DisplayURLProvider::get).thenReturn(urlProvider);
+        String url = JENKINS_URL + Util.encode(build.getUrl());
+        when(urlProvider.getRunURL(any())).thenReturn(url);
 
-
-	    causeData = CauseDataBuilder.causeData()
+        causeData = CauseDataBuilder.causeData()
                 .withActionType(CauseData.ActionType.NOTE)
                 .withSourceProjectId(PROJECT_ID)
                 .withTargetProjectId(PROJECT_ID)
@@ -132,31 +163,47 @@ public class CommitStatusUpdaterTest {
                 .withTargetProjectUrl("https://gitlab.org/test")
                 .build();
 
-	    when(gitlabCause.getData()).thenReturn(causeData);
-	    spy(client);
-	}
+        when(gitlabCause.getData()).thenReturn(causeData);
+        spy(client);
+    }
 
-	@After
-	public void tearDown() throws Exception {
-		mockedDisplayURLProvider.close();
-		mockedGitLabConnectionProperty.close();
-		mockedJenkins.close();
-		closeable.close();
-	}
+    @After
+    public void tearDown() throws Exception {
+        mockedDisplayURLProvider.close();
+        mockedGitLabConnectionProperty.close();
+        mockedJenkins.close();
+        closeable.close();
+    }
 
-	@Test
-	public void buildStateUpdateTest() {
-		CommitStatusUpdater.updateCommitStatus(build, taskListener, BuildState.success, STAGE);
+    @Test
+    public void buildStateUpdateTest() {
+        CommitStatusUpdater.updateCommitStatus(build, taskListener, BuildState.success, STAGE);
 
-		verify(client).changeBuildStatus(Integer.toString(PROJECT_ID), REVISION, BuildState.success, null, STAGE, DisplayURLProvider.get().getRunURL(build), BuildState.success.name());
-	}
+        verify(client)
+                .changeBuildStatus(
+                        Integer.toString(PROJECT_ID),
+                        REVISION,
+                        BuildState.success,
+                        null,
+                        STAGE,
+                        DisplayURLProvider.get().getRunURL(build),
+                        BuildState.success.name());
+    }
 
-	@Test
-	public void buildStateUpdateTestSpecificConnection() {
-	    CommitStatusUpdater.updateCommitStatus(build, taskListener, BuildState.success, STAGE,null, connection);
+    @Test
+    public void buildStateUpdateTestSpecificConnection() {
+        CommitStatusUpdater.updateCommitStatus(build, taskListener, BuildState.success, STAGE, null, connection);
 
-	    verify(client).changeBuildStatus(Integer.toString(PROJECT_ID), REVISION, BuildState.success, null, STAGE, DisplayURLProvider.get().getRunURL(build), BuildState.success.name());
-	}
+        verify(client)
+                .changeBuildStatus(
+                        Integer.toString(PROJECT_ID),
+                        REVISION,
+                        BuildState.success,
+                        null,
+                        STAGE,
+                        DisplayURLProvider.get().getRunURL(build),
+                        BuildState.success.name());
+    }
 
     @Test
     public void buildStateUpdateTestSpecificBuild() {
@@ -164,7 +211,15 @@ public class CommitStatusUpdaterTest {
         builds.add(new GitLabBranchBuild(Integer.toString(PROJECT_ID), REVISION));
         CommitStatusUpdater.updateCommitStatus(build, taskListener, BuildState.success, STAGE, builds, null);
 
-        verify(client).changeBuildStatus(Integer.toString(PROJECT_ID), REVISION, BuildState.success, null, STAGE, DisplayURLProvider.get().getRunURL(build), BuildState.success.name());
+        verify(client)
+                .changeBuildStatus(
+                        Integer.toString(PROJECT_ID),
+                        REVISION,
+                        BuildState.success,
+                        null,
+                        STAGE,
+                        DisplayURLProvider.get().getRunURL(build),
+                        BuildState.success.name());
     }
 
     @Test
@@ -173,42 +228,58 @@ public class CommitStatusUpdaterTest {
         builds.add(new GitLabBranchBuild(Integer.toString(PROJECT_ID), REVISION));
         CommitStatusUpdater.updateCommitStatus(build, taskListener, BuildState.success, STAGE, builds, connection);
 
-        verify(client).changeBuildStatus(Integer.toString(PROJECT_ID), REVISION, BuildState.success, null, STAGE, DisplayURLProvider.get().getRunURL(build), BuildState.success.name());
+        verify(client)
+                .changeBuildStatus(
+                        Integer.toString(PROJECT_ID),
+                        REVISION,
+                        BuildState.success,
+                        null,
+                        STAGE,
+                        DisplayURLProvider.get().getRunURL(build),
+                        BuildState.success.name());
     }
 
     @Test
     public void testTagEvent() {
         causeData = CauseDataBuilder.causeData()
-            .withActionType(CauseData.ActionType.TAG_PUSH)
-            .withSourceProjectId(PROJECT_ID)
-            .withTargetProjectId(PROJECT_ID)
-            .withBranch("refs/tags/3.0.0")
-            .withSourceBranch("refs/tags/3.0.0")
-            .withUserName("")
-            .withSourceRepoHomepage("https://gitlab.org/test")
-            .withSourceRepoName("test")
-            .withSourceNamespace("test-namespace")
-            .withSourceRepoUrl("git@gitlab.org:test.git")
-            .withSourceRepoSshUrl("git@gitlab.org:test.git")
-            .withSourceRepoHttpUrl("https://gitlab.org/test.git")
-            .withMergeRequestTitle("Test")
-            .withMergeRequestId(1)
-            .withMergeRequestIid(1)
-            .withTargetBranch("master")
-            .withTargetRepoName("test")
-            .withTargetNamespace("test-namespace")
-            .withTargetRepoSshUrl("git@gitlab.org:test.git")
-            .withTargetRepoHttpUrl("https://gitlab.org/test.git")
-            .withTriggeredByUser("test")
-            .withLastCommit(REVISION)
-            .withTargetProjectUrl("https://gitlab.org/test")
-            .build();
+                .withActionType(CauseData.ActionType.TAG_PUSH)
+                .withSourceProjectId(PROJECT_ID)
+                .withTargetProjectId(PROJECT_ID)
+                .withBranch("refs/tags/3.0.0")
+                .withSourceBranch("refs/tags/3.0.0")
+                .withUserName("")
+                .withSourceRepoHomepage("https://gitlab.org/test")
+                .withSourceRepoName("test")
+                .withSourceNamespace("test-namespace")
+                .withSourceRepoUrl("git@gitlab.org:test.git")
+                .withSourceRepoSshUrl("git@gitlab.org:test.git")
+                .withSourceRepoHttpUrl("https://gitlab.org/test.git")
+                .withMergeRequestTitle("Test")
+                .withMergeRequestId(1)
+                .withMergeRequestIid(1)
+                .withTargetBranch("master")
+                .withTargetRepoName("test")
+                .withTargetNamespace("test-namespace")
+                .withTargetRepoSshUrl("git@gitlab.org:test.git")
+                .withTargetRepoHttpUrl("https://gitlab.org/test.git")
+                .withTriggeredByUser("test")
+                .withLastCommit(REVISION)
+                .withTargetProjectUrl("https://gitlab.org/test")
+                .build();
 
         when(build.getCause(GitLabWebHookCause.class)).thenReturn(gitlabCause);
         when(gitlabCause.getData()).thenReturn(causeData);
 
         CommitStatusUpdater.updateCommitStatus(build, taskListener, BuildState.success, STAGE);
 
-        verify(client).changeBuildStatus(Integer.toString(PROJECT_ID), REVISION, BuildState.success, "3.0.0", STAGE, DisplayURLProvider.get().getRunURL(build), BuildState.success.name());
+        verify(client)
+                .changeBuildStatus(
+                        Integer.toString(PROJECT_ID),
+                        REVISION,
+                        BuildState.success,
+                        "3.0.0",
+                        STAGE,
+                        DisplayURLProvider.get().getRunURL(build),
+                        BuildState.success.name());
     }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/util/GitLabClientStub.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/util/GitLabClientStub.java
@@ -35,8 +35,7 @@ class GitLabClientStub implements GitLabClient {
     }
 
     @Override
-    public List<Group> getGroups(Boolean allAvailable, Boolean topLevelOnly, OrderType orderBy,
-            SortType sort) {
+    public List<Group> getGroups(Boolean allAvailable, Boolean topLevelOnly, OrderType orderBy, SortType sort) {
         return null;
     }
 
@@ -46,8 +45,12 @@ class GitLabClientStub implements GitLabClient {
     }
 
     @Override
-    public List<Project> getGroupProjects(String groupId, Boolean includeSubgroups, ProjectVisibilityType visibility,
-            OrderType orderBy, SortType sort) {
+    public List<Project> getGroupProjects(
+            String groupId,
+            Boolean includeSubgroups,
+            ProjectVisibilityType visibility,
+            OrderType orderBy,
+            SortType sort) {
         return null;
     }
 
@@ -72,14 +75,11 @@ class GitLabClientStub implements GitLabClient {
     }
 
     @Override
-    public void deleteProject(String projectId) {
-
-    }
+    public void deleteProject(String projectId) {}
 
     @Override
-    public void addProjectHook(String projectId, String url, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents) {
-
-    }
+    public void addProjectHook(
+            String projectId, String url, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents) {}
 
     @Override
     public List<ProjectHook> getProjectHooks(String projectName) {
@@ -87,34 +87,42 @@ class GitLabClientStub implements GitLabClient {
     }
 
     @Override
-    public void addProjectHook(String projectId, String url, String secretToken, Boolean pushEvents, Boolean mergeRequestEvents, Boolean noteEvents) {
-
-    }
-
-    @Override
-    public void changeBuildStatus(String projectId, String sha, BuildState state, String ref, String context, String targetUrl, String description) {
-
-    }
-
-    @Override
-    public void changeBuildStatus(Integer projectId, String sha, BuildState state, String ref, String context, String targetUrl, String description) {
-
-    }
+    public void addProjectHook(
+            String projectId,
+            String url,
+            String secretToken,
+            Boolean pushEvents,
+            Boolean mergeRequestEvents,
+            Boolean noteEvents) {}
 
     @Override
-    public void getCommit(String projectId, String sha) {
-
-    }
+    public void changeBuildStatus(
+            String projectId,
+            String sha,
+            BuildState state,
+            String ref,
+            String context,
+            String targetUrl,
+            String description) {}
 
     @Override
-    public void acceptMergeRequest(MergeRequest mr, String mergeCommitMessage, Boolean shouldRemoveSourceBranch) {
-
-    }
+    public void changeBuildStatus(
+            Integer projectId,
+            String sha,
+            BuildState state,
+            String ref,
+            String context,
+            String targetUrl,
+            String description) {}
 
     @Override
-    public void createMergeRequestNote(MergeRequest mr, String body) {
+    public void getCommit(String projectId, String sha) {}
 
-    }
+    @Override
+    public void acceptMergeRequest(MergeRequest mr, String mergeCommitMessage, Boolean shouldRemoveSourceBranch) {}
+
+    @Override
+    public void createMergeRequestNote(MergeRequest mr, String body) {}
 
     @Override
     public List<Awardable> getMergeRequestEmoji(MergeRequest mr) {
@@ -122,14 +130,10 @@ class GitLabClientStub implements GitLabClient {
     }
 
     @Override
-    public void awardMergeRequestEmoji(MergeRequest mr, String name) {
-
-    }
+    public void awardMergeRequestEmoji(MergeRequest mr, String name) {}
 
     @Override
-    public void deleteMergeRequestEmoji(MergeRequest mr, Integer awardId) {
-
-    }
+    public void deleteMergeRequestEmoji(MergeRequest mr, Integer awardId) {}
 
     @Override
     public List<MergeRequest> getMergeRequests(String projectId, State state, int page, int perPage) {

--- a/src/test/java/com/dabsquared/gitlabjenkins/util/ProjectIdUtilTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/util/ProjectIdUtilTest.java
@@ -19,13 +19,20 @@ public class ProjectIdUtilTest {
     @DataPoints
     public static TestData[] testData = {
         forRemoteUrl("git@gitlab.com", "git@gitlab.com:test/project.git").expectProjectId("test/project"),
-        forRemoteUrl("https://gitlab.com", "https://gitlab.com/test/project.git").expectProjectId("test/project"),
-        forRemoteUrl("https://myurl.com/gitlab", "https://myurl.com/gitlab/group/project.git").expectProjectId("group/project"),
-        forRemoteUrl("git@gitlab.com", "git@gitlab.com:group/subgroup/project.git").expectProjectId("group/subgroup/project"),
-        forRemoteUrl("https://myurl.com/gitlab", "https://myurl.com/gitlab/group/subgroup/project.git").expectProjectId("group/subgroup/project"),
-        forRemoteUrl("https://myurl.com", "https://myurl.com/group/subgroup/project.git").expectProjectId("group/subgroup/project"),
-        forRemoteUrl("https://myurl.com", "https://myurl.com/group/subgroup/subsubgroup/project.git").expectProjectId("group/subgroup/subsubgroup/project"),
-        forRemoteUrl("git@gitlab.com", "git@gitlab.com:group/subgroup/subsubgroup/project.git").expectProjectId("group/subgroup/subsubgroup/project"),
+        forRemoteUrl("https://gitlab.com", "https://gitlab.com/test/project.git")
+                .expectProjectId("test/project"),
+        forRemoteUrl("https://myurl.com/gitlab", "https://myurl.com/gitlab/group/project.git")
+                .expectProjectId("group/project"),
+        forRemoteUrl("git@gitlab.com", "git@gitlab.com:group/subgroup/project.git")
+                .expectProjectId("group/subgroup/project"),
+        forRemoteUrl("https://myurl.com/gitlab", "https://myurl.com/gitlab/group/subgroup/project.git")
+                .expectProjectId("group/subgroup/project"),
+        forRemoteUrl("https://myurl.com", "https://myurl.com/group/subgroup/project.git")
+                .expectProjectId("group/subgroup/project"),
+        forRemoteUrl("https://myurl.com", "https://myurl.com/group/subgroup/subsubgroup/project.git")
+                .expectProjectId("group/subgroup/subsubgroup/project"),
+        forRemoteUrl("git@gitlab.com", "git@gitlab.com:group/subgroup/subsubgroup/project.git")
+                .expectProjectId("group/subgroup/subsubgroup/project"),
         forRemoteUrl("http://myhost", "http://myhost.com/group/project.git").expectProjectId("group/project"),
         forRemoteUrl("", "http://myhost.com/group/project.git").expectProjectId("group/project"),
         forRemoteUrl("", "http://myhost.com:group/project.git").expectProjectId("group/project"),
@@ -39,7 +46,6 @@ public class ProjectIdUtilTest {
 
         assertThat(projectId, is(testData.expectedProjectId));
     }
-
 
     static final class TestData {
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/ActionResolverTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/ActionResolverTest.java
@@ -119,7 +119,8 @@ public class ActionResolverTest {
         when(request.getRestOfPath()).thenReturn("");
         when(request.getMethod()).thenReturn("POST");
         when(request.getHeader("X-Gitlab-Event")).thenReturn("Merge Request Hook");
-        when(request.getInputStream()).thenReturn(new ResourceServletInputStream("ActionResolverTest_postMergeRequest.json"));
+        when(request.getInputStream())
+                .thenReturn(new ResourceServletInputStream("ActionResolverTest_postMergeRequest.json"));
 
         WebHookAction resolvedAction = new ActionResolver().resolve(projectName, request);
 
@@ -133,7 +134,8 @@ public class ActionResolverTest {
         when(request.getRestOfPath()).thenReturn("");
         when(request.getMethod()).thenReturn("POST");
         when(request.getHeader("X-Gitlab-Event")).thenReturn("System Hook");
-        when(request.getInputStream()).thenReturn(new ResourceServletInputStream("ActionResolverTest_postSystemHook_MergeRequest.json"));
+        when(request.getInputStream())
+                .thenReturn(new ResourceServletInputStream("ActionResolverTest_postSystemHook_MergeRequest.json"));
 
         WebHookAction resolvedAction = new ActionResolver().resolve(projectName, request);
 
@@ -147,7 +149,8 @@ public class ActionResolverTest {
         when(request.getRestOfPath()).thenReturn("");
         when(request.getMethod()).thenReturn("POST");
         when(request.getHeader("X-Gitlab-Event")).thenReturn("System Hook");
-        when(request.getInputStream()).thenReturn(new ResourceServletInputStream("ActionResolverTest_postSystemHook_Push.json"));
+        when(request.getInputStream())
+                .thenReturn(new ResourceServletInputStream("ActionResolverTest_postSystemHook_Push.json"));
 
         WebHookAction resolvedAction = new ActionResolver().resolve(projectName, request);
 
@@ -161,7 +164,8 @@ public class ActionResolverTest {
         when(request.getRestOfPath()).thenReturn("");
         when(request.getMethod()).thenReturn("POST");
         when(request.getHeader("X-Gitlab-Event")).thenReturn("System Hook");
-        when(request.getInputStream()).thenReturn(new ResourceServletInputStream("ActionResolverTest_postSystemHook_PushTag.json"));
+        when(request.getInputStream())
+                .thenReturn(new ResourceServletInputStream("ActionResolverTest_postSystemHook_PushTag.json"));
 
         WebHookAction resolvedAction = new ActionResolver().resolve(projectName, request);
 
@@ -203,7 +207,8 @@ public class ActionResolverTest {
         when(request.getRestOfPath()).thenReturn("");
         when(request.getMethod()).thenReturn("POST");
         when(request.getHeader("X-Gitlab-Event")).thenReturn("Tag Push Hook");
-        when(request.getInputStream()).thenReturn(new ResourceServletInputStream("ActionResolverTest_postPushTag.json"));
+        when(request.getInputStream())
+                .thenReturn(new ResourceServletInputStream("ActionResolverTest_postPushTag.json"));
 
         WebHookAction resolvedAction = new ActionResolver().resolve(projectName, request);
 
@@ -238,7 +243,6 @@ public class ActionResolverTest {
         assertThat(resolvedAction, instanceOf(NoopAction.class));
     }
 
-
     private static class ResourceServletInputStream extends ServletInputStream {
 
         private final InputStream input;
@@ -253,17 +257,16 @@ public class ActionResolverTest {
         }
 
         @Override
-        public boolean isReady(){
+        public boolean isReady() {
             return true;
         }
 
         @Override
-        public boolean isFinished(){
+        public boolean isFinished() {
             return true;
         }
 
         @Override
-        public void setReadListener(ReadListener var1){
-        }
+        public void setReadListener(ReadListener var1) {}
     }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/BuildWebHookActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/BuildWebHookActionTest.java
@@ -4,28 +4,23 @@
  */
 package com.dabsquared.gitlabjenkins.webhook.build;
 
-import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
 import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
-
+import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
-
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.Project;
 import hudson.security.ACL;
-
 import org.acegisecurity.Authentication;
-
 import org.junit.Before;
-import org.junit.Test;
 import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
 import org.kohsuke.stapler.HttpResponses.HttpResponseException;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test the BuildWebHookAction class
@@ -40,8 +35,7 @@ public class BuildWebHookActionTest {
     private FreeStyleProject project;
     private GitLabPushTrigger trigger;
 
-    public BuildWebHookActionTest() {
-    }
+    public BuildWebHookActionTest() {}
 
     @Before
     public void confgureGitLabConnection() throws Exception {
@@ -73,11 +67,9 @@ public class BuildWebHookActionTest {
         trigger.setSecretToken(triggerToken);
         String actionToken = triggerToken + "-no-match"; // Won't match
         BuildWebHookActionImpl action = new BuildWebHookActionImpl(project, actionToken);
-        assertThrows(HttpResponseException.class,
-                () -> {
-                    action.runNotifier();
-                }
-        );
+        assertThrows(HttpResponseException.class, () -> {
+            action.runNotifier();
+        });
         assertFalse("performOnPost was called, unexpected token match?", action.performOnPostCalled);
     }
 
@@ -88,11 +80,9 @@ public class BuildWebHookActionTest {
         trigger.setSecretToken(triggerToken);
         String actionToken = null;
         BuildWebHookActionImpl action = new BuildWebHookActionImpl(project, actionToken);
-        assertThrows(HttpResponseException.class,
-                () -> {
-                    action.runNotifier();
-                }
-        );
+        assertThrows(HttpResponseException.class, () -> {
+            action.runNotifier();
+        });
         assertFalse("performOnPost was called, unexpected token match?", action.performOnPostCalled);
     }
 
@@ -139,11 +129,9 @@ public class BuildWebHookActionTest {
         }
 
         @Override
-        public void processForCompatibility() {
-        }
+        public void processForCompatibility() {}
 
         @Override
-        public void execute() {
-        }
+        public void execute() {}
     }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildActionTest.java
@@ -69,13 +69,13 @@ public class MergeRequestBuildActionTest {
         QueueListener ql = new QueueListener() {
             @Override
             public void onEnterWaiting(Queue.WaitingItem wi) {
-                System.out.println("Got "+wi+" : "+wi.getCausesDescription());
+                System.out.println("Got " + wi + " : " + wi.getCausesDescription());
                 wouldFire = true;
             }
 
             @Override
             public void onEnterBuildable(Queue.BuildableItem bi) {
-                System.out.println("Is buildable: "+bi.getCausesDescription());
+                System.out.println("Is buildable: " + bi.getCausesDescription());
             }
         };
         jenkins.getInstance().getExtensionList(QueueListener.class).add(ql);
@@ -94,7 +94,6 @@ public class MergeRequestBuildActionTest {
         // some defaults of the trigger
         trigger.setBranchFilterType(BranchFilterType.All);
     }
-
 
     @Test
     public void build() throws IOException {
@@ -117,8 +116,7 @@ public class MergeRequestBuildActionTest {
 
             trigger.start(testProject, false);
 
-            new MergeRequestBuildAction(testProject, json, null)
-                .execute(response);
+            new MergeRequestBuildAction(testProject, json, null).execute(response);
         } catch (HttpResponses.HttpResponseException hre) {
             // Test for OK status of a response.
             try {
@@ -169,7 +167,8 @@ public class MergeRequestBuildActionTest {
         trigger.setTriggerOnMergeRequest(false);
         testProject.addTrigger(trigger);
         testProject.setScm(new GitSCM(gitRepoUrl));
-        QueueTaskFuture<?> future = testProject.scheduleBuild2(0, new ParametersAction(new StringParameterValue("gitlabTargetBranch", "master")));
+        QueueTaskFuture<?> future = testProject.scheduleBuild2(
+                0, new ParametersAction(new StringParameterValue("gitlabTargetBranch", "master")));
         future.get();
 
         executeMergeRequestAction(testProject, getJson("MergeRequestEvent_merged.json"));
@@ -177,35 +176,38 @@ public class MergeRequestBuildActionTest {
     }
 
     @Test
-    public void build_alreadyBuiltMR_differentTargetBranch() throws IOException, ExecutionException, InterruptedException {
+    public void build_alreadyBuiltMR_differentTargetBranch()
+            throws IOException, ExecutionException, InterruptedException {
         FreeStyleProject testProject = jenkins.createFreeStyleProject();
         testProject.addTrigger(trigger);
         testProject.setScm(new GitSCM(gitRepoUrl));
-        QueueTaskFuture<?> future = testProject.scheduleBuild2(0, new GitLabWebHookCause(causeData()
-                .withActionType(CauseData.ActionType.MERGE)
-                .withSourceProjectId(1)
-                .withTargetProjectId(1)
-                .withBranch("feature")
-                .withSourceBranch("feature")
-                .withUserName("")
-                .withSourceRepoHomepage("https://gitlab.org/test")
-                .withSourceRepoName("test")
-                .withSourceNamespace("test-namespace")
-                .withSourceRepoUrl("git@gitlab.org:test.git")
-                .withSourceRepoSshUrl("git@gitlab.org:test.git")
-                .withSourceRepoHttpUrl("https://gitlab.org/test.git")
-                .withMergeRequestTitle("Test")
-                .withMergeRequestId(1)
-                .withMergeRequestIid(1)
-                .withTargetBranch("master")
-                .withTargetRepoName("test")
-                .withTargetNamespace("test-namespace")
-                .withTargetRepoSshUrl("git@gitlab.org:test.git")
-                .withTargetRepoHttpUrl("https://gitlab.org/test.git")
-                .withTriggeredByUser("test")
-                .withLastCommit("123")
-                .withTargetProjectUrl("https://gitlab.org/test")
-                .build()));
+        QueueTaskFuture<?> future = testProject.scheduleBuild2(
+                0,
+                new GitLabWebHookCause(causeData()
+                        .withActionType(CauseData.ActionType.MERGE)
+                        .withSourceProjectId(1)
+                        .withTargetProjectId(1)
+                        .withBranch("feature")
+                        .withSourceBranch("feature")
+                        .withUserName("")
+                        .withSourceRepoHomepage("https://gitlab.org/test")
+                        .withSourceRepoName("test")
+                        .withSourceNamespace("test-namespace")
+                        .withSourceRepoUrl("git@gitlab.org:test.git")
+                        .withSourceRepoSshUrl("git@gitlab.org:test.git")
+                        .withSourceRepoHttpUrl("https://gitlab.org/test.git")
+                        .withMergeRequestTitle("Test")
+                        .withMergeRequestId(1)
+                        .withMergeRequestIid(1)
+                        .withTargetBranch("master")
+                        .withTargetRepoName("test")
+                        .withTargetNamespace("test-namespace")
+                        .withTargetRepoSshUrl("git@gitlab.org:test.git")
+                        .withTargetRepoHttpUrl("https://gitlab.org/test.git")
+                        .withTriggeredByUser("test")
+                        .withLastCommit("123")
+                        .withTargetProjectUrl("https://gitlab.org/test")
+                        .build()));
         future.get();
 
         executeMergeRequestAction(testProject, getJson("MergeRequestEvent_alreadyBuiltMR_differentTargetBranch.json"));

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/NoteBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/NoteBuildActionTest.java
@@ -66,7 +66,6 @@ public class NoteBuildActionTest {
         gitRepoUrl = tmp.getRoot().toURI().toString();
     }
 
-
     @Test
     public void build() throws IOException {
         FreeStyleProject testProject = jenkins.createFreeStyleProject();
@@ -83,7 +82,8 @@ public class NoteBuildActionTest {
         FreeStyleProject testProject = jenkins.createFreeStyleProject();
         testProject.addTrigger(trigger);
         testProject.setScm(new GitSCM(gitRepoUrl));
-        QueueTaskFuture<?> future = testProject.scheduleBuild2(0, new ParametersAction(new StringParameterValue("gitlabTargetBranch", "master")));
+        QueueTaskFuture<?> future = testProject.scheduleBuild2(
+                0, new ParametersAction(new StringParameterValue("gitlabTargetBranch", "master")));
         future.get();
 
         exception.expect(HttpResponses.HttpResponseException.class);
@@ -93,35 +93,38 @@ public class NoteBuildActionTest {
     }
 
     @Test
-    public void build_alreadyBuiltMR_differentTargetBranch() throws IOException, ExecutionException, InterruptedException {
+    public void build_alreadyBuiltMR_differentTargetBranch()
+            throws IOException, ExecutionException, InterruptedException {
         FreeStyleProject testProject = jenkins.createFreeStyleProject();
         testProject.addTrigger(trigger);
         testProject.setScm(new GitSCM(gitRepoUrl));
-        QueueTaskFuture<?> future = testProject.scheduleBuild2(0, new GitLabWebHookCause(causeData()
-                .withActionType(CauseData.ActionType.NOTE)
-                .withSourceProjectId(1)
-                .withTargetProjectId(1)
-                .withBranch("feature")
-                .withSourceBranch("feature")
-                .withUserName("")
-                .withSourceRepoHomepage("https://gitlab.org/test")
-                .withSourceRepoName("test")
-                .withSourceNamespace("test-namespace")
-                .withSourceRepoUrl("git@gitlab.org:test.git")
-                .withSourceRepoSshUrl("git@gitlab.org:test.git")
-                .withSourceRepoHttpUrl("https://gitlab.org/test.git")
-                .withMergeRequestTitle("Test")
-                .withMergeRequestId(1)
-                .withMergeRequestIid(1)
-                .withTargetBranch("master")
-                .withTargetRepoName("test")
-                .withTargetNamespace("test-namespace")
-                .withTargetRepoSshUrl("git@gitlab.org:test.git")
-                .withTargetRepoHttpUrl("https://gitlab.org/test.git")
-                .withTriggeredByUser("test")
-                .withLastCommit("123")
-                .withTargetProjectUrl("https://gitlab.org/test")
-                .build()));
+        QueueTaskFuture<?> future = testProject.scheduleBuild2(
+                0,
+                new GitLabWebHookCause(causeData()
+                        .withActionType(CauseData.ActionType.NOTE)
+                        .withSourceProjectId(1)
+                        .withTargetProjectId(1)
+                        .withBranch("feature")
+                        .withSourceBranch("feature")
+                        .withUserName("")
+                        .withSourceRepoHomepage("https://gitlab.org/test")
+                        .withSourceRepoName("test")
+                        .withSourceNamespace("test-namespace")
+                        .withSourceRepoUrl("git@gitlab.org:test.git")
+                        .withSourceRepoSshUrl("git@gitlab.org:test.git")
+                        .withSourceRepoHttpUrl("https://gitlab.org/test.git")
+                        .withMergeRequestTitle("Test")
+                        .withMergeRequestId(1)
+                        .withMergeRequestIid(1)
+                        .withTargetBranch("master")
+                        .withTargetRepoName("test")
+                        .withTargetNamespace("test-namespace")
+                        .withTargetRepoSshUrl("git@gitlab.org:test.git")
+                        .withTargetRepoHttpUrl("https://gitlab.org/test.git")
+                        .withTriggeredByUser("test")
+                        .withLastCommit("123")
+                        .withTargetProjectUrl("https://gitlab.org/test")
+                        .build()));
         future.get();
 
         exception.expect(HttpResponses.HttpResponseException.class);

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PipelineBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PipelineBuildActionTest.java
@@ -42,13 +42,13 @@ public class PipelineBuildActionTest {
     FreeStyleProject testProject;
 
     @Before
-    public void setUp() throws IOException{
+    public void setUp() throws IOException {
         testProject = jenkins.createFreeStyleProject();
         testProject.addTrigger(trigger);
     }
 
     @Test
-    public void buildOnSuccess () throws IOException {
+    public void buildOnSuccess() throws IOException {
         exception.expect(HttpResponses.HttpResponseException.class);
         new PipelineBuildAction(testProject, getJson("PipelineEvent.json"), null).execute(response);
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildActionTest.java
@@ -103,9 +103,10 @@ public class PushBuildActionTest {
         GitSCMSource source = new GitSCMSource("http://test");
         SCMSourceOwner item = mock(SCMSourceOwner.class);
         when(item.getSCMSources()).thenReturn(Collections.singletonList(source));
-        Assert.assertThrows(HttpResponses.HttpResponseException.class, () -> new PushBuildAction(item, getJson("PushEvent.json"), null).execute(response));
+        Assert.assertThrows(
+                HttpResponses.HttpResponseException.class,
+                () -> new PushBuildAction(item, getJson("PushEvent.json"), null).execute(response));
         verify(item).onSCMSourceUpdated(isA(GitSCMSource.class));
-
     }
 
     @Test
@@ -114,7 +115,9 @@ public class PushBuildActionTest {
         source.getTraits().add(new IgnoreOnPushNotificationTrait());
         SCMSourceOwner item = mock(SCMSourceOwner.class);
         when(item.getSCMSources()).thenReturn(Collections.singletonList(source));
-        Assert.assertThrows(HttpResponses.HttpResponseException.class, () -> new PushBuildAction(item, getJson("PushEvent.json"), null).execute(response));
+        Assert.assertThrows(
+                HttpResponses.HttpResponseException.class,
+                () -> new PushBuildAction(item, getJson("PushEvent.json"), null).execute(response));
         verify(item, never()).onSCMSourceUpdated(isA(GitSCMSource.class));
     }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/BuildPageRedirectActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/BuildPageRedirectActionTest.java
@@ -35,10 +35,13 @@ public abstract class BuildPageRedirectActionTest {
 
     @Rule
     public TemporaryFolder tmp = new TemporaryFolder();
+
     protected String commitSha1;
     protected String branch = "master";
+
     @Mock
     private StaplerResponse response;
+
     private String gitRepoUrl;
 
     @Before
@@ -66,14 +69,17 @@ public abstract class BuildPageRedirectActionTest {
     }
 
     @Test
-    public void redirectToBuildStatusUrl() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    public void redirectToBuildStatusUrl()
+            throws IOException, ExecutionException, InterruptedException, TimeoutException {
         FreeStyleProject testProject = jenkins.createFreeStyleProject();
         testProject.setScm(new GitSCM(gitRepoUrl));
         testProject.setQuietPeriod(0);
         QueueTaskFuture<FreeStyleBuild> future = testProject.scheduleBuild2(0);
         FreeStyleBuild build = future.get(15, TimeUnit.SECONDS);
 
-        doThrow(IOException.class).when(response).sendRedirect2(jenkins.getInstance().getRootUrl() + build.getUrl());
+        doThrow(IOException.class)
+                .when(response)
+                .sendRedirect2(jenkins.getInstance().getRootUrl() + build.getUrl());
         getBuildPageRedirectAction(testProject).execute(response);
 
         verify(response).sendRedirect2(jenkins.getInstance().getRootUrl() + build.getBuildStatusUrl());

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/BuildStatusActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/BuildStatusActionTest.java
@@ -80,7 +80,8 @@ public abstract class BuildStatusActionTest {
         testProject.setScm(new GitSCM(gitRepoUrl));
         testProject.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 build.setResult(Result.FAILURE);
                 return true;
             }
@@ -102,7 +103,8 @@ public abstract class BuildStatusActionTest {
         testProject.setScm(new GitSCM(gitRepoUrl));
         testProject.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 buildStarted.signal();
                 keepRunning.block();
                 return true;
@@ -125,7 +127,8 @@ public abstract class BuildStatusActionTest {
         testProject.setScm(new GitSCM(gitRepoUrl));
         testProject.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 try {
                     build.doStop();
                 } catch (ServletException e) {
@@ -149,7 +152,8 @@ public abstract class BuildStatusActionTest {
         testProject.setScm(new GitSCM(gitRepoUrl));
         testProject.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 build.setResult(Result.UNSTABLE);
                 return true;
             }
@@ -168,7 +172,6 @@ public abstract class BuildStatusActionTest {
         FreeStyleProject testProject = jenkins.createFreeStyleProject();
         testProject.setScm(new GitSCM(gitRepoUrl));
 
-
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         mockResponse(out);
         getBuildStatusAction(testProject).execute(response);
@@ -178,15 +181,20 @@ public abstract class BuildStatusActionTest {
 
     protected abstract BuildStatusAction getBuildStatusAction(FreeStyleProject project);
 
-    protected abstract void assertSuccessfulBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
+    protected abstract void assertSuccessfulBuild(
+            FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
 
-    protected abstract void assertFailedBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
+    protected abstract void assertFailedBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response)
+            throws IOException;
 
-    protected abstract void assertRunningBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
+    protected abstract void assertRunningBuild(
+            FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
 
-    protected abstract void assertCanceledBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
+    protected abstract void assertCanceledBuild(
+            FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
 
-    protected abstract void assertUnstableBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
+    protected abstract void assertUnstableBuild(
+            FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException;
 
     protected abstract void assertNotFoundBuild(ByteArrayOutputStream out, StaplerResponse response) throws IOException;
 
@@ -196,16 +204,14 @@ public abstract class BuildStatusActionTest {
             public void write(int b) throws IOException {
                 out.write(b);
             }
+
             @Override
-            public void setWriteListener(javax.servlet.WriteListener writeListener) {
-            }
+            public void setWriteListener(javax.servlet.WriteListener writeListener) {}
 
             @Override
             public boolean isReady() {
                 return true;
             }
-
-
         };
         when(response.getOutputStream()).thenReturn(servletOutputStream);
         when(response.getWriter()).thenReturn(new PrintWriter(servletOutputStream));

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/StatusJsonActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/StatusJsonActionTest.java
@@ -56,7 +56,8 @@ public class StatusJsonActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertUnstableBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
+    protected void assertUnstableBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response)
+            throws IOException {
         JSONObject object = JSONObject.fromObject(new String(out.toByteArray()));
         assertThat(object.getString("sha"), is(commitSha1));
         assertThat(object.getInt("id"), is(build.getNumber()));

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/StatusPngActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/StatusPngActionTest.java
@@ -16,7 +16,8 @@ import org.kohsuke.stapler.StaplerResponse;
 public abstract class StatusPngActionTest extends BuildStatusActionTest {
 
     @Override
-    protected void assertSuccessfulBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
+    protected void assertSuccessfulBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response)
+            throws IOException {
         verify(response).setHeader("Expires", "Fri, 01 Jan 1984 00:00:00 GMT");
         verify(response).setHeader("Cache-Control", "no-cache, private");
         verify(response).setHeader("Content-Type", "image/png");
@@ -24,7 +25,8 @@ public abstract class StatusPngActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertFailedBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
+    protected void assertFailedBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response)
+            throws IOException {
         verify(response).setHeader("Expires", "Fri, 01 Jan 1984 00:00:00 GMT");
         verify(response).setHeader("Cache-Control", "no-cache, private");
         verify(response).setHeader("Content-Type", "image/png");
@@ -32,7 +34,8 @@ public abstract class StatusPngActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertRunningBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
+    protected void assertRunningBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response)
+            throws IOException {
         verify(response).setHeader("Expires", "Fri, 01 Jan 1984 00:00:00 GMT");
         verify(response).setHeader("Cache-Control", "no-cache, private");
         verify(response).setHeader("Content-Type", "image/png");
@@ -40,7 +43,8 @@ public abstract class StatusPngActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertCanceledBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
+    protected void assertCanceledBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response)
+            throws IOException {
         verify(response).setHeader("Expires", "Fri, 01 Jan 1984 00:00:00 GMT");
         verify(response).setHeader("Cache-Control", "no-cache, private");
         verify(response).setHeader("Content-Type", "image/png");
@@ -48,7 +52,8 @@ public abstract class StatusPngActionTest extends BuildStatusActionTest {
     }
 
     @Override
-    protected void assertUnstableBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response) throws IOException {
+    protected void assertUnstableBuild(FreeStyleBuild build, ByteArrayOutputStream out, StaplerResponse response)
+            throws IOException {
         verify(response).setHeader("Expires", "Fri, 01 Jan 1984 00:00:00 GMT");
         verify(response).setHeader("Cache-Control", "no-cache, private");
         verify(response).setHeader("Content-Type", "image/png");

--- a/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStepTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabCommitStatusStepTest.java
@@ -16,8 +16,8 @@ public class GitLabCommitStatusStepTest {
     @Test
     public void bare_gitlabCommitStatus() throws Exception {
         WorkflowJob project = j.createProject(WorkflowJob.class);
-        String pipelineText =  IOUtils.toString(getClass().getResourceAsStream(
-            "pipeline/bare-gitlabCommitStatus-pipeline.groovy"));
+        String pipelineText =
+                IOUtils.toString(getClass().getResourceAsStream("pipeline/bare-gitlabCommitStatus-pipeline.groovy"));
         project.setDefinition(new CpsFlowDefinition(pipelineText, false));
         Run<?, ?> build = j.buildAndAssertSuccess(project);
         j.assertLogContains("this is simple jenkins-build", build);
@@ -26,8 +26,8 @@ public class GitLabCommitStatusStepTest {
     @Test
     public void named_simple_pipeline_builds_as_LString() throws Exception {
         WorkflowJob project = j.createProject(WorkflowJob.class);
-        String pipelineText =  IOUtils.toString(getClass().getResourceAsStream(
-            "pipeline/named-simple-pipeline-builds-as-LString.groovy"));
+        String pipelineText = IOUtils.toString(
+                getClass().getResourceAsStream("pipeline/named-simple-pipeline-builds-as-LString.groovy"));
         project.setDefinition(new CpsFlowDefinition(pipelineText, false));
         Run<?, ?> build = j.buildAndAssertSuccess(project);
         j.assertLogContains("this is pre-build stage", build);
@@ -36,8 +36,8 @@ public class GitLabCommitStatusStepTest {
     @Test
     public void named_simple_pipeline_builds_as_String() throws Exception {
         WorkflowJob project = j.createProject(WorkflowJob.class);
-        String pipelineText =  IOUtils.toString(getClass().getResourceAsStream(
-            "pipeline/named-simple-pipeline-builds-as-String.groovy"));
+        String pipelineText = IOUtils.toString(
+                getClass().getResourceAsStream("pipeline/named-simple-pipeline-builds-as-String.groovy"));
         project.setDefinition(new CpsFlowDefinition(pipelineText, false));
         Run<?, ?> build = j.buildAndAssertSuccess(project);
         j.assertLogContains("this is pre-build stage", build);
@@ -46,8 +46,7 @@ public class GitLabCommitStatusStepTest {
     @Test
     public void multisite() throws Exception {
         WorkflowJob project = j.createProject(WorkflowJob.class);
-        String pipelineText =  IOUtils.toString(getClass().getResourceAsStream(
-            "pipeline/multisite-pipeline.groovy"));
+        String pipelineText = IOUtils.toString(getClass().getResourceAsStream("pipeline/multisite-pipeline.groovy"));
         project.setDefinition(new CpsFlowDefinition(pipelineText, false));
         Run<?, ?> build = j.buildAndAssertSuccess(project);
         j.assertLogContains("this is stage3", build);
@@ -56,8 +55,8 @@ public class GitLabCommitStatusStepTest {
     @Test
     public void multiproject_specific_connection() throws Exception {
         WorkflowJob project = j.createProject(WorkflowJob.class);
-        String pipelineText =  IOUtils.toString(getClass().getResourceAsStream(
-            "pipeline/multiproject-specific-connection-pipeline.groovy"));
+        String pipelineText = IOUtils.toString(
+                getClass().getResourceAsStream("pipeline/multiproject-specific-connection-pipeline.groovy"));
         project.setDefinition(new CpsFlowDefinition(pipelineText, false));
         Run<?, ?> build = j.buildAndAssertSuccess(project);
         j.assertLogContains("this is pre-build stage", build);
@@ -66,8 +65,7 @@ public class GitLabCommitStatusStepTest {
     @Test
     public void multiproject() throws Exception {
         WorkflowJob project = j.createProject(WorkflowJob.class);
-        String pipelineText =  IOUtils.toString(getClass().getResourceAsStream(
-            "pipeline/multiproject-pipeline.groovy"));
+        String pipelineText = IOUtils.toString(getClass().getResourceAsStream("pipeline/multiproject-pipeline.groovy"));
         project.setDefinition(new CpsFlowDefinition(pipelineText, false));
         Run<?, ?> build = j.buildAndAssertSuccess(project);
         j.assertLogContains("this is pre-build stage", build);

--- a/src/test/java/com/dabsquared/gitlabjenkins/workflow/UpdateGitLabCommitStatusStepTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/workflow/UpdateGitLabCommitStatusStepTest.java
@@ -26,9 +26,11 @@ import org.mockserver.junit.MockServerRule;
 
 public class UpdateGitLabCommitStatusStepTest {
 
-    @Rule public RealJenkinsRule rr = new RealJenkinsRule();
+    @Rule
+    public RealJenkinsRule rr = new RealJenkinsRule();
 
-    @Rule public MockServerRule mockServer = new MockServerRule(new Object());
+    @Rule
+    public MockServerRule mockServer = new MockServerRule(new Object());
 
     private MockServerClient mockServerClient;
 
@@ -46,15 +48,13 @@ public class UpdateGitLabCommitStatusStepTest {
     public void updateGitlabCommitStatus() throws Throwable {
         int port = mockServer.getPort();
         String pipelineText =
-                IOUtils.toString(
-                        getClass().getResourceAsStream("pipeline/updateGitlabCommitStatus.groovy"));
+                IOUtils.toString(getClass().getResourceAsStream("pipeline/updateGitlabCommitStatus.groovy"));
         rr.then(j -> {
             _updateGitlabCommitStatus(j, port, pipelineText);
         });
     }
 
-    private static void _updateGitlabCommitStatus(JenkinsRule j, int port, String pipelineText)
-            throws Throwable {
+    private static void _updateGitlabCommitStatus(JenkinsRule j, int port, String pipelineText) throws Throwable {
         setupGitLabConnections(j, port);
         WorkflowJob project = j.createProject(WorkflowJob.class);
         project.setDefinition(new CpsFlowDefinition(pipelineText, false));
@@ -77,14 +77,13 @@ public class UpdateGitLabCommitStatusStepTest {
                                 Secret.fromString("secret")));
             }
         }
-        connectionConfig.addConnection(
-                new GitLabConnection(
-                        "test-connection",
-                        "http://localhost:" + port + "/gitlab",
-                        "apiTokenId",
-                        new V4GitLabClientBuilder(),
-                        false,
-                        10,
-                        10));
+        connectionConfig.addConnection(new GitLabConnection(
+                "test-connection",
+                "http://localhost:" + port + "/gitlab",
+                "apiTokenId",
+                new V4GitLabClientBuilder(),
+                false,
+                10,
+                10));
     }
 }


### PR DESCRIPTION
This PR applies the Spotless configuration from https://github.com/jenkinsci/plugin-pom/pull/733 to this repository and formats the entire repository by running `mvn spotless:apply`. See that PR for a description of the changes and their motivation. Since formatting is a subjective matter, the choice is up to the maintainers about whether or not they wish to opt in. I would not be upset if the maintainers choose not to accept this PR. If accepted, the next steps after merging this PR would be to add a `.git-blame-ignore-revs` file so that this commit does not show up in Git blame.