### PR TITLE
Replace mockito-inline with mockito-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Replace mockito-inline with mockito-core

https://github.com/jenkinsci/embeddable-build-status-plugin/pull/191 notes that mockito-inline was removed in mockito/mockito#2945, replaced with mockito-core. Consumers of mockito-inline should replace their dependency on mockito-inline with a dependency on mockito-core.

This change prepares for the bump of the parent pom from 4.59 to 4.60.
