### PR TITLE
Add getters to patch AcceptGitLabMergeRequestStep.java

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/AcceptGitLabMergeRequestStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/AcceptGitLabMergeRequestStep.java
@@ -56,11 +56,11 @@ public class AcceptGitLabMergeRequestStep extends Step {
     }
 
     public Boolean getRemoveSourceBranch() {
-        return removeSourceBranch;
+        return this.removeSourceBranch;
     }
 
     public boolean getUseMRDescription() {
-        return useMRDescription;
+        return this.useMRDescription;
     }
 
     @DataBoundSetter

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/AcceptGitLabMergeRequestStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/AcceptGitLabMergeRequestStep.java
@@ -55,6 +55,14 @@ public class AcceptGitLabMergeRequestStep extends Step {
         return mergeCommitMessage;
     }
 
+    public Boolean getRemoveSourceBranch() {
+        return removeSourceBranch;
+    }
+
+    public boolean getUseMRDescription() {
+        return useMRDescription;
+    }
+
     @DataBoundSetter
     public void setMergeCommitMessage(String mergeCommitMessage) {
         this.mergeCommitMessage = StringUtils.isEmpty(mergeCommitMessage) ? null : mergeCommitMessage;


### PR DESCRIPTION
When using Snippet Generator of pipeline generator for acceptGitLabMR this error message comes  - `no public field ‘useMRDescription’ (or getter method) found in class com.dabsquared.gitlabjenkins.workflow.AcceptGitLabMergeRequestStep`. Adding required getters to patch this issue.

Closes #692
