### PR TITLE
Add gitlabMergeCommitSha to Fix #1046

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ gitlabSourceNamespace
 gitlabSourceRepoURL
 gitlabSourceRepoSshUrl
 gitlabSourceRepoHttpUrl
+gitlabMergeCommitSha
 gitlabMergeRequestTitle
 gitlabMergeRequestDescription
 gitlabMergeRequestId

--- a/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
@@ -31,6 +31,7 @@ public final class CauseData {
     private final String sourceRepoUrl;
     private final String sourceRepoSshUrl;
     private final String sourceRepoHttpUrl;
+    private final String mergeCommitSha;
     private final String mergeRequestTitle;
     private final String mergeRequestDescription;
     private final Integer mergeRequestId;
@@ -77,6 +78,7 @@ public final class CauseData {
             String sourceRepoUrl,
             String sourceRepoSshUrl,
             String sourceRepoHttpUrl,
+            String mergeCommitSha,
             String mergeRequestTitle,
             String mergeRequestDescription,
             Integer mergeRequestId,
@@ -120,6 +122,7 @@ public final class CauseData {
         this.sourceRepoUrl = sourceRepoUrl == null ? sourceRepoSshUrl : sourceRepoUrl;
         this.sourceRepoSshUrl = Objects.requireNonNull(sourceRepoSshUrl, "sourceRepoSshUrl must not be null.");
         this.sourceRepoHttpUrl = Objects.requireNonNull(sourceRepoHttpUrl, "sourceRepoHttpUrl must not be null.");
+        this.mergeCommitSha = mergeCommitSha == null ? "" : mergeCommitSha;
         this.mergeRequestTitle = Objects.requireNonNull(mergeRequestTitle, "mergeRequestTitle must not be null.");
         this.mergeRequestDescription = mergeRequestDescription == null ? "" : mergeRequestDescription;
         this.mergeRequestId = mergeRequestId;
@@ -166,6 +169,7 @@ public final class CauseData {
         variables.put("gitlabSourceRepoURL", sourceRepoUrl);
         variables.put("gitlabSourceRepoSshUrl", sourceRepoSshUrl);
         variables.put("gitlabSourceRepoHttpUrl", sourceRepoHttpUrl);
+        variables.putIfNotNull("gitlabMergeCommitSha", mergeCommitSha);
         variables.put("gitlabMergeRequestTitle", mergeRequestTitle);
         variables.put("gitlabMergeRequestDescription", mergeRequestDescription);
         variables.put("gitlabMergeRequestId", mergeRequestId == null ? "" : mergeRequestId.toString());
@@ -271,6 +275,11 @@ public final class CauseData {
     @Exported
     public String getMergeRequestTitle() {
         return mergeRequestTitle;
+    }
+
+    @Exported
+    public String getMergeCommitSha() {
+        return mergeCommitSha;
     }
 
     @Exported
@@ -421,6 +430,7 @@ public final class CauseData {
         return new MergeRequest(
                 mergeRequestId,
                 mergeRequestIid,
+                mergeCommitSha,
                 sourceBranch,
                 targetBranch,
                 mergeRequestTitle,
@@ -454,6 +464,7 @@ public final class CauseData {
                 .append(sourceRepoUrl, causeData.sourceRepoUrl)
                 .append(sourceRepoSshUrl, causeData.sourceRepoSshUrl)
                 .append(sourceRepoHttpUrl, causeData.sourceRepoHttpUrl)
+                .append(mergeCommitSha, causeData.mergeCommitSha)
                 .append(mergeRequestTitle, causeData.mergeRequestTitle)
                 .append(mergeRequestDescription, causeData.mergeRequestDescription)
                 .append(mergeRequestId, causeData.mergeRequestId)
@@ -502,6 +513,7 @@ public final class CauseData {
                 .append(sourceRepoUrl)
                 .append(sourceRepoSshUrl)
                 .append(sourceRepoHttpUrl)
+                .append(mergeCommitSha)
                 .append(mergeRequestTitle)
                 .append(mergeRequestDescription)
                 .append(mergeRequestId)
@@ -550,6 +562,7 @@ public final class CauseData {
                 .append("sourceRepoUrl", sourceRepoUrl)
                 .append("sourceRepoSshUrl", sourceRepoSshUrl)
                 .append("sourceRepoHttpUrl", sourceRepoHttpUrl)
+                .append("mergeCommitSha", mergeCommitSha)
                 .append("mergeRequestTitle", mergeRequestTitle)
                 .append("mergeRequestDescription", mergeRequestDescription)
                 .append("mergeRequestId", mergeRequestId)

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/MergeRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/MergeRequest.java
@@ -17,6 +17,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 public class MergeRequest {
     private Integer id;
     private Integer iid;
+    private String commitSha;
     private String sourceBranch;
     private String targetBranch;
     private Integer projectId;
@@ -41,6 +42,7 @@ public class MergeRequest {
     public MergeRequest(
             int id,
             int iid,
+            String commitSha,
             String sourceBranch,
             String targetBranch,
             String title,
@@ -50,6 +52,7 @@ public class MergeRequest {
             String mergeStatus) {
         this.id = id;
         this.iid = iid;
+        this.commitSha = commitSha;
         this.sourceBranch = sourceBranch;
         this.targetBranch = targetBranch;
         this.title = title;
@@ -75,6 +78,15 @@ public class MergeRequest {
 
     public void setIid(Integer iid) {
         this.iid = iid;
+    }
+
+    @Exported
+    public String getCommitSha() {
+        return commitSha;
+    }
+
+    public void setCommitSha(String commitSha) {
+        this.commitSha = commitSha;
     }
 
     @Exported
@@ -233,6 +245,7 @@ public class MergeRequest {
         return new EqualsBuilder()
                 .append(id, that.id)
                 .append(iid, that.iid)
+                .append(commitSha, that.commitSha)
                 .append(sourceBranch, that.sourceBranch)
                 .append(targetBranch, that.targetBranch)
                 .append(projectId, that.projectId)
@@ -257,6 +270,7 @@ public class MergeRequest {
         return new HashCodeBuilder(17, 37)
                 .append(id)
                 .append(iid)
+                .append(commitSha)
                 .append(sourceBranch)
                 .append(targetBranch)
                 .append(projectId)
@@ -281,6 +295,7 @@ public class MergeRequest {
         return new ToStringBuilder(this)
                 .append("id", id)
                 .append("iid", iid)
+                .append("commitSha", commitSha)
                 .append("sourceBranch", sourceBranch)
                 .append("targetBranch", targetBranch)
                 .append("projectId", projectId)

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestObjectAttributes.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestObjectAttributes.java
@@ -30,6 +30,7 @@ public class MergeRequestObjectAttributes {
     private Commit lastCommit;
     private String oldrev;
     private String mergeStatus;
+    private String mergeCommitSha;
     private String url;
     private Action action;
     private Boolean workInProgress;
@@ -170,6 +171,14 @@ public class MergeRequestObjectAttributes {
         this.oldrev = oldrev;
     }
 
+    public String getMergeCommitSha() {
+        return mergeCommitSha;
+    }
+
+    public void setMergeCommitSha(String mergeCommitSha) {
+        this.mergeCommitSha = mergeCommitSha;
+    }
+
     public String getMergeStatus() {
         return mergeStatus;
     }
@@ -228,6 +237,7 @@ public class MergeRequestObjectAttributes {
                 .append(source, that.source)
                 .append(target, that.target)
                 .append(lastCommit, that.lastCommit)
+                .append(mergeCommitSha, that.mergeCommitSha)
                 .append(mergeStatus, that.mergeStatus)
                 .append(url, that.url)
                 .append(action, that.action)
@@ -255,6 +265,7 @@ public class MergeRequestObjectAttributes {
                 .append(source)
                 .append(target)
                 .append(lastCommit)
+                .append(mergeCommitSha)
                 .append(mergeStatus)
                 .append(url)
                 .append(action)
@@ -281,6 +292,7 @@ public class MergeRequestObjectAttributes {
                 .append("source", source)
                 .append("target", target)
                 .append("lastCommit", lastCommit)
+                .append("mergeCommitSha", mergeCommitSha)
                 .append("mergeStatus", mergeStatus)
                 .append("url", url)
                 .append("action", action)

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -206,6 +206,7 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
                 .withSourceRepoUrl(hook.getObjectAttributes().getSource().getUrl())
                 .withSourceRepoSshUrl(hook.getObjectAttributes().getSource().getSshUrl())
                 .withSourceRepoHttpUrl(hook.getObjectAttributes().getSource().getHttpUrl())
+                .withMergeCommitSha(hook.getObjectAttributes().getMergeCommitSha())
                 .withMergeRequestTitle(hook.getObjectAttributes().getTitle())
                 .withMergeRequestDescription(hook.getObjectAttributes().getDescription())
                 .withMergeRequestId(hook.getObjectAttributes().getId())
@@ -243,7 +244,9 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
     }
 
     private String retrieveRevisionToBuild(MergeRequestHook hook) throws NoRevisionToBuildException {
-        if (hook.getObjectAttributes() != null
+        if (hook.getObjectAttributes().getMergeCommitSha() != null) {
+            return hook.getObjectAttributes().getMergeCommitSha();
+        } else if (hook.getObjectAttributes() != null
                 && hook.getObjectAttributes().getLastCommit() != null
                 && hook.getObjectAttributes().getLastCommit().getId() != null) {
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/OpenMergeRequestPushHookTriggerHandler.java
@@ -165,6 +165,7 @@ class OpenMergeRequestPushHookTriggerHandler implements PushHookTriggerHandler {
                 .withSourceRepoUrl(project.getSshUrlToRepo())
                 .withSourceRepoSshUrl(project.getSshUrlToRepo())
                 .withSourceRepoHttpUrl(project.getHttpUrlToRepo())
+                .withMergeCommitSha(mergeRequest.getCommitSha())
                 .withMergeRequestTitle(mergeRequest.getTitle())
                 .withMergeRequestDescription(mergeRequest.getDescription())
                 .withMergeRequestId(mergeRequest.getId())

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImpl.java
@@ -73,6 +73,7 @@ class PushHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<PushHook>
                     .withSourceRepoUrl(hook.getRepository().getUrl())
                     .withSourceRepoSshUrl(hook.getRepository().getGitSshUrl())
                     .withSourceRepoHttpUrl(hook.getRepository().getGitHttpUrl())
+                    .withMergeCommitSha(null)
                     .withMergeRequestTitle("")
                     .withMergeRequestDescription("")
                     .withMergeRequestId(null)

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/TestUtility.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/TestUtility.java
@@ -131,7 +131,7 @@ final class TestUtility {
     static <P extends MergeRequestNotifier> P preparePublisher(P publisher, AbstractBuild build) {
         P spyPublisher = spy(publisher);
         MergeRequest mergeRequest =
-                new MergeRequest(MERGE_REQUEST_ID, MERGE_REQUEST_IID, "", "", "", PROJECT_ID, PROJECT_ID, "", "");
+                new MergeRequest(MERGE_REQUEST_ID, MERGE_REQUEST_IID, "", "", "", "", PROJECT_ID, PROJECT_ID, "", "");
         doReturn(mergeRequest).when(spyPublisher).getMergeRequest(build);
         return spyPublisher;
     }

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/TestUtility.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/TestUtility.java
@@ -44,6 +44,7 @@ final class TestUtility {
     static final String GITLAB_CONNECTION_V3 = "GitLabV3";
     static final String GITLAB_CONNECTION_V4 = "GitLabV4";
     static final String BUILD_URL = "/build/123";
+    static final String MERGE_COMMIT_SHA = "eKJ3wuqJT98Kc8TCcBK7oggLR1E9Bty7eqSHfSLT";
     static final int BUILD_NUMBER = 1;
     static final int PROJECT_ID = 3;
     static final int MERGE_REQUEST_ID = 1;
@@ -130,8 +131,8 @@ final class TestUtility {
 
     static <P extends MergeRequestNotifier> P preparePublisher(P publisher, AbstractBuild build) {
         P spyPublisher = spy(publisher);
-        MergeRequest mergeRequest =
-                new MergeRequest(MERGE_REQUEST_ID, MERGE_REQUEST_IID, "", "", "", "", PROJECT_ID, PROJECT_ID, "", "");
+        MergeRequest mergeRequest = new MergeRequest(
+                MERGE_REQUEST_ID, MERGE_REQUEST_IID, MERGE_COMMIT_SHA, "", "", "", PROJECT_ID, PROJECT_ID, "", "");
         doReturn(mergeRequest).when(spyPublisher).getMergeRequest(build);
         return spyPublisher;
     }


### PR DESCRIPTION
Hello, 

This PR fix the following problems:
- https://github.com/jenkinsci/gitlab-plugin/issues/1046
- https://issues.jenkins.io/browse/JENKINS-61964

If parameter `gitlabMergeCommitSha` is found in webhook, then Jenkins will check out git repository to squash/merge commit, not to the last commit from source branch.

Tested on the following environment:
- Jenkins 2.388 and 2.397
- GitLab Community Edition [15.11.2](https://gitlab.com/gitlab-org/gitlab-foss/-/tags/v15.11.2)

Closes #1046. 