### PR TITLE
Use latest plugin BOM for 2.387.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
       <dependency>
         <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>2102.v854b_fec19c92</version>
+        <artifactId>bom-2.387.x</artifactId>
+        <version>2179.v0884e842b_859</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Use latest plugin BOM for 2.387.x

The minimum Jenkins version is already set to 2.387.3 so we should also update the plugin bill of materials to rely on 2.387.x as well.
