### PR TITLE
Add JAVA_TOOLS_OPTIONS to environment of jenkins in docker-compose.yml

### DIFF
--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -28,4 +28,6 @@ services:
       - "50000:50000"
     volumes:
       - '/srv/docker/jenkins:/var/jenkins_home'
+    environment:
+      - "JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:50000"
     shm_size: '5gb'


### PR DESCRIPTION
<!-- ### Before submitting a pull request, please make sure you read the instructions in the ["Contribution to the Plugin"](https://github.com/jenkinsci/gitlab-plugin/tree/master#contributing-to-the-plugin) section in the README.

*(if you read the above instructions, remove the paragraph and start describing the pull request)* -->
## Description
In order to enable the IDE (in this case IntelliJ) debugger to be connected to the docker instance, we will need to add the environment variable` JAVA_TOOLS_OPTIONS` with some specific value to the `docker-compose.yml` file. 

In our case for connecting to port `50000`:
`"JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:50000"`
