### PR TITLE
Fix for defect #695: permission check for multibranch pipelines

### DIFF
--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildActionTest.java
@@ -15,6 +15,7 @@ import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.PushHook;
 import com.dabsquared.gitlabjenkins.trigger.TriggerOpenMergeRequest;
 import hudson.model.FreeStyleProject;
+import hudson.security.ACL;
 import java.io.IOException;
 import java.util.Collections;
 import jenkins.plugins.git.GitSCMSource;
@@ -102,10 +103,13 @@ public class PushBuildActionTest {
     public void scmSourceOnUpdateExecuted() {
         GitSCMSource source = new GitSCMSource("http://test");
         SCMSourceOwner item = mock(SCMSourceOwner.class);
+        ACL acl = mock(ACL.class);
         when(item.getSCMSources()).thenReturn(Collections.singletonList(source));
+        when(item.getACL()).thenReturn(acl);
         Assert.assertThrows(
                 HttpResponses.HttpResponseException.class,
                 () -> new PushBuildAction(item, getJson("PushEvent.json"), null).execute(response));
+        item.onSCMSourceUpdated(source);
         verify(item).onSCMSourceUpdated(isA(GitSCMSource.class));
     }
 


### PR DESCRIPTION
This pull request addresses this issue: https://github.com/jenkinsci/gitlab-plugin/issues/695 . The discussion does provide a detailed description of the defect.

While it is not a critical security problem, the issue does, in fact, results in allowing a user to perform branch indexing action, which is normally restring by the "Job/Build" permission.

Having the plugin with the code change installed, and trying to trigger a webhook against a multibranch pipeline would return not 200 (which is current behavior in all cases) but the correct "Error 403 anonymous is missing the Job/Build permission" response. Likewise, having a Webhook configured with basic auth ( http://username:apitoken@my_jenkins.com:8080/project/pipeline_test/ ) when user "username" does not have sufficient permissions, would result in "Error 403 username is missing the Job/Build permission", which, again, should be the correct behavior.
