### PR TITLE
do not sign git commits in tests

### DIFF
--- a/src/test/java/com/dabsquared/gitlabjenkins/testing/integration/GitLabIT.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testing/integration/GitLabIT.java
@@ -250,7 +250,7 @@ public class GitLabIT {
         // Setup remote master branch
         tmp.newFile("test");
         git.add().addFilepattern("test");
-        RevCommit commit = git.commit().setMessage("test").call();
+        RevCommit commit = git.commit().setSign(false).setMessage("test").call();
         git.push()
                 .setRemote("origin")
                 .add("master")
@@ -262,7 +262,7 @@ public class GitLabIT {
             // Setup remote feature branch
             git.checkout().setName("feature").setCreateBranch(true).call();
             tmp.newFile("feature");
-            commit = git.commit().setMessage("feature").call();
+            commit = git.commit().setSign(false).setMessage("feature").call();
             git.push()
                     .setRemote("origin")
                     .add("feature")

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImplTest.java
@@ -397,7 +397,7 @@ public class MergeRequestHookTriggerHandlerImplTest {
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());
         git.add().addFilepattern("test");
-        RevCommit commit = git.commit().setMessage("test").call();
+        RevCommit commit = git.commit().setSign(false).setMessage("test").call();
         ObjectId head = git.getRepository().resolve(Constants.HEAD);
         String repositoryUrl = tmp.getRoot().toURI().toString();
 
@@ -511,7 +511,7 @@ public class MergeRequestHookTriggerHandlerImplTest {
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());
         git.add().addFilepattern("test");
-        RevCommit commit = git.commit().setMessage("test").call();
+        RevCommit commit = git.commit().setSign(false).setMessage("test").call();
         ObjectId head = git.getRepository().resolve(Constants.HEAD);
         String repositoryUrl = tmp.getRoot().toURI().toString();
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImplTest.java
@@ -98,7 +98,7 @@ public class NoteHookTriggerHandlerImplTest {
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());
         git.add().addFilepattern("test");
-        RevCommit commit = git.commit().setMessage("test").call();
+        RevCommit commit = git.commit().setSign(false).setMessage("test").call();
         ObjectId head = git.getRepository().resolve(Constants.HEAD);
         String repositoryUrl = tmp.getRoot().toURI().toString();
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImplTest.java
@@ -64,7 +64,7 @@ public class PipelineHookTriggerHandlerImplTest {
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());
         git.add().addFilepattern("test");
-        git.commit().setMessage("test").call();
+        git.commit().setSign(false).setMessage("test").call();
         ObjectId head = git.getRepository().resolve(Constants.HEAD);
 
         pipelineHookTriggerHandler = new PipelineHookTriggerHandlerImpl(allowedStates);

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerImplTest.java
@@ -89,7 +89,7 @@ public class PushHookTriggerHandlerImplTest {
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());
         git.add().addFilepattern("test");
-        RevCommit commit = git.commit().setMessage("test").call();
+        RevCommit commit = git.commit().setSign(false).setMessage("test").call();
         ObjectId head = git.getRepository().resolve(Constants.HEAD);
         String repositoryUrl = tmp.getRoot().toURI().toString();
 
@@ -141,7 +141,7 @@ public class PushHookTriggerHandlerImplTest {
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());
         git.add().addFilepattern("test");
-        RevCommit commit = git.commit().setMessage("test").call();
+        RevCommit commit = git.commit().setSign(false).setMessage("test").call();
         ObjectId head = git.getRepository().resolve(Constants.HEAD);
         String repositoryUrl = tmp.getRoot().toURI().toString();
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildActionTest.java
@@ -87,7 +87,7 @@ public class MergeRequestBuildActionTest {
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());
         git.add().addFilepattern("test");
-        RevCommit commit = git.commit().setMessage("test").call();
+        RevCommit commit = git.commit().setSign(false).setMessage("test").call();
         commitSha1 = commit.getId().getName();
         gitRepoUrl = tmp.getRoot().toURI().toString();
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/NoteBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/NoteBuildActionTest.java
@@ -61,7 +61,7 @@ public class NoteBuildActionTest {
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());
         git.add().addFilepattern("test");
-        RevCommit commit = git.commit().setMessage("test").call();
+        RevCommit commit = git.commit().setSign(false).setMessage("test").call();
         commitSha1 = commit.getId().getName();
         gitRepoUrl = tmp.getRoot().toURI().toString();
     }

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/BuildPageRedirectActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/BuildPageRedirectActionTest.java
@@ -50,7 +50,7 @@ public abstract class BuildPageRedirectActionTest {
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());
         git.add().addFilepattern("test");
-        RevCommit commit = git.commit().setMessage("test").call();
+        RevCommit commit = git.commit().setSign(false).setMessage("test").call();
         commitSha1 = commit.getId().getName();
         gitRepoUrl = tmp.getRoot().toURI().toString();
     }

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/BuildStatusActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/status/BuildStatusActionTest.java
@@ -56,7 +56,7 @@ public abstract class BuildStatusActionTest {
         tmp.newFile("test");
         Git git = Git.open(tmp.getRoot());
         git.add().addFilepattern("test");
-        RevCommit commit = git.commit().setMessage("test").call();
+        RevCommit commit = git.commit().setSign(false).setMessage("test").call();
         commitSha1 = commit.getId().getName();
         gitRepoUrl = tmp.getRoot().toURI().toString();
     }


### PR DESCRIPTION
Remove signing git commits in tests.
I had been running into test failures regarding git commit signing that I believe were related to my local git environment. Signing the commits did not seem necessary regarding tests, so I thought removing them could reduce some problems and not affect testing too much.