### PR TITLE
Added support for retrieving merge request ref

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/CommitStatusUpdater.java
@@ -162,6 +162,9 @@ public class CommitStatusUpdater {
         if (cause == null) {
             return environment == null ? null : environment.get("BRANCH_NAME", null);
         }
+        if (cause.getData().getActionType() == CauseData.ActionType.MERGE) {
+            return String.format("refs/merge-requests/%s/head", cause.getData().getMergeRequestIid());
+        }
         if (cause.getData().getActionType() == CauseData.ActionType.TAG_PUSH) {
             return StringUtils.removeStart(cause.getData().getSourceBranch(), "refs/tags/");
         }


### PR DESCRIPTION
Added support for merge MERGE enum type when determining the branch name or tag. Without this, a duplicate pipeline is generated in Gitlab when using a merge request pipeline from the gitlab side.