### PR TITLE
Rely on default Jenkins PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,0 @@
-### Before submitting a pull request, please make sure you read the instructions in the ["Contribution to the Plugin"](https://github.com/jenkinsci/gitlab-plugin/tree/master#contributing-to-the-plugin) section in the README.
-
-*(if you read the above instructions, remove the paragraph and start describing the pull request)*


### PR DESCRIPTION
## Rely on default Jenkins PR template

Custom template does not mention several important topics.  For example, the default template guides the submitter to use a branch that is not the master branch.  The default template encourages the submitter to provide tests. The default template encourages the submitter to describe the testing that was performed on the pull request.  Those are all good things that should be used for the GitLab plugin.

https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md is the default template.
