### PR TITLE
Fix "Test Connection" button when used with Jackson 2.16.1 or later

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/JacksonConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/JacksonConfig.java
@@ -18,7 +18,7 @@ import javax.ws.rs.ext.Provider;
 public class JacksonConfig implements ContextResolver<ObjectMapper> {
     public ObjectMapper getContext(Class<?> type) {
         return new ObjectMapper()
-                .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+                .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/util/JsonUtil.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/JsonUtil.java
@@ -20,7 +20,7 @@ import java.util.Locale;
 public final class JsonUtil {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+            .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
             .configure(SerializationFeature.INDENT_OUTPUT, true)


### PR DESCRIPTION
Here is a pull request for the proposed solution as proposed and discussed on the issue #1605 - would be great if you could release that soon please.

### Testing done?

When the most recent Jackson 2 API plugin (2.16.1.x) is used, compilation fails without this change and succeeds with this change.  Interactive testing of the "Test connection" button confirms that the new code is well behaved

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x]  Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests
```
