### PR TITLE
Require Jenkins 2.401.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,11 +71,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>joda-time</groupId>
-        <artifactId>joda-time</artifactId>
-        <version>2.12.5</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -95,6 +90,10 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jersey2-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>joda-time-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
   </distributionManagement>
 
   <properties>
-    <revision>1.7.19</revision>
+    <revision>1.8.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.401.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
   <properties>
     <revision>1.7.19</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.401.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
@@ -66,8 +66,8 @@
       <dependency>
         <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-2.401.x</artifactId>
+        <version>2675.v1515e14da_7a_6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.401.3 or newer

Needed for the Jackson 2.16.1-373.ve709c6871598 release that removes Jackson 2 API constants used by this plugin.

https://github.com/jenkinsci/gitlab-plugin/issues/1605 notes that the CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES constant needs to be replaced
with SNAKE_CASE.

https://github.com/FasterXML/jackson-databind/pull/4162 removed those deprecated aliases in https://github.com/FasterXML/jackson-databind/commit/d7a1efc7f45af4f56c0df4eccb0244418b6428bb

This change is preparation for a dependency on Jackson 2 API 2.16.1.

Also switches to use the joda-time plugin instead of joda-time jar file.

Also increases the plugin version from 1.7.x to 1.8.0 so that users know that they need to install this version.  Without this version, the "Test connection" button will continue to report errors unless the user downgrades their Jackson 2 API plugin to 2.15.2-*.

### Testing done

Automated tests pass.

Interactive testing using this pull request shows the message:

Client error: Class com.fasterxml.jackson.databind.PropertyNamingStrategy does not have member field 'com.fasterxml.jackson.databind.PropertyNamingStrategy CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES

When I replace the Jackson 2 API plugin 2.16.1 with Jackson 2 API plugin 2.15.2, then the "test connection" button reports success.  That shows I can duplicate the problem that is fixed in 

* #1606 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
