### PR TITLE
Fixes the NPE in AbstractWebHookTriggerHandler.java

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/AbstractWebHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/AbstractWebHookTriggerHandler.java
@@ -100,7 +100,7 @@ public abstract class AbstractWebHookTriggerHandler<H extends WebHook> implement
         } catch (NullPointerException e) {
             LOGGER.log(Level.WARNING, e.getMessage(), e);
         }
-    }    
+    }
 
     protected Action[] createActions(Job<?, ?> job, H hook) {
         ArrayList<Action> actions = new ArrayList<>();

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImpl.java
@@ -132,7 +132,9 @@ class PipelineHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<Pipel
                                 ? ""
                                 : hook.getRepository().getGitSshUrl())
                 .withSourceRepoHttpUrl(
-                        hook.getRepository() == null ? "" : hook.getRepository().getGitHttpUrl())
+                        hook.getRepository() == null || hook.getRepository() == null
+                                ? ""
+                                : hook.getRepository().getGitHttpUrl())
                 .withMergeRequestTitle("")
                 .withTargetProjectId(hook.getProject().getId())
                 .withTargetBranch(getTargetBranch(hook) == null ? "" : getTargetBranch(hook))

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImpl.java
@@ -132,9 +132,7 @@ class PipelineHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<Pipel
                                 ? ""
                                 : hook.getRepository().getGitSshUrl())
                 .withSourceRepoHttpUrl(
-                        hook.getRepository() == null || hook.getRepository() == null
-                                ? ""
-                                : hook.getRepository().getGitHttpUrl())
+                    hook.getRepository() == null ? "" : hook.getRepository().getGitHttpUrl())
                 .withMergeRequestTitle("")
                 .withTargetProjectId(hook.getProject().getId())
                 .withTargetBranch(getTargetBranch(hook) == null ? "" : getTargetBranch(hook))


### PR DESCRIPTION
Fixes #1123 NPE error

I think the `job.getProperty(GitLabConnectionProperty.class).getClient();` expression creates the NPE error. That's why I've checked the `connectionProperty` expression first. 