### PR TITLE
update PushBuildAction to use 'AbstractGitSCMSource' to trigger 'GitLab Branch Source' repository scan

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
@@ -20,7 +20,7 @@ import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.plugins.git.traits.IgnoreOnPushNotificationTrait;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
@@ -108,8 +108,8 @@ public class PushBuildAction extends BuildWebHookAction {
 
         public void run() {
             for (SCMSource scmSource : ((SCMSourceOwner) project).getSCMSources()) {
-                if (scmSource instanceof GitSCMSource) {
-                    GitSCMSource gitSCMSource = (GitSCMSource) scmSource;
+                if (scmSource instanceof AbstractGitSCMSource) {
+                    AbstractGitSCMSource gitSCMSource = (AbstractGitSCMSource) scmSource;
                     try {
                         if (new URIish(gitSCMSource.getRemote()).equals(new URIish(gitSCMSource.getRemote()))) {
                             if (SCMTrait.find(gitSCMSource.getTraits(), IgnoreOnPushNotificationTrait.class) == null) {


### PR DESCRIPTION
The 'PushBuildAction' does not trigger updates for projects created with '[GitLab Branch Source](https://github.com/jenkinsci/gitlab-branch-source-plugin)' plugin.

In the Jenkins logs you could only find a trace of the webhook POST sent by the GitLab Jenkins integration, but no further trace of anything and no build was scheduled.

This is because the actual SCMSource implementation in 'GitLab Branch Source' does not inherit from 'GITScmSource'.

Using 'AbstractGitSCMSource' instead of 'GitSCMSource' fixes that.


### Testing done

- In GitLab: create a project with the Jenkins integration switched on
- In Jenkins: create a GitLab Branch Source project with disabled automatic webhook handling
- commit a change into GitLab
- In Jenkins: the log also now shows this trace 'Notify scmSourceOwner xxx_project_xxx about changes for xxx_repo_xxx' and a 'GitLab Branch Source' repository scan is initiated