### PR TITLE
Jenkins queue action added that mimics logic in PendingBuildsHandler to avoid pending pipelines for jobs dropped from the queue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ work
 .settings
 .DS_Store
 META-INF/
+.vscode/

--- a/src/main/java/com/dabsquared/gitlabjenkins/action/BranchQueueAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/action/BranchQueueAction.java
@@ -1,0 +1,42 @@
+package com.dabsquared.gitlabjenkins.action;
+
+import hudson.Util;
+import hudson.model.Action;
+import hudson.model.InvisibleAction;
+import hudson.model.Queue.QueueAction;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Allows the queue scheduler to compare source branches when deduping
+ *
+ * @author Seb Hopley
+ */
+public class BranchQueueAction extends InvisibleAction implements Serializable, QueueAction {
+
+    private String sourceBranch;
+
+    public BranchQueueAction(String sourceBranch) {
+        this.sourceBranch = sourceBranch;
+    }
+
+    public String getSourceBranch() {
+        return sourceBranch;
+    }
+
+    @Override
+    public boolean shouldSchedule(List<Action> actions) {
+        // this shouldn't happen so just return true
+        if (this.sourceBranch == null) {
+            return true;
+        }
+        List<BranchQueueAction> otherActions = Util.filter(actions, BranchQueueAction.class);
+        for (BranchQueueAction action : otherActions) {
+            if (this.sourceBranch.equals(action.getSourceBranch())) {
+                return false;
+            }
+        }
+        // if we get to this point there were no matching actions so a new build is required
+        return true;
+    }
+}

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/AbstractWebHookTriggerHandler.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/AbstractWebHookTriggerHandler.java
@@ -1,5 +1,6 @@
 package com.dabsquared.gitlabjenkins.trigger.handler;
 
+import com.dabsquared.gitlabjenkins.action.BranchQueueAction;
 import com.dabsquared.gitlabjenkins.cause.CauseData;
 import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
@@ -105,6 +106,7 @@ public abstract class AbstractWebHookTriggerHandler<H extends WebHook> implement
     protected Action[] createActions(Job<?, ?> job, H hook) {
         ArrayList<Action> actions = new ArrayList<>();
         actions.add(new CauseAction(new GitLabWebHookCause(retrieveCauseData(hook))));
+        actions.add(new BranchQueueAction(getSourceBranch(hook)));
         try {
             SCMTriggerItem item = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(job);
             GitSCM gitSCM = getGitSCM(item);

--- a/src/test/java/com/dabsquared/gitlabjenkins/action/BranchQueueActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/action/BranchQueueActionTest.java
@@ -1,0 +1,154 @@
+package com.dabsquared.gitlabjenkins.action;
+
+import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.CommitBuilder.commit;
+import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.MergeRequestObjectAttributesBuilder.mergeRequestObjectAttributes;
+import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.UserBuilder.user;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
+import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
+import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.Action;
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.MergeRequestHook;
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.MergeRequestHookBuilder;
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.ProjectBuilder;
+import com.dabsquared.gitlabjenkins.publisher.GitLabCommitStatusPublisher;
+import com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterType;
+import hudson.model.FreeStyleProject;
+import hudson.model.Project;
+import hudson.model.Queue;
+import java.io.IOException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BranchQueueActionTest {
+
+    private static final String GITLAB_BUILD_NAME = "Jenkins";
+
+    @ClassRule
+    public static JenkinsRule jenkins = new JenkinsRule();
+
+    @Mock
+    private GitLabClient gitLabClient;
+
+    @Mock
+    private GitLabConnectionProperty gitLabConnectionProperty;
+
+    @Before
+    public void init() {
+        when(gitLabConnectionProperty.getClient()).thenReturn(gitLabClient);
+    }
+
+    @After
+    public void clearQueue() {
+        Queue queue = jenkins.getInstance().getQueue();
+        for (Queue.Item item : queue.getItems()) {
+            queue.cancel(item);
+        }
+    }
+
+    @Test
+    public void queuedMergeRequestBuildsAreNotCancelledForDifferentSourceBranch() throws IOException {
+        Project project = freestyleProject("project1", new GitLabCommitStatusPublisher(GITLAB_BUILD_NAME, false));
+
+        GitLabPushTrigger gitLabPushTrigger = gitLabPushTrigger(project);
+        gitLabPushTrigger.setCancelPendingBuildsOnUpdate(true);
+
+        assertThat(jenkins.getInstance().getQueue().getItems().length, is(0));
+
+        gitLabPushTrigger.onPost(mergeRequestHook(1, "sourceBranch", "commit1"));
+        gitLabPushTrigger.onPost(
+                mergeRequestHook(1, "anotherBranch", "commit1")); // Same commit different source branch
+
+        assertThat(jenkins.getInstance().getQueue().getItems().length, is(2));
+    }
+
+    @Test
+    public void queuedMergeRequestBuildsAreCancelledForSameBranches() throws IOException {
+        Project project = freestyleProject("project3", new GitLabCommitStatusPublisher(GITLAB_BUILD_NAME, false));
+
+        GitLabPushTrigger gitLabPushTrigger = gitLabPushTrigger(project);
+        gitLabPushTrigger.setCancelPendingBuildsOnUpdate(true);
+
+        assertThat(jenkins.getInstance().getQueue().getItems().length, is(0));
+
+        gitLabPushTrigger.onPost(mergeRequestHook(1, "sourceBranch", "commit1"));
+        gitLabPushTrigger.onPost(mergeRequestHook(1, "sourceBranch", "commit1")); // Same commit and branches
+
+        assertThat(jenkins.getInstance().getQueue().getItems().length, is(1));
+    }
+
+    private GitLabPushTrigger gitLabPushTrigger(Project project) throws IOException {
+        GitLabPushTrigger gitLabPushTrigger = gitLabPushTrigger();
+        project.addTrigger(gitLabPushTrigger);
+        gitLabPushTrigger.start(project, true);
+        return gitLabPushTrigger;
+    }
+
+    private GitLabPushTrigger gitLabPushTrigger() {
+        GitLabPushTrigger gitLabPushTrigger = new GitLabPushTrigger();
+        gitLabPushTrigger.setTriggerOnPush(true);
+        gitLabPushTrigger.setTriggerOnMergeRequest(true);
+        gitLabPushTrigger.setPendingBuildName(GITLAB_BUILD_NAME);
+        gitLabPushTrigger.setBranchFilterType(BranchFilterType.NameBasedFilter);
+        gitLabPushTrigger.setBranchFilterName("");
+        return gitLabPushTrigger;
+    }
+
+    private MergeRequestHook mergeRequestHook(int projectId, String sourceBranch, String commitId) {
+        return MergeRequestHookBuilder.mergeRequestHook()
+                .withObjectAttributes(mergeRequestObjectAttributes()
+                        .withAction(Action.update)
+                        .withState(State.updated)
+                        .withIid(1)
+                        .withTitle("test")
+                        .withTargetProjectId(1)
+                        .withTargetBranch("targetBranch")
+                        .withSourceBranch(sourceBranch)
+                        .withSourceProjectId(projectId)
+                        .withLastCommit(
+                                commit().withAuthor(user().withName("author").build())
+                                        .withId(commitId)
+                                        .build())
+                        .withSource(ProjectBuilder.project()
+                                .withName("test")
+                                .withNamespace("test-namespace")
+                                .withHomepage("https://gitlab.org/test")
+                                .withUrl("git@gitlab.org:test.git")
+                                .withSshUrl("git@gitlab.org:test.git")
+                                .withHttpUrl("https://gitlab.org/test.git")
+                                .build())
+                        .withTarget(ProjectBuilder.project()
+                                .withName("test")
+                                .withNamespace("test-namespace")
+                                .withHomepage("https://gitlab.org/test")
+                                .withUrl("git@gitlab.org:test.git")
+                                .withSshUrl("git@gitlab.org:test.git")
+                                .withHttpUrl("https://gitlab.org/test.git")
+                                .build())
+                        .build())
+                .withProject(ProjectBuilder.project()
+                        .withWebUrl("https://gitlab.org/test.git")
+                        .build())
+                .build();
+    }
+
+    private Project freestyleProject(String name, GitLabCommitStatusPublisher gitLabCommitStatusPublisher)
+            throws IOException {
+        FreeStyleProject project = jenkins.createFreeStyleProject(name);
+        project.setQuietPeriod(5000);
+        project.getPublishersList().add(gitLabCommitStatusPublisher);
+        project.addProperty(gitLabConnectionProperty);
+        return project;
+    }
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/action/BranchQueueActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/action/BranchQueueActionTest.java
@@ -5,6 +5,7 @@ import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.M
 import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.UserBuilder.user;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
@@ -21,6 +22,7 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Project;
 import hudson.model.Queue;
 import java.io.IOException;
+import java.util.Arrays;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -86,6 +88,18 @@ public class BranchQueueActionTest {
         gitLabPushTrigger.onPost(mergeRequestHook(1, "sourceBranch", "commit1")); // Same commit and branches
 
         assertThat(jenkins.getInstance().getQueue().getItems().length, is(1));
+    }
+
+    @Test
+    public void testNullSourceBranch() {
+        BranchQueueAction action1 = new BranchQueueAction(null);
+        BranchQueueAction action2 = new BranchQueueAction("sourceBranch");
+
+        boolean resultOfScheduleNull = action1.shouldSchedule(Arrays.asList(action2));
+        boolean resultOfQueuedNull = action2.shouldSchedule(Arrays.asList(action1));
+
+        assertTrue(resultOfScheduleNull);
+        assertTrue(resultOfQueuedNull);
     }
 
     private GitLabPushTrigger gitLabPushTrigger(Project project) throws IOException {


### PR DESCRIPTION
This change fixes a bug where pipelines are left stuck at pending in Gitlab. 

The issue is that builds with a different source branch but the same commit are not treated as a duplicate by the PendingBuildsHandler (which is correct). The builds get scheduled but the Jenkins queue manager only checks if the commits are the same not the source branch as such it sees the build as a duplicate and removes it from the queue, because the job is never run the pipeline status is never updated and it sits at pending until manually cancelled.

This was fixed by adding a queue action for the queue manger to use to determine if the builds have the same source branch or not.

### Testing done

I've added tests for the scenario.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue