### PR TITLE
Switch Note.id from Integer to Long

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Note.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Note.java
@@ -8,7 +8,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
 public class Note {
-    private Integer id;
+    private Long id;
     private Integer projectId;
     private User author;
     private Date createdAt;
@@ -17,11 +17,11 @@ public class Note {
 
     public Note() {}
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/NoteObjectAttributes.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/NoteObjectAttributes.java
@@ -12,7 +12,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
 public class NoteObjectAttributes {
 
-    private Integer id;
+    private Long id;
     private String note;
     private Integer authorId;
     private Integer projectId;
@@ -20,11 +20,11 @@ public class NoteObjectAttributes {
     private Date updatedAt;
     private String url;
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImplTest.java
@@ -72,7 +72,7 @@ public class NoteHookTriggerHandlerImplTest {
                 project,
                 noteHook()
                         .withObjectAttributes(noteObjectAttributes()
-                                .withId(1)
+                                .withId(1L)
                                 .withNote("ci-run")
                                 .withAuthorId(1)
                                 .withProjectId(1)
@@ -119,7 +119,7 @@ public class NoteHookTriggerHandlerImplTest {
                 project,
                 noteHook()
                         .withObjectAttributes(noteObjectAttributes()
-                                .withId(1)
+                                .withId(1L)
                                 .withNote("ci-run")
                                 .withAuthorId(1)
                                 .withProjectId(1)


### PR DESCRIPTION
## Switch Note.id from Integer to Long

GitLab has changed the data type of the Note id field from int to bigint.

Fixes #1705

https://github.com/jenkinsci/gitlab-plugin/issues/1705#issuecomment-2407261384 describes the issue in more detail.

### Testing done

Automated testing only.  Needs multiple affected users to report their test results with their installations before this can be moved from draft.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
