### PR TITLE
Avoid caching the credential, instead get the credential value whenever it is required through the request filter 

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnection.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnection.java
@@ -1,5 +1,8 @@
 package com.dabsquared.gitlabjenkins.connection;
 
+import static com.dabsquared.gitlabjenkins.gitlab.api.GitLabClientBuilder.getAllGitLabClientBuilders;
+import static com.dabsquared.gitlabjenkins.gitlab.api.GitLabClientBuilder.getGitLabClientBuilderById;
+
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
@@ -21,6 +24,13 @@ import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
 import jenkins.model.Jenkins;
 import org.eclipse.jgit.util.StringUtils;
 import org.kohsuke.accmod.Restricted;
@@ -29,17 +39,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
-
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import static com.dabsquared.gitlabjenkins.gitlab.api.GitLabClientBuilder.getAllGitLabClientBuilders;
-import static com.dabsquared.gitlabjenkins.gitlab.api.GitLabClientBuilder.getGitLabClientBuilderById;
 
 /**
  * @author Robin Müller
@@ -156,7 +155,8 @@ public class GitLabConnection extends AbstractDescribableImpl<GitLabConnection> 
         if (!clientCache.containsKey(clientId)) {
             clientCache.put(
                     clientId,
-                    clientBuilder.buildClient(url, credentialResolver, ignoreCertificateErrors, connectionTimeout, readTimeout));
+                    clientBuilder.buildClient(
+                            url, credentialResolver, ignoreCertificateErrors, connectionTimeout, readTimeout));
         }
         return clientCache.get(clientId);
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
@@ -27,6 +27,7 @@ public class GitlabCredentialResolver {
         return credentialsId;
     }
 
+    @Restricted(NoExternalUse.class)
     public void setCredentialsId(String credentialsId) {
         this.credentialsId = credentialsId;
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
@@ -20,6 +20,7 @@ public class GitlabCredentialResolver {
         return item;
     }
 
+    @Restricted(NoExternalUse.class)
     public void setItem(Item item) {
         this.item = item;
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
@@ -1,6 +1,8 @@
 package com.dabsquared.gitlabjenkins.connection;
 
 import hudson.model.Item;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 public class GitlabCredentialResolver {
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
@@ -22,6 +22,7 @@ public class GitlabCredentialResolver {
         this.item = item;
     }
 
+    @Restricted(NoExternalUse.class)
     public String getCredentialsId() {
         return credentialsId;
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
@@ -7,8 +7,7 @@ public class GitlabCredentialResolver {
     private Item item;
     private String credentialsId;
 
-    public GitlabCredentialResolver() {
-    }
+    public GitlabCredentialResolver() {}
 
     public GitlabCredentialResolver(Item item, String credentialsId) {
         this.item = item;

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
@@ -16,6 +16,7 @@ public class GitlabCredentialResolver {
         this.credentialsId = credentialsId;
     }
 
+    @Restricted(NoExternalUse.class)
     public Item getItem() {
         return item;
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitlabCredentialResolver.java
@@ -1,0 +1,33 @@
+package com.dabsquared.gitlabjenkins.connection;
+
+import hudson.model.Item;
+
+public class GitlabCredentialResolver {
+
+    private Item item;
+    private String credentialsId;
+
+    public GitlabCredentialResolver() {
+    }
+
+    public GitlabCredentialResolver(Item item, String credentialsId) {
+        this.item = item;
+        this.credentialsId = credentialsId;
+    }
+
+    public Item getItem() {
+        return item;
+    }
+
+    public void setItem(Item item) {
+        this.item = item;
+    }
+
+    public String getCredentialsId() {
+        return credentialsId;
+    }
+
+    public void setCredentialsId(String credentialsId) {
+        this.credentialsId = credentialsId;
+    }
+}

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClientBuilder.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClientBuilder.java
@@ -10,8 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-
-import hudson.model.Item;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -50,7 +48,11 @@ public abstract class GitLabClientBuilder implements Comparable<GitLabClientBuil
 
     @NonNull
     public abstract GitLabClient buildClient(
-        String url, GitlabCredentialResolver credentialResolver, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout);
+            String url,
+            GitlabCredentialResolver credentialResolver,
+            boolean ignoreCertificateErrors,
+            int connectionTimeout,
+            int readTimeout);
 
     @Override
     public final int compareTo(@NonNull GitLabClientBuilder other) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClientBuilder.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClientBuilder.java
@@ -2,6 +2,7 @@ package com.dabsquared.gitlabjenkins.gitlab.api;
 
 import static java.util.Collections.sort;
 
+import com.dabsquared.gitlabjenkins.connection.GitlabCredentialResolver;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionPoint;
 import java.io.Serializable;
@@ -9,6 +10,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+
+import hudson.model.Item;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -47,7 +50,7 @@ public abstract class GitLabClientBuilder implements Comparable<GitLabClientBuil
 
     @NonNull
     public abstract GitLabClient buildClient(
-            String url, String token, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout);
+        String url, GitlabCredentialResolver credentialResolver, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout);
 
     @Override
     public final int compareTo(@NonNull GitLabClientBuilder other) {

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectGitLabClientBuilder.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectGitLabClientBuilder.java
@@ -20,7 +20,11 @@ public final class AutodetectGitLabClientBuilder extends GitLabClientBuilder {
     @Override
     @NonNull
     public GitLabClient buildClient(
-        String url, GitlabCredentialResolver resolver, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout) {
+            String url,
+            GitlabCredentialResolver resolver,
+            boolean ignoreCertificateErrors,
+            int connectionTimeout,
+            int readTimeout) {
         Collection<GitLabClientBuilder> candidates = new ArrayList<>(getAllGitLabClientBuilders());
         candidates.remove(this);
         return new AutodetectingGitLabClient(

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectGitLabClientBuilder.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectGitLabClientBuilder.java
@@ -1,5 +1,6 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.impl;
 
+import com.dabsquared.gitlabjenkins.connection.GitlabCredentialResolver;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClientBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -19,10 +20,10 @@ public final class AutodetectGitLabClientBuilder extends GitLabClientBuilder {
     @Override
     @NonNull
     public GitLabClient buildClient(
-            String url, String token, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout) {
+        String url, GitlabCredentialResolver resolver, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout) {
         Collection<GitLabClientBuilder> candidates = new ArrayList<>(getAllGitLabClientBuilders());
         candidates.remove(this);
         return new AutodetectingGitLabClient(
-                candidates, url, token, ignoreCertificateErrors, connectionTimeout, readTimeout);
+                candidates, url, resolver, ignoreCertificateErrors, connectionTimeout, readTimeout);
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
@@ -1,5 +1,6 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.impl;
 
+import com.dabsquared.gitlabjenkins.connection.GitlabCredentialResolver;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClientBuilder;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.*;
@@ -11,7 +12,7 @@ import javax.ws.rs.NotFoundException;
 final class AutodetectingGitLabClient implements GitLabClient {
     private final Iterable<GitLabClientBuilder> builders;
     private final String url;
-    private final String token;
+    private final GitlabCredentialResolver credentialResolver;
     private final boolean ignoreCertificateErrors;
     private final int connectionTimeout;
     private final int readTimeout;
@@ -20,13 +21,13 @@ final class AutodetectingGitLabClient implements GitLabClient {
     AutodetectingGitLabClient(
             Iterable<GitLabClientBuilder> builders,
             String url,
-            String token,
+            GitlabCredentialResolver credentialResolver,
             boolean ignoreCertificateErrors,
             int connectionTimeout,
             int readTimeout) {
         this.builders = builders;
         this.url = url;
-        this.token = token;
+        this.credentialResolver = credentialResolver;
         this.ignoreCertificateErrors = ignoreCertificateErrors;
         this.connectionTimeout = connectionTimeout;
         this.readTimeout = readTimeout;
@@ -381,7 +382,7 @@ final class AutodetectingGitLabClient implements GitLabClient {
     private GitLabClient autodetect() {
         for (GitLabClientBuilder candidate : builders) {
             GitLabClient client =
-                    candidate.buildClient(url, token, ignoreCertificateErrors, connectionTimeout, readTimeout);
+                    candidate.buildClient(url, credentialResolver, ignoreCertificateErrors, connectionTimeout, readTimeout);
             try {
                 client.getCurrentUser();
                 return client;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
@@ -381,8 +381,8 @@ final class AutodetectingGitLabClient implements GitLabClient {
 
     private GitLabClient autodetect() {
         for (GitLabClientBuilder candidate : builders) {
-            GitLabClient client =
-                    candidate.buildClient(url, credentialResolver, ignoreCertificateErrors, connectionTimeout, readTimeout);
+            GitLabClient client = candidate.buildClient(
+                    url, credentialResolver, ignoreCertificateErrors, connectionTimeout, readTimeout);
             try {
                 client.getCurrentUser();
                 return client;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClientBuilder.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClientBuilder.java
@@ -19,6 +19,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ProxyConfiguration;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.security.ACL;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
@@ -46,10 +49,6 @@ import javax.ws.rs.client.ClientResponseFilter;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.RuntimeDelegate;
-
-import hudson.model.Item;
-import hudson.model.ItemGroup;
-import hudson.security.ACL;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -100,7 +99,11 @@ public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
     @NonNull
     @Override
     public final GitLabClient buildClient(
-        String url, GitlabCredentialResolver credentialResolver, boolean ignoreCertificateErrors, int connectionTimeout, int readTimeout) {
+            String url,
+            GitlabCredentialResolver credentialResolver,
+            boolean ignoreCertificateErrors,
+            int connectionTimeout,
+            int readTimeout) {
         return buildClient(
                 url,
                 credentialResolver,
@@ -178,6 +181,7 @@ public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
     private static class ApiHeaderTokenFilter implements ClientRequestFilter {
         private final GitlabCredentialResolver credentialResolver;
         private final String url;
+
         ApiHeaderTokenFilter(GitlabCredentialResolver credentialResolver, String url) {
             this.credentialResolver = credentialResolver;
             this.url = url;
@@ -188,12 +192,12 @@ public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
             Item item = credentialResolver.getItem();
             ItemGroup<?> context = item != null ? item.getParent() : Jenkins.get();
             StandardCredentials credentials = CredentialsMatchers.firstOrNull(
-                lookupCredentials(
-                    StandardCredentials.class,
-                    context,
-                    ACL.SYSTEM,
-                    URIRequirementBuilder.fromUri(url).build()),
-                CredentialsMatchers.withId(credentialResolver.getCredentialsId()));
+                    lookupCredentials(
+                            StandardCredentials.class,
+                            context,
+                            ACL.SYSTEM,
+                            URIRequirementBuilder.fromUri(url).build()),
+                    CredentialsMatchers.withId(credentialResolver.getCredentialsId()));
 
             if (item != null) {
                 com.cloudbees.plugins.credentials.CredentialsProvider.track(item, credentials);
@@ -207,9 +211,9 @@ public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
                     return ((StringCredentials) credentials).getSecret().getPlainText();
                 }
             }
-            throw new IllegalStateException("No credentials found for credentialsId: " + credentialResolver.getCredentialsId());
+            throw new IllegalStateException(
+                    "No credentials found for credentialsId: " + credentialResolver.getCredentialsId());
         }
-
 
         public void filter(ClientRequestContext requestContext) {
             requestContext.getHeaders().putSingle(PRIVATE_TOKEN, getApiToken(credentialResolver));

--- a/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClientTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClientTest.java
@@ -1,15 +1,11 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.impl;
 
-import static com.dabsquared.gitlabjenkins.gitlab.api.impl.TestUtility.API_TOKEN;
-import static com.dabsquared.gitlabjenkins.gitlab.api.impl.TestUtility.addGitLabApiToken;
-import static com.dabsquared.gitlabjenkins.gitlab.api.impl.TestUtility.assertApiImpl;
-import static com.dabsquared.gitlabjenkins.gitlab.api.impl.TestUtility.responseNotFound;
-import static com.dabsquared.gitlabjenkins.gitlab.api.impl.TestUtility.responseOk;
-import static com.dabsquared.gitlabjenkins.gitlab.api.impl.TestUtility.versionRequest;
+import static com.dabsquared.gitlabjenkins.gitlab.api.impl.TestUtility.*;
 import static org.junit.Assert.fail;
 import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.matchers.Times.once;
 
+import com.dabsquared.gitlabjenkins.connection.GitlabCredentialResolver;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClientBuilder;
 import java.io.IOException;
 import java.util.Arrays;
@@ -44,7 +40,7 @@ public class AutodetectingGitLabClientTest {
 
         List<GitLabClientBuilder> builders =
                 Arrays.<GitLabClientBuilder>asList(new V3GitLabClientBuilder(), new V4GitLabClientBuilder());
-        api = new AutodetectingGitLabClient(builders, gitLabUrl, API_TOKEN, true, 10, 10);
+        api = new AutodetectingGitLabClient(builders, gitLabUrl, new GitlabCredentialResolver(null, API_TOKEN_ID), true, 10, 10);
 
         v3Request = versionRequest(V3GitLabApiProxy.ID);
         v4Request = versionRequest(V4GitLabApiProxy.ID);

--- a/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClientTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClientTest.java
@@ -40,7 +40,8 @@ public class AutodetectingGitLabClientTest {
 
         List<GitLabClientBuilder> builders =
                 Arrays.<GitLabClientBuilder>asList(new V3GitLabClientBuilder(), new V4GitLabClientBuilder());
-        api = new AutodetectingGitLabClient(builders, gitLabUrl, new GitlabCredentialResolver(null, API_TOKEN_ID), true, 10, 10);
+        api = new AutodetectingGitLabClient(
+                builders, gitLabUrl, new GitlabCredentialResolver(null, API_TOKEN_ID), true, 10, 10);
 
         v3Request = versionRequest(V3GitLabApiProxy.ID);
         v4Request = versionRequest(V4GitLabApiProxy.ID);

--- a/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/TestUtility.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/TestUtility.java
@@ -10,6 +10,7 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
+import com.dabsquared.gitlabjenkins.connection.GitlabCredentialResolver;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClientBuilder;
 import hudson.util.Secret;
@@ -65,7 +66,7 @@ class TestUtility {
     }
 
     static GitLabClient buildClientWithDefaults(GitLabClientBuilder clientBuilder, String url) {
-        return clientBuilder.buildClient(url, API_TOKEN, IGNORE_CERTIFICATE_ERRORS, CONNECTION_TIMEOUT, READ_TIMEOUT);
+        return clientBuilder.buildClient(url, new GitlabCredentialResolver(null, API_TOKEN), IGNORE_CERTIFICATE_ERRORS, CONNECTION_TIMEOUT, READ_TIMEOUT);
     }
 
     static void assertApiImpl(GitLabClient client, Class<? extends GitLabApiProxy> apiImplClass) throws Exception {

--- a/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/TestUtility.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/TestUtility.java
@@ -26,7 +26,7 @@ import org.mockserver.model.HttpResponse;
 
 class TestUtility {
     static final String API_TOKEN = "secret";
-    private static final String API_TOKEN_ID = "apiTokenId";
+    static final String API_TOKEN_ID = "apiTokenId";
     private static final boolean IGNORE_CERTIFICATE_ERRORS = true;
     private static final int CONNECTION_TIMEOUT = 10;
     private static final int READ_TIMEOUT = 10;
@@ -66,7 +66,7 @@ class TestUtility {
     }
 
     static GitLabClient buildClientWithDefaults(GitLabClientBuilder clientBuilder, String url) {
-        return clientBuilder.buildClient(url, new GitlabCredentialResolver(null, API_TOKEN), IGNORE_CERTIFICATE_ERRORS, CONNECTION_TIMEOUT, READ_TIMEOUT);
+        return clientBuilder.buildClient(url, new GitlabCredentialResolver(null, API_TOKEN_ID), IGNORE_CERTIFICATE_ERRORS, CONNECTION_TIMEOUT, READ_TIMEOUT);
     }
 
     static void assertApiImpl(GitLabClient client, Class<? extends GitLabApiProxy> apiImplClass) throws Exception {

--- a/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/TestUtility.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/TestUtility.java
@@ -66,7 +66,12 @@ class TestUtility {
     }
 
     static GitLabClient buildClientWithDefaults(GitLabClientBuilder clientBuilder, String url) {
-        return clientBuilder.buildClient(url, new GitlabCredentialResolver(null, API_TOKEN_ID), IGNORE_CERTIFICATE_ERRORS, CONNECTION_TIMEOUT, READ_TIMEOUT);
+        return clientBuilder.buildClient(
+                url,
+                new GitlabCredentialResolver(null, API_TOKEN_ID),
+                IGNORE_CERTIFICATE_ERRORS,
+                CONNECTION_TIMEOUT,
+                READ_TIMEOUT);
     }
 
     static void assertApiImpl(GitLabClient client, Class<? extends GitLabApiProxy> apiImplClass) throws Exception {

--- a/src/test/java/com/dabsquared/gitlabjenkins/testing/gitlab/rule/GitLabRule.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testing/gitlab/rule/GitLabRule.java
@@ -91,7 +91,7 @@ public class GitLabRule implements TestRule {
                                 CredentialsScope.SYSTEM,
                                 API_TOKEN_ID,
                                 "GitLab API Token",
-                                Secret.fromString(getApiToken())));
+                                Secret.fromString(getApiToken().getCredentialsId())));
             }
         }
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/testing/gitlab/rule/GitLabRule.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/testing/gitlab/rule/GitLabRule.java
@@ -8,6 +8,7 @@ import com.cloudbees.plugins.credentials.domains.Domain;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnection;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
+import com.dabsquared.gitlabjenkins.connection.GitlabCredentialResolver;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
 import com.dabsquared.gitlabjenkins.gitlab.api.impl.V3GitLabClientBuilder;
 import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
@@ -128,7 +129,7 @@ public class GitLabRule implements TestRule {
         }
     }
 
-    private String getApiToken() {
+    private GitlabCredentialResolver getApiToken() {
         try {
             Class.forName("org.postgresql.Driver");
             try (Connection connection = DriverManager.getConnection(
@@ -137,7 +138,7 @@ public class GitLabRule implements TestRule {
                         .createStatement()
                         .executeQuery("SELECT authentication_token FROM users WHERE username = 'root'");
                 resultSet.next();
-                return resultSet.getString("authentication_token");
+                return new GitlabCredentialResolver(null, resultSet.getString("authentication_token"));
             }
         } catch (ClassNotFoundException | SQLException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixes #963. 

### Description

This pull request introduces a new `GitlabCredentialResolver` class to manage the retrieval of credentials for GitLab connections more centrally and securely within the Jenkins GitLab plugin. The previous logic for handling API tokens has been refactored out of `GitLabConnection` and related classes into this new resolver class, improving code readability and maintainability.

Key changes include:
- Creation of the `GitlabCredentialResolver` class to handle credential resolution based on `Item` context and credential IDs.
- Refactoring `GitLabClientBuilder` and its implementations to accept a `GitlabCredentialResolver` instead of a plain API token string.
- Modifying `ApiHeaderTokenFilter` to utilize `GitlabCredentialResolver` for injecting API tokens into HTTP requests.
- Updates to unit tests to accommodate the new method of resolving credentials, ensuring compatibility with the new design.
- **Fix for AWS Secret Manager Issue**: Addressed an issue where, if AWS Secret Manager is used with a rotation mechanism, the plugin encounters problems because the client is cached and always uses the token with which it was initially created. This change ensures that credentials are retrieved each time they are used, allowing the plugin to work correctly with rotated tokens.

### Testing done

- **Unit Tests**: Updated existing tests to use `GitlabCredentialResolver`, ensuring they pass with the refactored code. This includes modifying tests like `AutodetectingGitLabClientTest` and `TestUtility`.
- **Manual Testing**: Verified the following scenarios manually:
  - Connection to GitLab using both global API tokens and job-specific credentials.
  - Ensured that the new `GitlabCredentialResolver` properly tracks credentials when associated with specific Jenkins items.
  - Verified that API requests include the correct `PRIVATE_TOKEN` header for both global and job-specific tokens.
  - Tested the resolution of credentials in environments with AWS Secret Manager to confirm that rotated tokens are correctly retrieved and used.
- **Automated Test Execution**: Ran all existing tests to ensure that there are no regressions introduced by this refactoring.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


