### PR TITLE
Add merge request labels to environment variables 

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ gitlabMergedByUser
 gitlabMergeRequestAssignee
 gitlabMergeRequestLastCommit
 gitlabMergeRequestTargetProjectId
+gitlabMergeRequestLabels
 gitlabTargetBranch
 gitlabTargetRepoName
 gitlabTargetNamespace

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
   - [Accept merge request after build](#accept-merge-request)
   - [Notify specific project by a specific GitLab connection](#notify-specific-project-by-a-specific-gitlab-connection)
   - [Cancel pending builds on merge request update](#cancel-pending-builds-on-merge-request-update)
+  - [Check if a label is applied to a merge request](#check-if-a-label-is-applied-to-a-merge-request)
 - [Compatibility](#compatibility)
 - [Contributing to the Plugin](#contributing-to-the-plugin)
 - [Testing With Docker](src/docker/README.md#quick-test-environment-setup-using-docker-for-linuxamd64)

--- a/README.md
+++ b/README.md
@@ -610,6 +610,22 @@ gitlabCommitStatus(
 To cancel pending builds of the same merge request when new commits are pushed, check 'Cancel pending merge request builds on update' from the Advanced-section in the trigger configuration.
 This saves time in projects where builds can stay long time in a build queue and you care only about the status of the newest commit.
 
+### Check if a label is applied to a merge request  
+To handle conditional logic in your pipelines based on merge request labels, use:
+```groovy
+script {
+    if (GitLabMergeRequestLabelExists("bugfix"))
+    {
+        echo 'bugfix label detected!'
+    }
+}
+```  
+A comma separated string of the labels is also present as an environment variable: `gitlabMergeRequestLabels`.  
+e.g for a merge request with the labels: [`bugfix`, `review needed`], `env.gitlabMergeRequestLabels="bugfix,review needed"`.  
+#### *notes:*
+- The environment variable will be null if no labels are applied to the merge request.
+- This feature is not available for multibranch pipeline jobs or GitLab push hooks.
+
 ## Compatibility
 
 Version 1.2.1 of the plugin introduces a backwards-incompatible change

--- a/src/docker/README.md
+++ b/src/docker/README.md
@@ -5,10 +5,11 @@ In order to test the plugin on different versions of `GitLab` and `Jenkins` you 
 An example docker-compose file is available at `gitlab-plugin/src/docker` which the user can use to set up instances of the latest `GitLab` version and latest `Jenkins` LTS version for linux/amd64.
 
 If they don't already exist, create the following directories and make sure the user that Docker is running as owns them:
-* /srv/docker/gitlab/postgresql
-* /srv/docker/gitlab/gitlab
-* /srv/docker/gitlab/redis
-* /srv/docker/jenkins
+* /srv/docker/gitlab/postgresql  
+* /srv/docker/gitlab/gitlab  
+* /srv/docker/gitlab/redis  
+* /srv/docker/jenkins  
+
 To start the containers for Linux, run `docker-compose up -d` from the `src/docker` folder. If you have problems accessing the services in the containers, run `docker-compose up` by itself to see output from the services as they start, and the latter command is the verbose version of the former.
 
 ## Quick test environment setup using Docker for MacOS/arm64

--- a/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
@@ -40,6 +40,7 @@ public final class CauseData {
     private final String mergedByUser;
     private final String mergeRequestAssignee;
     private final Integer mergeRequestTargetProjectId;
+    private final List<String> mergeRequestLabels;
     private final String targetBranch;
     private final String targetRepoName;
     private final String targetNamespace;
@@ -84,6 +85,7 @@ public final class CauseData {
             Integer mergeRequestId,
             Integer mergeRequestIid,
             Integer mergeRequestTargetProjectId,
+            List<String> mergeRequestLabels,
             String targetBranch,
             String targetRepoName,
             String targetNamespace,
@@ -131,6 +133,7 @@ public final class CauseData {
         this.mergedByUser = mergedByUser == null ? "" : mergedByUser;
         this.mergeRequestAssignee = mergeRequestAssignee == null ? "" : mergeRequestAssignee;
         this.mergeRequestTargetProjectId = mergeRequestTargetProjectId;
+        this.mergeRequestLabels = mergeRequestLabels == null ? Collections.emptyList() : mergeRequestLabels;
         this.targetBranch = Objects.requireNonNull(targetBranch, "targetBranch must not be null.");
         this.targetRepoName = Objects.requireNonNull(targetRepoName, "targetRepoName must not be null.");
         this.targetNamespace = Objects.requireNonNull(targetNamespace, "targetNamespace must not be null.");
@@ -177,6 +180,7 @@ public final class CauseData {
         variables.put(
                 "gitlabMergeRequestTargetProjectId",
                 mergeRequestTargetProjectId == null ? "" : mergeRequestTargetProjectId.toString());
+        variables.put("gitlabMergeRequestLabels", StringUtils.join(mergeRequestLabels, ","));
         variables.put("gitlabMergeRequestLastCommit", lastCommit);
         variables.putIfNotNull("gitlabMergeRequestState", mergeRequestState);
         variables.putIfNotNull("gitlabMergedByUser", mergedByUser);
@@ -300,6 +304,11 @@ public final class CauseData {
     @Exported
     public Integer getMergeRequestTargetProjectId() {
         return mergeRequestTargetProjectId;
+    }
+
+    @Exported
+    public List<String> getMergeRequestLabels() {
+        return mergeRequestLabels;
     }
 
     @Exported
@@ -473,6 +482,7 @@ public final class CauseData {
                 .append(mergedByUser, causeData.mergedByUser)
                 .append(mergeRequestAssignee, causeData.mergeRequestAssignee)
                 .append(mergeRequestTargetProjectId, causeData.mergeRequestTargetProjectId)
+                .append(mergeRequestLabels, causeData.mergeRequestLabels)
                 .append(targetBranch, causeData.targetBranch)
                 .append(targetRepoName, causeData.targetRepoName)
                 .append(targetNamespace, causeData.targetNamespace)
@@ -522,6 +532,7 @@ public final class CauseData {
                 .append(mergedByUser)
                 .append(mergeRequestAssignee)
                 .append(mergeRequestTargetProjectId)
+                .append(mergeRequestLabels)
                 .append(targetBranch)
                 .append(targetRepoName)
                 .append(targetNamespace)
@@ -571,6 +582,7 @@ public final class CauseData {
                 .append("mergedByUser", mergedByUser)
                 .append("mergeRequestAssignee", mergeRequestAssignee)
                 .append("mergeRequestTargetProjectId", mergeRequestTargetProjectId)
+                .append("mergeRequestLabels", mergeRequestLabels)
                 .append("targetBranch", targetBranch)
                 .append("targetRepoName", targetRepoName)
                 .append("targetNamespace", targetNamespace)

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -219,8 +219,10 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
                 .withMergeRequestTargetProjectId(hook.getObjectAttributes().getTargetProjectId())
                 .withMergeRequestLabels(
                         hook.getLabels() == null
-                        ? null
-                        : hook.getLabels().stream().map(MergeRequestLabel::getTitle).collect(toList()))
+                                ? null
+                                : hook.getLabels().stream()
+                                        .map(MergeRequestLabel::getTitle)
+                                        .collect(toList()))
                 .withTargetBranch(hook.getObjectAttributes().getTargetBranch())
                 .withTargetRepoName(hook.getObjectAttributes().getTarget().getName())
                 .withTargetNamespace(hook.getObjectAttributes().getTarget().getNamespace())

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerImpl.java
@@ -5,6 +5,7 @@ import static com.dabsquared.gitlabjenkins.trigger.handler.builder.generated.Bui
 import static com.dabsquared.gitlabjenkins.util.LoggerUtil.toArray;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toList;
 
 import com.dabsquared.gitlabjenkins.cause.CauseData;
 import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
@@ -216,6 +217,10 @@ class MergeRequestHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<M
                 .withMergeRequestAssignee(
                         hook.getAssignee() == null ? null : hook.getAssignee().getUsername())
                 .withMergeRequestTargetProjectId(hook.getObjectAttributes().getTargetProjectId())
+                .withMergeRequestLabels(
+                        hook.getLabels() == null
+                        ? null
+                        : hook.getLabels().stream().map(MergeRequestLabel::getTitle).collect(toList()))
                 .withTargetBranch(hook.getObjectAttributes().getTargetBranch())
                 .withTargetRepoName(hook.getObjectAttributes().getTarget().getName())
                 .withTargetNamespace(hook.getObjectAttributes().getTarget().getNamespace())

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStep.java
@@ -18,6 +18,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.export.ExportedBean;
 
+/**
+ * @author Yiftah Waisman
+ */
 @ExportedBean
 public class GitLabMergeRequestLabelExistsStep extends Step {
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStep.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStep.java
@@ -1,0 +1,93 @@
+package com.dabsquared.gitlabjenkins.workflow;
+
+import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.export.ExportedBean;
+
+@ExportedBean
+public class GitLabMergeRequestLabelExistsStep extends Step {
+
+    private String label;
+
+    @DataBoundConstructor
+    public GitLabMergeRequestLabelExistsStep(String label) {
+        this.label = StringUtils.isEmpty(label) ? null : label;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new GitLabMergeRequestLabelExistsStepExecution(context, this);
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    @DataBoundSetter
+    public void setLabel(String label) {
+        this.label = StringUtils.isEmpty(label) ? null : label;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "GitLabMergeRequestLabelExists";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Check if a GitLab merge request has a specific label";
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            Set<Class<?>> context = new HashSet<>();
+            Collections.addAll(context, TaskListener.class, Run.class);
+            return Collections.unmodifiableSet(context);
+        }
+    }
+
+    public static class GitLabMergeRequestLabelExistsStepExecution extends AbstractSynchronousStepExecution<Boolean> {
+        private static final long serialVersionUID = 1;
+
+        private final transient Run<?, ?> run;
+
+        private final transient GitLabMergeRequestLabelExistsStep step;
+
+        public GitLabMergeRequestLabelExistsStepExecution(StepContext context, GitLabMergeRequestLabelExistsStep step)
+                throws Exception {
+            super(context);
+            this.step = step;
+            run = context.get(Run.class);
+        }
+
+        @Override
+        protected Boolean run() throws Exception {
+            GitLabWebHookCause cause = run.getCause(GitLabWebHookCause.class);
+            if (cause == null) {
+                return false;
+            }
+            List<String> labels = cause.getData().getMergeRequestLabels();
+            if (labels == null) {
+                return false;
+            }
+            return labels.contains(step.getLabel());
+        }
+    }
+}

--- a/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
@@ -18,14 +18,13 @@ import hudson.model.FreeStyleProject;
 import hudson.model.StreamBuildListener;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * @author Evgeni Golov

--- a/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
@@ -24,6 +24,8 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Evgeni Golov
@@ -88,6 +90,7 @@ public class GitLabEnvironmentContributorTest {
                 .withMergeRequestTitle("Test")
                 .withMergeRequestId(1)
                 .withMergeRequestIid(1)
+                .withMergeRequestLabels(Arrays.asList("important", "test", "label"))
                 .withTargetBranch("master")
                 .withTargetRepoName("test")
                 .withTargetNamespace("test-namespace")
@@ -106,5 +109,6 @@ public class GitLabEnvironmentContributorTest {
         assertEquals("test", env.get("gitlabTargetRepoName"));
         assertEquals("feature", env.get("gitlabSourceBranch"));
         assertEquals("test", env.get("gitlabSourceRepoName"));
+        assertEquals("important,test,label", env.get("gitlabMergeRequestLabels"));
     }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
@@ -74,7 +74,8 @@ public class GitLabEnvironmentContributorTest {
         }
     }
 
-    public void testFreeStyleProjectNoLabelsBase(CauseData causeData) throws IOException, InterruptedException, ExecutionException {
+    public void testFreeStyleProjectNoLabelsBase(CauseData causeData)
+            throws IOException, InterruptedException, ExecutionException {
         FreeStyleProject p = jenkins.createFreeStyleProject();
         GitLabWebHookCause cause = new GitLabWebHookCause(causeData);
         FreeStyleBuild b = p.scheduleBuild2(0, cause).get();
@@ -86,7 +87,7 @@ public class GitLabEnvironmentContributorTest {
     public void freeStyleProjectTestNoLabels() throws IOException, InterruptedException, ExecutionException {
         testFreeStyleProjectNoLabelsBase(generateCauseData());
     }
-        
+
     @Test
     public void freeStyleProjectTestNullLabels() throws IOException, InterruptedException, ExecutionException {
         testFreeStyleProjectNoLabelsBase(generateCauseDataNullList());
@@ -147,9 +148,7 @@ public class GitLabEnvironmentContributorTest {
     }
 
     private CauseData generateCauseDataNullList() {
-        return generateCauseDataBase()
-                .withMergeRequestLabels(null)
-                .build();
+        return generateCauseDataBase().withMergeRequestLabels(null).build();
     }
 
     private CauseData generateCauseDataEmptyList() {

--- a/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
@@ -74,10 +74,10 @@ public class GitLabEnvironmentContributorTest {
         }
     }
 
-    public void testFreeStyleProjectLabels(CauseData data, String expected)
+    public void testFreeStyleProjectLabels(CauseData causeData, String expected)
             throws IOException, InterruptedException, ExecutionException {
         FreeStyleProject p = jenkins.createFreeStyleProject();
-        GitLabWebHookCause cause = new GitLabWebHookCause(data);
+        GitLabWebHookCause cause = new GitLabWebHookCause(causeData);
         FreeStyleBuild b = p.scheduleBuild2(0, cause).get();
         EnvVars env = b.getEnvironment(listener);
         assertEquals(expected, env.get("gitlabMergeRequestLabels"));

--- a/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/environment/GitLabEnvironmentContributorTest.java
@@ -74,31 +74,27 @@ public class GitLabEnvironmentContributorTest {
         }
     }
 
-    @Test
-    public void freeStyleProjectTestNoLabels() throws IOException, InterruptedException, ExecutionException {
+    public void testFreeStyleProjectNoLabelsBase(CauseData causeData) throws IOException, InterruptedException, ExecutionException {
         FreeStyleProject p = jenkins.createFreeStyleProject();
-        GitLabWebHookCause cause = new GitLabWebHookCause(generateCauseData());
+        GitLabWebHookCause cause = new GitLabWebHookCause(causeData);
         FreeStyleBuild b = p.scheduleBuild2(0, cause).get();
         EnvVars env = b.getEnvironment(listener);
-        assertEquals("", env.get("gitlabMergeRequestLabels"));
+        assertEquals(null, env.get("gitlabMergeRequestLabels"));
+    }
+
+    @Test
+    public void freeStyleProjectTestNoLabels() throws IOException, InterruptedException, ExecutionException {
+        testFreeStyleProjectNoLabelsBase(generateCauseData());
     }
         
     @Test
     public void freeStyleProjectTestNullLabels() throws IOException, InterruptedException, ExecutionException {
-        FreeStyleProject p = jenkins.createFreeStyleProject();
-        GitLabWebHookCause cause = new GitLabWebHookCause(generateCauseDataNullList());
-        FreeStyleBuild b = p.scheduleBuild2(0, cause).get();
-        EnvVars env = b.getEnvironment(listener);
-        assertEquals("", env.get("gitlabMergeRequestLabels"));
+        testFreeStyleProjectNoLabelsBase(generateCauseDataNullList());
     }
 
     @Test
     public void freeStyleProjectTestEmptyLabels() throws IOException, InterruptedException, ExecutionException {
-        FreeStyleProject p = jenkins.createFreeStyleProject();
-        GitLabWebHookCause cause = new GitLabWebHookCause(generateCauseDataEmptyList());
-        FreeStyleBuild b = p.scheduleBuild2(0, cause).get();
-        EnvVars env = b.getEnvironment(listener);
-        assertEquals("", env.get("gitlabMergeRequestLabels"));
+        testFreeStyleProjectNoLabelsBase(generateCauseDataEmptyList());
     }
 
     @Test

--- a/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
@@ -32,7 +32,7 @@ public class GitLabMergeRequestLabelExistsStepTest {
     @ClassRule
     public static JenkinsRule jenkins = new JenkinsRule();
 
-    private void test_webhook_base(CauseData causeData, String expected)
+    private void testWebhookBase(CauseData causeData, String expected)
             throws IOException, ExecutionException, InterruptedException, FormException {
         // load the pipeline script from resources
         WorkflowJob project = jenkins.createProject(WorkflowJob.class);
@@ -53,7 +53,7 @@ public class GitLabMergeRequestLabelExistsStepTest {
     }
 
     @Test
-    public void test_label_exists_in_mr_webhook()
+    public void testLabelExistsInMrWebhook()
             throws IOException, ExecutionException, InterruptedException, FormException {
         // create a cause data object with a label
         CauseData causeData = generateCauseDataWithLabels(Arrays.asList("test label"));
@@ -61,7 +61,7 @@ public class GitLabMergeRequestLabelExistsStepTest {
     }
 
     @Test
-    public void test_no_labels_in_mr_webhook()
+    public void testNoLabelsInMrWebhook()
             throws IOException, ExecutionException, InterruptedException, FormException {
         // create a cause data object with a label
         CauseData causeData = generateCauseData();

--- a/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
@@ -23,6 +23,9 @@ import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.junit.MockitoJUnitRunner;
 
+/**
+ * @author Yiftah Waisman
+ */
 @RunWith(MockitoJUnitRunner.class)
 public class GitLabMergeRequestLabelExistsStepTest {
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
@@ -29,7 +29,7 @@ public class GitLabMergeRequestLabelExistsStepTest {
     @ClassRule
     public static JenkinsRule jenkins = new JenkinsRule();
 
-    private void test_webhook_base(CauseData causeData, String expected_log_msg)
+    private void test_webhook_base(CauseData causeData, String expected)
             throws IOException, ExecutionException, InterruptedException, FormException {
         // load the pipeline script from resources
         WorkflowJob project = jenkins.createProject(WorkflowJob.class);
@@ -46,7 +46,7 @@ public class GitLabMergeRequestLabelExistsStepTest {
         WorkflowRun run = (WorkflowRun) future.get();
 
         // observe the logs to see if the label was detected or not
-        jenkins.assertLogContains(expected_log_msg, run);
+        jenkins.assertLogContains(expected, run);
     }
 
     @Test
@@ -58,10 +58,19 @@ public class GitLabMergeRequestLabelExistsStepTest {
     }
 
     @Test
-    public void test_label_doesnt_exist_in_mr_webhook()
+    public void test_no_labels_in_mr_webhook()
             throws IOException, ExecutionException, InterruptedException, FormException {
         // create a cause data object with a label
         CauseData causeData = generateCauseData();
+        test_webhook_base(causeData, "test label not found");
+    }
+
+    @Test
+    public void test_label_doesnt_exist_in_mr_webhook()
+            throws IOException, ExecutionException, InterruptedException, FormException {
+        // create a cause data object with a label
+        CauseData causeData = generateCauseDataWithLabels(
+                Arrays.asList("test", "label", "test label suffixed", "prefixed test label"));
         test_webhook_base(causeData, "test label not found");
     }
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
@@ -61,8 +61,7 @@ public class GitLabMergeRequestLabelExistsStepTest {
     }
 
     @Test
-    public void testNoLabelsInMrWebhook()
-            throws IOException, ExecutionException, InterruptedException, FormException {
+    public void testNoLabelsInMrWebhook() throws IOException, ExecutionException, InterruptedException, FormException {
         // create a cause data object with a label
         CauseData causeData = generateCauseData();
         testWebhookBase(causeData, "test label not found");

--- a/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
@@ -34,7 +34,7 @@ public class GitLabMergeRequestLabelExistsStepTest {
         // load the pipeline script from resources
         WorkflowJob project = jenkins.createProject(WorkflowJob.class);
         String pipelineText = IOUtils.toString(
-                getClass().getResourceAsStream("jenkinsFile/GitLabMergeRequestLabel-jenkinsFile.groovy"),
+                getClass().getResourceAsStream("pipeline/GitLabMergeRequestLabel-pipeline.groovy"),
                 StandardCharsets.UTF_8);
         project.setDefinition(new CpsFlowDefinition(pipelineText, false));
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
@@ -57,7 +57,7 @@ public class GitLabMergeRequestLabelExistsStepTest {
             throws IOException, ExecutionException, InterruptedException, FormException {
         // create a cause data object with a label
         CauseData causeData = generateCauseDataWithLabels(Arrays.asList("test label"));
-        test_webhook_base(causeData, "test label found");
+        testWebhookBase(causeData, "test label found");
     }
 
     @Test
@@ -65,16 +65,16 @@ public class GitLabMergeRequestLabelExistsStepTest {
             throws IOException, ExecutionException, InterruptedException, FormException {
         // create a cause data object with a label
         CauseData causeData = generateCauseData();
-        test_webhook_base(causeData, "test label not found");
+        testWebhookBase(causeData, "test label not found");
     }
 
     @Test
-    public void test_label_doesnt_exist_in_mr_webhook()
+    public void testLabelDoesntExistInMrWebhook()
             throws IOException, ExecutionException, InterruptedException, FormException {
         // create a cause data object with a label
         CauseData causeData = generateCauseDataWithLabels(
                 Arrays.asList("test", "label", "test label suffixed", "prefixed test label"));
-        test_webhook_base(causeData, "test label not found");
+        testWebhookBase(causeData, "test label not found");
     }
 
     private CauseDataBuilder generateCauseDataBase() {

--- a/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/workflow/GitLabMergeRequestLabelExistsStepTest.java
@@ -1,0 +1,105 @@
+package com.dabsquared.gitlabjenkins.workflow;
+
+import static com.dabsquared.gitlabjenkins.cause.CauseDataBuilder.causeData;
+
+import com.dabsquared.gitlabjenkins.cause.CauseData;
+import com.dabsquared.gitlabjenkins.cause.CauseDataBuilder;
+import com.dabsquared.gitlabjenkins.cause.GitLabWebHookCause;
+import hudson.model.CauseAction;
+import hudson.model.queue.QueueTaskFuture;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GitLabMergeRequestLabelExistsStepTest {
+
+    @ClassRule
+    public static JenkinsRule jenkins = new JenkinsRule();
+
+    public static WorkflowJob project;
+
+    @Before
+    public void setup() throws Exception {
+        // load the pipeline script from resources
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class);
+        String pipelineText = IOUtils.toString(
+                getClass().getResourceAsStream("jenkinsfile/GitLabMergeRequestLabel-jenkinsFile.groovy"),
+                StandardCharsets.UTF_8);
+        project.setDefinition(new CpsFlowDefinition(pipelineText, false));
+    }
+
+    private void test_webhook_base(CauseData causeData, String expected_log_msg)
+            throws IOException, ExecutionException, InterruptedException {
+        // create a merge request webhook and schedule it
+        GitLabWebHookCause cause = new GitLabWebHookCause(causeData);
+        QueueTaskFuture<?> future = project.scheduleBuild2(0, new CauseAction(cause));
+
+        // wait for the build to finish and obtain the run object
+        WorkflowRun run = (WorkflowRun) future.get();
+
+        // observe the logs to see if the label was detected or not
+        jenkins.assertLogContains(expected_log_msg, run);
+    }
+
+    @Test
+    public void test_label_exists_in_mr_webhook() throws IOException, ExecutionException, InterruptedException {
+        // create a cause data object with a label
+        CauseData causeData = generateCauseDataWithLabels(Arrays.asList("test label"));
+        test_webhook_base(causeData, "test label found");
+    }
+
+    @Test
+    public void test_label_doesnt_exist_in_mr_webhook() throws IOException, ExecutionException, InterruptedException {
+        // create a cause data object with a label
+        CauseData causeData = generateCauseData();
+        test_webhook_base(causeData, "test label not found");
+    }
+
+    private CauseDataBuilder generateCauseDataBase() {
+        return causeData()
+                .withActionType(CauseData.ActionType.MERGE)
+                .withSourceProjectId(1)
+                .withTargetProjectId(1)
+                .withBranch("feature")
+                .withSourceBranch("feature")
+                .withUserName("")
+                .withSourceRepoHomepage("https://gitlab.org/test")
+                .withSourceRepoName("test")
+                .withSourceNamespace("test-namespace")
+                .withSourceRepoUrl("git@gitlab.org:test.git")
+                .withSourceRepoSshUrl("git@gitlab.org:test.git")
+                .withSourceRepoHttpUrl("https://gitlab.org/test.git")
+                .withMergeRequestTitle("Test")
+                .withMergeRequestId(1)
+                .withMergeRequestIid(1)
+                .withTargetBranch("master")
+                .withTargetRepoName("test")
+                .withTargetNamespace("test-namespace")
+                .withTargetRepoSshUrl("git@gitlab.org:test.git")
+                .withTargetRepoHttpUrl("https://gitlab.org/test.git")
+                .withTriggeredByUser("test")
+                .withLastCommit("123")
+                .withTargetProjectUrl("https://gitlab.org/test");
+    }
+
+    private CauseData generateCauseData() {
+        return generateCauseDataBase().build();
+    }
+
+    private CauseData generateCauseDataWithLabels(List<String> labels) {
+        return generateCauseDataBase().withMergeRequestLabels(labels).build();
+    }
+}

--- a/src/test/resources/com/dabsquared/gitlabjenkins/workflow/jenkinsFile/GitLabMergeRequestLabel-jenkinsFile.groovy
+++ b/src/test/resources/com/dabsquared/gitlabjenkins/workflow/jenkinsFile/GitLabMergeRequestLabel-jenkinsFile.groovy
@@ -1,0 +1,22 @@
+package com.dabsquared.gitlabjenkins.workflow.jenkinsFile
+
+pipeline {
+  agent any
+  triggers {
+    gitlab(triggerOnPush: true, triggerOnMergeRequest: true, branchFilterType: 'All')
+  }
+  stages {
+    stage("build") {
+      steps {
+        if (GitLabMergeRequestLabelExists("test label"))
+        {
+          echo "test label found"
+        }
+        else
+        {
+          echo "test label not found"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/com/dabsquared/gitlabjenkins/workflow/jenkinsFile/GitLabMergeRequestLabel-jenkinsFile.groovy
+++ b/src/test/resources/com/dabsquared/gitlabjenkins/workflow/jenkinsFile/GitLabMergeRequestLabel-jenkinsFile.groovy
@@ -1,22 +1,13 @@
 package com.dabsquared.gitlabjenkins.workflow.jenkinsFile
 
-pipeline {
-  agent any
-  triggers {
-    gitlab(triggerOnPush: true, triggerOnMergeRequest: true, branchFilterType: 'All')
+node {
+  echo "build started"
+  if (GitLabMergeRequestLabelExists("test label"))
+  {
+    echo "test label found"
   }
-  stages {
-    stage("build") {
-      steps {
-        if (GitLabMergeRequestLabelExists("test label"))
-        {
-          echo "test label found"
-        }
-        else
-        {
-          echo "test label not found"
-        }
-      }
-    }
+  else
+  {
+    echo "test label not found"
   }
 }

--- a/src/test/resources/com/dabsquared/gitlabjenkins/workflow/pipeline/GitLabMergeRequestLabel-pipeline.groovy
+++ b/src/test/resources/com/dabsquared/gitlabjenkins/workflow/pipeline/GitLabMergeRequestLabel-pipeline.groovy
@@ -1,4 +1,4 @@
-package com.dabsquared.gitlabjenkins.workflow.jenkinsFile
+package com.dabsquared.gitlabjenkins.workflow.pipeline
 
 node {
   echo "build started"


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

**many thanks to @anton-johansson at #901 and @jakub-bochenski at #646 for starting this work**  
closes #900 

### Done
- rebased work from #901 to latest master branch
- provided test cases at `GitLabEnvironmentContributorTest.java`
- added pipeline helper function `GitLabMergeRequestLabelExists("some label") -> Boolean`
- added explanation to `README.md`
- provided test cases at `GitLabMergeRequestLabelExistsStepTest.java`
- indentation fix in `src/docker/README.md`

#### groovy example of using the helper function:
```groovy
if (GitLabMergeRequestLabelExists("test label")) {
    echo "test label found"
}
```
#### groovy example of echoing all the labels:
```groovy
// Check if the environment variable is null (should never be empty - see unit tests)
if (env.gitlabMergeRequestLabels == null) {
    echo "No merge request labels provided."
} else {
    // Split the labels by commas and trim each label
    def labels = env.gitlabMergeRequestLabels.split(',').collect { it.trim() }
    echo "Merge request labels:"
    labels.each { label -> echo label }
}
```

### Testing done
  - test set up:
    - OpenSUSE Leap 15.6 VM
    - Java 17 (openjdk)
    - Maven 3.9.9
    - docker running inside the VM
      - **changed the `Jenkins` tag to `2.479` (with `lts` I got an error when trying to install the plugin: Jenkins minimum version required: 2.479)**
      - GitLab tags tested: `latest` (`17.5`), `15.11.13-ce.0`
- built the plugin with `mvn deploy` and manually installed to Jenkins with the web UI.
- created a pipeline in `Jenkins`, integrated it to `GitLab` and observed the behavior of new environment variable and helper function in push and merge request hooks.  
  
### Note
- @anton-johansson provided a note in his merge request #901 that this doesn't work when putting comments to merge requests, because the webhook doesn't contain the labels.
- using the GitLab Jenkins Integration (under `Settings -> Integrations -> Jenkins`) doesn't send webhooks on comments.
- using a  generic web trigger  (under `Settings -> Webhooks`) allows sending hooks on comments, and according to the oldest doc online - [GitLab 15.6 Webhook events](https://archives.docs.gitlab.com/15.6/ee/user/project/integrations/webhook_events.html#comment-on-a-merge-request) it does send the labels on comments in merge requests.
- the class `NoteHook` doesn't handle the labels

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
