### PR TITLE
Handle merge request labels in Note Webhooks (comments)

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestObjectAttributes.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/MergeRequestObjectAttributes.java
@@ -1,6 +1,7 @@
 package com.dabsquared.gitlabjenkins.gitlab.hook.model;
 
 import java.util.Date;
+import java.util.List;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -34,6 +35,7 @@ public class MergeRequestObjectAttributes {
     private String url;
     private Action action;
     private Boolean workInProgress;
+    private List<MergeRequestLabel> labels;
 
     public Integer getId() {
         return id;
@@ -211,6 +213,14 @@ public class MergeRequestObjectAttributes {
         this.workInProgress = workInProgress;
     }
 
+    public List<MergeRequestLabel> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(List<MergeRequestLabel> labels) {
+        this.labels = labels;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -243,6 +253,7 @@ public class MergeRequestObjectAttributes {
                 .append(action, that.action)
                 .append(oldrev, that.oldrev)
                 .append(workInProgress, that.workInProgress)
+                .append(labels, that.labels)
                 .isEquals();
     }
 
@@ -270,6 +281,7 @@ public class MergeRequestObjectAttributes {
                 .append(url)
                 .append(action)
                 .append(workInProgress)
+                .append(labels)
                 .toHashCode();
     }
 
@@ -298,6 +310,7 @@ public class MergeRequestObjectAttributes {
                 .append("action", action)
                 .append("oldrev", oldrev)
                 .append("workInProgress", workInProgress)
+                .append("labels", labels)
                 .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImpl.java
@@ -2,8 +2,10 @@ package com.dabsquared.gitlabjenkins.trigger.handler.note;
 
 import static com.dabsquared.gitlabjenkins.cause.CauseDataBuilder.causeData;
 import static com.dabsquared.gitlabjenkins.trigger.handler.builder.generated.BuildStatusUpdateBuilder.buildStatusUpdate;
+import static java.util.stream.Collectors.toList;
 
 import com.dabsquared.gitlabjenkins.cause.CauseData;
+import com.dabsquared.gitlabjenkins.gitlab.hook.model.MergeRequestLabel;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.NoteHook;
 import com.dabsquared.gitlabjenkins.trigger.exception.NoRevisionToBuildException;
 import com.dabsquared.gitlabjenkins.trigger.filter.BranchFilter;
@@ -97,6 +99,12 @@ class NoteHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<NoteHook>
                 .withTriggerPhrase(hook.getObjectAttributes().getNote())
                 .withCommentAuthor(
                         hook.getUser() == null ? null : hook.getUser().getUsername())
+                .withMergeRequestLabels(
+                        hook.getMergeRequest().getLabels() == null
+                                ? null
+                                : hook.getMergeRequest().getLabels().stream()
+                                        .map(MergeRequestLabel::getTitle)
+                                        .collect(toList()))
                 .build();
     }
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImplTest.java
@@ -1,6 +1,7 @@
 package com.dabsquared.gitlabjenkins.trigger.handler.note;
 
 import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.CommitBuilder.commit;
+import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.MergeRequestLabelBuilder.mergeRequestLabel;
 import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.MergeRequestObjectAttributesBuilder.mergeRequestObjectAttributes;
 import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.NoteHookBuilder.noteHook;
 import static com.dabsquared.gitlabjenkins.gitlab.hook.model.builder.generated.NoteObjectAttributesBuilder.noteObjectAttributes;
@@ -10,10 +11,12 @@ import static com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterConfig.Bra
 import static com.dabsquared.gitlabjenkins.trigger.filter.MergeRequestLabelFilterFactory.newMergeRequestLabelFilter;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
 import com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterFactory;
 import com.dabsquared.gitlabjenkins.trigger.filter.BranchFilterType;
+import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
@@ -21,6 +24,7 @@ import hudson.model.FreeStyleProject;
 import hudson.plugins.git.GitSCM;
 import hudson.util.OneShotEvent;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.concurrent.ExecutionException;
 import org.eclipse.jgit.api.Git;
@@ -62,6 +66,8 @@ public class NoteHookTriggerHandlerImplTest {
             @Override
             public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
                     throws InterruptedException, IOException {
+                EnvVars env = build.getEnvironment(listener);
+                assertEquals(null, env.get("gitlabMergeRequestLabels"));
                 buildTriggered.signal();
                 return true;
             }
@@ -109,6 +115,8 @@ public class NoteHookTriggerHandlerImplTest {
             @Override
             public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
                     throws InterruptedException, IOException {
+                EnvVars env = build.getEnvironment(listener);
+                assertEquals("bugfix,help needed", env.get("gitlabMergeRequestLabels"));
                 buildTriggered.signal();
                 return true;
             }
@@ -137,6 +145,31 @@ public class NoteHookTriggerHandlerImplTest {
                                 .withSourceProjectId(1)
                                 .withSourceBranch("feature")
                                 .withTargetBranch("master")
+                                .withLabels(Arrays.asList(
+                                        mergeRequestLabel()
+                                                .withId(3)
+                                                .withTitle("bugfix")
+                                                .withColor("#009966")
+                                                .withProjectId(1)
+                                                .withCreatedAt(currentDate)
+                                                .withUpdatedAt(currentDate)
+                                                .withTemplate(false)
+                                                .withDescription(null)
+                                                .withType("ProjectLabel")
+                                                .withGroupId(null)
+                                                .build(),
+                                        mergeRequestLabel()
+                                                .withId(4)
+                                                .withTitle("help needed")
+                                                .withColor("#FF0000")
+                                                .withProjectId(1)
+                                                .withCreatedAt(currentDate)
+                                                .withUpdatedAt(currentDate)
+                                                .withTemplate(false)
+                                                .withDescription(null)
+                                                .withType("ProjectLabel")
+                                                .withGroupId(null)
+                                                .build()))
                                 .withLastCommit(commit().withAuthor(
                                                 user().withName("test").build())
                                         .withId(commit.getName())


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- related to #1713   
- closes #1715   
- `MergeRequestObjectAttributes` now holds the merge request labels. (and not only `MergeRequestHook`)  
  - [aligns with the payload GitLab sends on a **merge request** webhook](https://docs.gitlab.com/17.5/ee/user/project/integrations/webhook_events.html#comment-on-a-merge-request)
  - labels are sent both as a top level level entry `labels` and also as a sub entry `object_attributes.labels`
- `NoteHookTriggerHandlerImpl` adds the merge request labels to `CauseData`
- unit tests added + E2E tested with docker images from `src/docker` after compiling the plugin

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
