### PR TITLE
#1427: Prevent job triggering for non-matching webhooks

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/merge/MergeRequestHookTriggerHandlerFactory.java
@@ -31,9 +31,15 @@ public final class MergeRequestHookTriggerHandlerFactory {
             boolean cancelPendingBuildsOnUpdate) {
 
         TriggerConfigChain chain = new TriggerConfigChain();
-        chain.acceptOnlyIf(
+        chain.rejectUnless(
                         triggerOpenMergeRequest != TriggerOpenMergeRequest.never,
                         of(State.opened, State.updated),
+                        of(Action.update))
+                .acceptIf(
+                        triggerOpenMergeRequest != TriggerOpenMergeRequest.never, of(State.updated), of(Action.update))
+                .acceptIf(
+                        triggerOpenMergeRequest != TriggerOpenMergeRequest.never && triggerOpenMergeRequest != null,
+                        of(State.opened),
                         of(Action.update))
                 .acceptOnlyIf(triggerOnApprovedMergeRequest, null, of(Action.approved))
                 .acceptIf(triggerOnMergeRequest, of(State.opened, State.reopened), null)


### PR DESCRIPTION
8ec69c7ada9da38a760f532b9dd34bdf538f8ccb introduced a change that does not handle jobs created using Jenkins DSL properly, as DSL jobs that do not specify `triggerOpenMergeRequestOnPush` have the `triggerOpenMergeRequest` value passed into
`MergeRequestHookTriggerHandlerFactory` as `null`, with the above change causing the value not to be handled as `never` where the plugin previously treated `null` as `never`. This results in webhooks triggering builds for DSL-created jobs even where the job is doing actions that aren't valid for a Merge Request in that state (e.g. triggering release builds even though the Merge Request hasn't been merged). This change returns to handling an unspecified `triggerOpenMergeRequest` value as being equivalent to specifying it as `never`.

<!-- Please describe your pull request here. -->

### Testing done

Automated test to cover failing scenario.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
