### PR TITLE
Fix docker compose port conflict

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,10 @@ See https://github.com/jenkinsci/gitlab-plugin/tree/master/src/docker/README.md
 When testing with a Docker Jenkins instance, the debugger can be setup in the following way:
 * From the main menu, select Run -> Edit Configurations.
 * In the Run/Debug Configurations dialog, click the Add New Configuration button `+` and select Remote JVM Debug.
-* Enter any relevant name, the Host (the address of the machine where the host app will run. If running it on the same machine, it needs to be localhost. If the program is running on another machine, specify its address here) and the Port (by default use 50000). The Command Line argument will be automatically setup.
+* Enter any relevant name, the Host (the address of the machine where the host app will run. If running it on the same machine, it needs to be localhost. If the program is running on another machine, specify its address here) and the Port (by default use 50001). The Command Line argument will be automatically setup.
 * Enter Apply.
 
-Now start your Jenkins instance and debugger and you should get something like this - `Connected to the target VM, address: 'localhost:50000', transport: 'socket'`.
+Now start your Jenkins instance and debugger and you should get something like this - `Connected to the target VM, address: 'localhost:50001', transport: 'socket'`.
 Breakpoints can now be set up to halt the debugger at the required break point to understand the flow of the program.  
 
 ## Release Workflow

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -25,7 +25,6 @@ services:
     image: jenkins/jenkins:lts
     ports:
       - "8080:8080"
-      - "50000:50000"
       - "50001:50001"
     volumes:
       - '/srv/docker/jenkins:/var/jenkins_home'

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -26,8 +26,9 @@ services:
     ports:
       - "8080:8080"
       - "50000:50000"
+      - "50001:50001"
     volumes:
       - '/srv/docker/jenkins:/var/jenkins_home'
     environment:
-      - "JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:50000"
+      - "JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:50001"
     shm_size: '5gb'


### PR DESCRIPTION
The default jenkins agent port conflicts with the compose file which currently configures Jenkins with a JAVA_TOOL_OPTIONS setting that opens JDWP debugging on port 50000.

This PR changes the JDWP debug port to 50001 to resolve the issues, and port 50000 still remains for agents.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
