### PR TITLE
Declare plugin dependencies explicitly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.19</version>
+    <version>5.22</version>
     <relativePath />
   </parent>
 
@@ -50,7 +50,9 @@
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
+    <hpi.bundledArtifacts>jakarta.validation-api,jboss-annotations-api_1.3_spec,jboss-jaxb-api_2.3_spec,jboss-jaxrs-api_2.1_spec,jboss-logging,reactive-streams,resteasy-client,resteasy-jaxrs</hpi.bundledArtifacts>
     <hpi.compatibleSinceVersion>1.4.0</hpi.compatibleSinceVersion>
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <mockserver.version>5.15.0</mockserver.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>


### PR DESCRIPTION
## Declare plugin dependencies explicitly

Do not allow new bundled dependencies without a change to the list of bundled dependencies.

Inspired by pull request:

* https://github.com/jenkinsci/maven-hpi-plugin/pull/771

### Testing done

Confirmed that compilation passes.  Rely on ci.jenkins.io for more complete testing.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
