### PR TITLE
Resolve incompatibility with Jackson 2 API 2.20.0

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/JacksonConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/JacksonConfig.java
@@ -2,7 +2,7 @@ package com.dabsquared.gitlabjenkins.gitlab;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -18,7 +18,7 @@ import javax.ws.rs.ext.Provider;
 public class JacksonConfig implements ContextResolver<ObjectMapper> {
     public ObjectMapper getContext(Class<?> type) {
         return new ObjectMapper()
-                .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/util/JsonUtil.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/JsonUtil.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
@@ -20,7 +20,7 @@ import java.util.Locale;
 public final class JsonUtil {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
             .configure(SerializationFeature.INDENT_OUTPUT, true)


### PR DESCRIPTION
## Replace deprecated SNAKE_CASE with current SNAKE_CASE

Jackson API 2.20.0 removes the PropertyNamingStrategy.SNAKE_CASE symbol.  The replacement symbol is PropertyNamingStrategies.SNAKE_CASE.

Refer to BOM test failures in:

* https://github.com/jenkinsci/bom/pull/5622

### Testing done

Confirmed that previous code fails to compile with Jackson 2 API 2.20.0 incremental build.

Confirmed it compiles with Jackson 2 API 2.20.0 incremental build and with current Jackson 2 API 2.19.x.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
