### PR TITLE
Fix `scmTag`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}</connection>
     <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
-    <tag>1.9.7</tag>
+    <tag>${scmTag}</tag>
     <url>https://github.com/${gitHubRepo}</url>
   </scm>
 


### PR DESCRIPTION
From #1807:

> 20:12:59  Error: ZIP error: Error: Wrong commit hash in /project/scm/tag, expected 759758e314861d7f2cb04fa6c7f6a96ca28ab03a, got 1.9.7 from https://ci.jenkins.io/job/Plugins/job/gitlab-plugin/job/PR-1807/3/artifact/**/*759758e31486*/*759758e31486*/*zip*/archive.zip