### PR TITLE
Migrate tests to JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <mockserver.version>5.15.0</mockserver.version>
     <spotless.check.skip>false</spotless.check.skip>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
   <dependencyManagement>
@@ -260,13 +261,6 @@
     <dependency>
       <groupId>org.mock-server</groupId>
       <artifactId>mockserver-junit-jupiter</artifactId>
-      <version>${mockserver.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- used by UpdateGitLabCommitStatusStepTest -->
-    <dependency>
-      <groupId>org.mock-server</groupId>
-      <artifactId>mockserver-junit-rule</artifactId>
       <version>${mockserver.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/publisher/GitLabCommitStatusPublisherTest.java
@@ -96,7 +96,7 @@ class GitLabCommitStatusPublisherTest {
     }
 
     @Test
-    void running_v3() throws Exception {
+    void running_v3() {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V3, null, "test/project.git");
         HttpRequest[] requests = prepareCheckCommitAndUpdateStatusRequests("v3", build, BuildState.running);
 
@@ -104,7 +104,7 @@ class GitLabCommitStatusPublisherTest {
     }
 
     @Test
-    void running_v4() throws Exception {
+    void running_v4() {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, null, "test/project.git");
         HttpRequest[] requests = prepareCheckCommitAndUpdateStatusRequests("v4", build, BuildState.running);
 
@@ -112,7 +112,7 @@ class GitLabCommitStatusPublisherTest {
     }
 
     @Test
-    void runningWithLibrary() throws Exception {
+    void runningWithLibrary() {
         AbstractBuild build = mockBuildWithLibrary(GITLAB_CONNECTION_V4, null, "test/project.git");
         HttpRequest[] requests = prepareCheckCommitAndUpdateStatusRequests("v4", build, BuildState.running);
 
@@ -228,7 +228,7 @@ class GitLabCommitStatusPublisherTest {
     }
 
     @Test
-    void running_multipleRepos() throws Exception {
+    void running_multipleRepos() {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, null, "test/project-1.git", "test/project-2.git");
         HttpRequest[] requests = new HttpRequest[] {
             prepareExistsCommitWithSuccessResponse("v4", "test/project-1"),
@@ -241,7 +241,7 @@ class GitLabCommitStatusPublisherTest {
     }
 
     @Test
-    void running_commitNotExists() throws Exception {
+    void running_commitNotExists() {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, null, "test/project.git");
         HttpRequest updateCommitStatus =
                 prepareUpdateCommitStatusWithSuccessResponse("v4", "test/project", build, BuildState.running);
@@ -251,7 +251,7 @@ class GitLabCommitStatusPublisherTest {
     }
 
     @Test
-    void running_failToUpdate() throws Exception {
+    void running_failToUpdate() {
         AbstractBuild build = mockBuild(GITLAB_CONNECTION_V4, null, "test/project.git");
         BuildListener buildListener = mock(BuildListener.class);
 

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/filter/AllBranchesFilterTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/filter/AllBranchesFilterTest.java
@@ -13,7 +13,7 @@ class AllBranchesFilterTest {
 
     @Test
     void isRandomBranchNameAllowed() {
-        String randomBranchName = RandomStringUtils.random(10, true, false);
+        String randomBranchName = RandomStringUtils.secure().next(10, true, false);
 
         assertThat(new AllBranchesFilter().isBranchAllowed(null, randomBranchName), is(true));
     }

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerGitlabServerTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/push/PushHookTriggerHandlerGitlabServerTest.java
@@ -101,10 +101,9 @@ class PushHookTriggerHandlerGitlabServerTest {
     @ParameterizedTest
     @MethodSource("data")
     void doNotCreateRevisionParameterAction_deleteBranchRequest(GitLabPushRequestSamples samples) {
-        assertThrows(NoRevisionToBuildException.class, () -> {
-            PushHook hook = samples.deleteBranchRequest();
-            new PushHookTriggerHandlerImpl(false).createRevisionParameter(hook, null);
-        });
+        PushHook hook = samples.deleteBranchRequest();
+        assertThrows(NoRevisionToBuildException.class, () -> new PushHookTriggerHandlerImpl(false)
+                .createRevisionParameter(hook, null));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/BuildWebHookActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/BuildWebHookActionTest.java
@@ -87,7 +87,7 @@ class BuildWebHookActionTest {
         assertTrue(action.performOnPostCalled, "performOnPost not called, token did not match?");
     }
 
-    public class BuildWebHookActionImpl extends BuildWebHookAction {
+    public static class BuildWebHookActionImpl extends BuildWebHookAction {
 
         // Used for the assertion that tokenMatches() returned true
         public boolean performOnPostCalled = false;

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/NoteBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/NoteBuildActionTest.java
@@ -69,69 +69,69 @@ class NoteBuildActionTest {
     }
 
     @Test
-    void build() {
-        assertThrows(HttpResponses.HttpResponseException.class, () -> {
-            FreeStyleProject testProject = jenkins.createFreeStyleProject();
-            testProject.addTrigger(trigger);
-            new NoteBuildAction(testProject, getJson("NoteEvent.json"), null).execute(response);
+    void build() throws Exception {
+        FreeStyleProject testProject = jenkins.createFreeStyleProject();
+        testProject.addTrigger(trigger);
 
-            verify(trigger).onPost(any(NoteHook.class));
-        });
+        assertThrows(
+                HttpResponses.HttpResponseException.class,
+                () -> new NoteBuildAction(testProject, getJson("NoteEvent.json"), null).execute(response));
+        verify(trigger).onPost(any(NoteHook.class));
     }
 
     @Test
-    void build_alreadyBuiltMR_alreadyBuiltMR() {
-        assertThrows(HttpResponses.HttpResponseException.class, () -> {
-            FreeStyleProject testProject = jenkins.createFreeStyleProject();
-            testProject.addTrigger(trigger);
-            testProject.setScm(new GitSCM(gitRepoUrl));
-            QueueTaskFuture<?> future = testProject.scheduleBuild2(
-                    0, new ParametersAction(new StringParameterValue("gitlabTargetBranch", "master")));
-            future.get();
-            new NoteBuildAction(testProject, getJson("NoteEvent_alreadyBuiltMR.json"), null).execute(response);
+    void build_alreadyBuiltMR_alreadyBuiltMR() throws Exception {
+        FreeStyleProject testProject = jenkins.createFreeStyleProject();
+        testProject.addTrigger(trigger);
+        testProject.setScm(new GitSCM(gitRepoUrl));
+        QueueTaskFuture<?> future = testProject.scheduleBuild2(
+                0, new ParametersAction(new StringParameterValue("gitlabTargetBranch", "master")));
+        future.get();
 
-            verify(trigger).onPost(any(NoteHook.class));
-        });
+        assertThrows(HttpResponses.HttpResponseException.class, () -> new NoteBuildAction(
+                        testProject, getJson("NoteEvent_alreadyBuiltMR.json"), null)
+                .execute(response));
+        verify(trigger).onPost(any(NoteHook.class));
     }
 
     @Test
-    void build_alreadyBuiltMR_differentTargetBranch() {
-        assertThrows(HttpResponses.HttpResponseException.class, () -> {
-            FreeStyleProject testProject = jenkins.createFreeStyleProject();
-            testProject.addTrigger(trigger);
-            testProject.setScm(new GitSCM(gitRepoUrl));
-            QueueTaskFuture<?> future = testProject.scheduleBuild2(
-                    0,
-                    new GitLabWebHookCause(causeData()
-                            .withActionType(CauseData.ActionType.NOTE)
-                            .withSourceProjectId(1)
-                            .withTargetProjectId(1)
-                            .withBranch("feature")
-                            .withSourceBranch("feature")
-                            .withUserName("")
-                            .withSourceRepoHomepage("https://gitlab.org/test")
-                            .withSourceRepoName("test")
-                            .withSourceNamespace("test-namespace")
-                            .withSourceRepoUrl("git@gitlab.org:test.git")
-                            .withSourceRepoSshUrl("git@gitlab.org:test.git")
-                            .withSourceRepoHttpUrl("https://gitlab.org/test.git")
-                            .withMergeRequestTitle("Test")
-                            .withMergeRequestId(1)
-                            .withMergeRequestIid(1)
-                            .withTargetBranch("master")
-                            .withTargetRepoName("test")
-                            .withTargetNamespace("test-namespace")
-                            .withTargetRepoSshUrl("git@gitlab.org:test.git")
-                            .withTargetRepoHttpUrl("https://gitlab.org/test.git")
-                            .withTriggeredByUser("test")
-                            .withLastCommit("123")
-                            .withTargetProjectUrl("https://gitlab.org/test")
-                            .build()));
-            future.get();
-            new NoteBuildAction(testProject, getJson("NoteEvent_alreadyBuiltMR.json"), null).execute(response);
+    void build_alreadyBuiltMR_differentTargetBranch() throws Exception {
+        FreeStyleProject testProject = jenkins.createFreeStyleProject();
+        testProject.addTrigger(trigger);
+        testProject.setScm(new GitSCM(gitRepoUrl));
+        QueueTaskFuture<?> future = testProject.scheduleBuild2(
+                0,
+                new GitLabWebHookCause(causeData()
+                        .withActionType(CauseData.ActionType.NOTE)
+                        .withSourceProjectId(1)
+                        .withTargetProjectId(1)
+                        .withBranch("feature")
+                        .withSourceBranch("feature")
+                        .withUserName("")
+                        .withSourceRepoHomepage("https://gitlab.org/test")
+                        .withSourceRepoName("test")
+                        .withSourceNamespace("test-namespace")
+                        .withSourceRepoUrl("git@gitlab.org:test.git")
+                        .withSourceRepoSshUrl("git@gitlab.org:test.git")
+                        .withSourceRepoHttpUrl("https://gitlab.org/test.git")
+                        .withMergeRequestTitle("Test")
+                        .withMergeRequestId(1)
+                        .withMergeRequestIid(1)
+                        .withTargetBranch("master")
+                        .withTargetRepoName("test")
+                        .withTargetNamespace("test-namespace")
+                        .withTargetRepoSshUrl("git@gitlab.org:test.git")
+                        .withTargetRepoHttpUrl("https://gitlab.org/test.git")
+                        .withTriggeredByUser("test")
+                        .withLastCommit("123")
+                        .withTargetProjectUrl("https://gitlab.org/test")
+                        .build()));
+        future.get();
 
-            verify(trigger).onPost(any(NoteHook.class));
-        });
+        assertThrows(HttpResponses.HttpResponseException.class, () -> new NoteBuildAction(
+                        testProject, getJson("NoteEvent_alreadyBuiltMR.json"), null)
+                .execute(response));
+        verify(trigger).onPost(any(NoteHook.class));
     }
 
     private String getJson(String name) throws Exception {

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PipelineBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PipelineBuildActionTest.java
@@ -2,7 +2,6 @@ package com.dabsquared.gitlabjenkins.webhook.build;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
@@ -51,20 +50,18 @@ class PipelineBuildActionTest {
 
     @Test
     void buildOnSuccess() {
-        assertThrows(HttpResponses.HttpResponseException.class, () -> {
-            new PipelineBuildAction(testProject, getJson("PipelineEvent.json"), null).execute(response);
-
-            verify(trigger).onPost(any(PipelineHook.class));
-        });
+        assertThrows(
+                HttpResponses.HttpResponseException.class,
+                () -> new PipelineBuildAction(testProject, getJson("PipelineEvent.json"), null).execute(response));
+        verify(trigger).onPost(any(PipelineHook.class));
     }
 
     @Test
     void doNotBuildOnFailure() {
-        assertThrows(HttpResponses.HttpResponseException.class, () -> {
-            new PipelineBuildAction(testProject, getJson("PipelineFailureEvent.json"), null).execute(response);
-
-            verify(trigger, never()).onPost(any(PipelineHook.class));
-        });
+        assertThrows(HttpResponses.HttpResponseException.class, () -> new PipelineBuildAction(
+                        testProject, getJson("PipelineFailureEvent.json"), null)
+                .execute(response));
+        verify(trigger).onPost(any(PipelineHook.class));
     }
 
     private String getJson(String name) throws Exception {

--- a/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildActionTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildActionTest.java
@@ -89,16 +89,16 @@ class PushBuildActionTest {
     }
 
     @Test
-    void invalidToken() {
-        assertThrows(HttpResponses.HttpResponseException.class, () -> {
-            FreeStyleProject testProject = jenkins.createFreeStyleProject();
-            when(trigger.getTriggerOpenMergeRequestOnPush()).thenReturn(TriggerOpenMergeRequest.never);
-            when(trigger.getSecretToken()).thenReturn("secret");
-            testProject.addTrigger(trigger);
-            new PushBuildAction(testProject, getJson("PushEvent.json"), "wrong-secret").execute(response);
+    void invalidToken() throws Exception {
+        FreeStyleProject testProject = jenkins.createFreeStyleProject();
+        when(trigger.getTriggerOpenMergeRequestOnPush()).thenReturn(TriggerOpenMergeRequest.never);
+        when(trigger.getSecretToken()).thenReturn("secret");
+        testProject.addTrigger(trigger);
 
-            verify(trigger, never()).onPost(any(PushHook.class));
-        });
+        assertThrows(
+                HttpResponses.HttpResponseException.class,
+                () -> new PushBuildAction(testProject, getJson("PushEvent.json"), "wrong-secret").execute(response));
+        verify(trigger, never()).onPost(any(PushHook.class));
     }
 
     private String getJson(String name) throws Exception {

--- a/src/test/java/com/dabsquared/gitlabjenkins/workflow/UpdateGitLabCommitStatusStepTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/workflow/UpdateGitLabCommitStatusStepTest.java
@@ -16,41 +16,34 @@ import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.RealJenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.RealJenkinsExtension;
 import org.mockserver.client.MockServerClient;
-import org.mockserver.junit.MockServerRule;
+import org.mockserver.junit.jupiter.MockServerExtension;
 
-public class UpdateGitLabCommitStatusStepTest {
+@ExtendWith(MockServerExtension.class)
+class UpdateGitLabCommitStatusStepTest {
 
-    @Rule
-    public RealJenkinsRule rr = new RealJenkinsRule();
-
-    @Rule
-    public MockServerRule mockServer = new MockServerRule(new Object());
+    @RegisterExtension
+    private final RealJenkinsExtension extension = new RealJenkinsExtension();
 
     private MockServerClient mockServerClient;
 
-    @Before
-    public void setUp() {
-        mockServerClient = new MockServerClient("localhost", mockServer.getPort());
-    }
-
-    @After
-    public void tearDown() {
-        mockServerClient.reset();
+    @BeforeEach
+    void setUp(MockServerClient client) {
+        mockServerClient = client;
     }
 
     @Test
-    public void updateGitlabCommitStatus() throws Throwable {
-        int port = mockServer.getPort();
+    void updateGitlabCommitStatus() throws Throwable {
+        int port = mockServerClient.getPort();
         String pipelineText = IOUtils.toString(
                 getClass().getResourceAsStream("pipeline/updateGitlabCommitStatus.groovy"), StandardCharsets.UTF_8);
-        rr.then(j -> {
+        extension.then(j -> {
             _updateGitlabCommitStatus(j, port, pipelineText);
         });
     }


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit Jupiter. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up
* Ban JUnit4 imports

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed