### PR TITLE
Require Jenkins 2.504.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,32 +108,12 @@
       <exclusions>
         <!-- Provided by Jenkins core -->
         <exclusion>
-          <groupId>com.github.stephenc.jcip</groupId>
-          <artifactId>jcip-annotations</artifactId>
-        </exclusion>
-        <!-- Provided by javax-activation-api plugin -->
-        <exclusion>
-          <groupId>com.sun.activation</groupId>
-          <artifactId>jakarta.activation</artifactId>
-        </exclusion>
-        <!-- Provided by Jenkins core -->
-        <exclusion>
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
         </exclusion>
         <exclusion>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
-        </exclusion>
-        <!-- Provided by jakarta-activation-api plugin -->
-        <exclusion>
-          <groupId>jakarta.activation</groupId>
-          <artifactId>jakarta.activation-api</artifactId>
-        </exclusion>
-        <!-- Provided by jaxb plugin -->
-        <exclusion>
-          <groupId>jakarta.xml.bind</groupId>
-          <artifactId>jakarta.xml.bind-api</artifactId>
         </exclusion>
         <!-- Provided by apache-httpcomponents-client-4-api plugin -->
         <exclusion>
@@ -267,16 +247,6 @@
       <version>${mockserver.version}</version>
       <scope>test</scope>
       <exclusions>
-        <!-- Provided by jaxb plugin -->
-        <exclusion>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-impl</artifactId>
-        </exclusion>
-        <!-- Provided by Jenkins core -->
-        <exclusion>
-          <groupId>commons-codec</groupId>
-          <artifactId>commons-codec</artifactId>
-        </exclusion>
         <!-- Banned via the exclude/include list in parent pom 4.62 -->
         <exclusion>
           <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <revision>1.9.11</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.492</jenkins.baseline>
+    <jenkins.baseline>2.504</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
@@ -64,7 +64,7 @@
         <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5473.vb_9533d9e5d88</version>
+        <version>5701.va_b_018a_a_6b_0d3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -83,7 +83,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jakarta-xml-bind-api</artifactId>
-      <version>4.0.5-3.v3d5b_a_73965b_9</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -92,7 +91,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jersey3-api</artifactId>
-      <version>3.1.11-2.v4a_b_db_cf4557b_</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -167,7 +165,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.20.1-423.v13951f6b_6532</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Require Jenkins 2.504.3 or newer

The [developer documentation](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions) recommends either Jenkins 2.504.3 or Jenkins 2.516.3 as minimum Jenkins versions.

We could also increase the minimum Jenkins version to 2.516.3 and have a longer time before the next increment of Jenkins version, if that is preferred.

Using Jenkins 2.504.3 as minimum Jenkins version allows us to remove 3 version declarations from the pom file and supersedes pull request:

* https://github.com/jenkinsci/gitlab-plugin/pull/1838

### Testing done

* Confirmed that automated tests pass

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
- ~Link to relevant issues in GitHub or Jira~
