### PR TITLE
Make Secret Token updates work when CSP is enforced

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,8 @@
     <changelist>-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.492</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <!-- TODO https://github.com/jenkinsci/jenkins/pull/20345 -->
+    <jenkins.version>2.537-rc37711.669feb_d92990</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <changelist>-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.504</jenkins.baseline>
-    <jenkins.version>2.540</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,7 @@
     <changelist>-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.504</jenkins.baseline>
-    <!-- TODO https://github.com/jenkinsci/jenkins/pull/20345 -->
-    <jenkins.version>2.537-rc37711.669feb_d92990</jenkins.version>
+    <jenkins.version>2.540</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -66,7 +66,6 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
-import org.kohsuke.stapler.StaplerResponse2;
 
 /**
  * Triggers a build when we receive a GitLab WebHook.
@@ -743,20 +742,6 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
         public FormValidation doCheckExcludeMergeRequestLabels(
                 @AncestorInPath final Job<?, ?> project, @QueryParameter final String value) {
             return ProjectLabelsProvider.instance().doCheckLabels(project, value);
-        }
-
-        public void doGenerateSecretToken(@AncestorInPath final Job<?, ?> project, StaplerResponse2 response) {
-            byte[] random = new byte[16]; // 16x8=128bit worth of randomness, since we use md5 digest as the API token
-            RANDOM.nextBytes(random);
-            String secretToken = Util.toHexString(random);
-            response.setHeader(
-                    "X-Jenkins-ValidateButton-Callback",
-                    "{\"callback\":\"updateSecretToken\",\"arguments\":[\"" + secretToken + "\"]}");
-        }
-
-        public void doClearSecretToken(@AncestorInPath final Job<?, ?> project, StaplerResponse2 response) {
-            response.setHeader(
-                    "X-Jenkins-ValidateButton-Callback", "{\"callback\":\"updateSecretToken\",\"arguments\":[\"\"]}");
         }
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -749,12 +749,14 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
             byte[] random = new byte[16]; // 16x8=128bit worth of randomness, since we use md5 digest as the API token
             RANDOM.nextBytes(random);
             String secretToken = Util.toHexString(random);
-            response.setHeader("script", "document.getElementById('secretToken').value='" + secretToken + "'");
+            response.setHeader(
+                    "X-Jenkins-ValidateButton-Callback",
+                    "{\"callback\":\"updateSecretToken\",\"arguments\":[\"" + secretToken + "\"]}");
         }
 
         public void doClearSecretToken(@AncestorInPath final Job<?, ?> project, StaplerResponse2 response) {
-            ;
-            response.setHeader("script", "document.getElementById('secretToken').value=''");
+            response.setHeader(
+                    "X-Jenkins-ValidateButton-Callback", "{\"callback\":\"updateSecretToken\",\"arguments\":[\"\"]}");
         }
     }
 }

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/adjunct.js
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/adjunct.js
@@ -1,0 +1,3 @@
+function updateSecretToken(newValue) {
+    document.getElementById('gitlab_plugin_secretToken').value = newValue;
+}

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/adjunct.js
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/adjunct.js
@@ -1,3 +1,13 @@
-function updateSecretToken(newValue) {
-    document.getElementById('gitlab_plugin_secretToken').value = newValue;
-}
+Behaviour.specify("BUTTON.gitlab_plugin-generate", "gitlab_plugin-generate", 0, function (e) {
+    e.onclick = function (evt) {
+        document.getElementById('gitlab_plugin_secretToken').value = [...Array(32)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
+        evt.preventDefault();
+    };
+});
+
+Behaviour.specify("BUTTON.gitlab_plugin-clear", "gitlab_plugin-clear", 0, function (e) {
+    e.onclick = function (evt) {
+        document.getElementById('gitlab_plugin_secretToken').value = "";
+        evt.preventDefault();
+    };
+});

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form"
-         xmlns:d="jelly:define">
+         xmlns:st="jelly:stapler">
   <f:entry title="Enabled GitLab triggers">
     <div>
       <f:entry title="Push Events" field="triggerOnPush">
@@ -102,8 +102,9 @@
       </div>
     </f:entry>
     <f:entry title="${%Secret token}" help="/plugin/gitlab-plugin/help/help-secretToken.html">
+      <st:adjunct includes="com.dabsquared.gitlabjenkins.GitLabPushTrigger.adjunct"/>
       <div>
-        <f:readOnlyTextbox field="secretToken" id="secretToken"/>
+        <f:readOnlyTextbox field="secretToken" id="gitlab_plugin_secretToken"/>
         <f:validateButton title="${%Generate}" method="generateSecretToken"/>
         <f:validateButton title="${%Clear}" method="clearSecretToken"/>
       </div>

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -103,11 +103,9 @@
     </f:entry>
     <f:entry title="${%Secret token}" help="/plugin/gitlab-plugin/help/help-secretToken.html">
       <st:adjunct includes="com.dabsquared.gitlabjenkins.GitLabPushTrigger.adjunct"/>
-      <div>
-        <f:readOnlyTextbox field="secretToken" id="gitlab_plugin_secretToken"/>
-        <f:validateButton title="${%Generate}" method="generateSecretToken"/>
-        <f:validateButton title="${%Clear}" method="clearSecretToken"/>
-      </div>
+      <f:readOnlyTextbox field="secretToken" id="gitlab_plugin_secretToken"/>
+      <button class="jenkins-button gitlab_plugin-generate jenkins-!-margin-right-1 jenkins-!-margin-top-1">${%Generate}</button>
+      <button class="jenkins-button gitlab_plugin-clear jenkins-!-margin-top-1">${%Clear}</button>
     </f:entry>
   </f:advanced>
 </j:jelly>


### PR DESCRIPTION
Fixes #1837 by no longer depending on the undocumented `f:validateButton` feature.  I recommend squash-merging due to unclean PR commit history.

As a bonus, made the form field ID a little more unique, in case there'd be some other plugin with a `secretToken` field.

### Testing done

Clicked the buttons in a freestyle config, see #1837. Saving still works, new value is effective on page load.

With CSP plugin installed, no new CSP findings in Manage Jenkins » Content Security Policy Report.

### Screenshots

#### Before

<img width="898" height="319" alt="Screenshot 2025-12-02 at 18 23 58" src="https://github.com/user-attachments/assets/87f8ca00-03ef-4a82-aac9-cbac8d070d23" />

#### After

<img width="474" height="217" alt="Screenshot 2025-12-02 at 18 21 54" src="https://github.com/user-attachments/assets/595241d6-69ab-4cdb-b292-e220358a7431" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
