### PR TITLE
Fix missing gitlabMergeRequestState for note webhook triggers.

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/note/NoteHookTriggerHandlerImpl.java
@@ -86,6 +86,7 @@ class NoteHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<NoteHook>
                 .withMergeRequestDescription(hook.getMergeRequest().getDescription())
                 .withMergeRequestId(hook.getMergeRequest().getId())
                 .withMergeRequestIid(hook.getMergeRequest().getIid())
+                .withMergeRequestState(hook.getMergeRequest().getState())
                 .withMergeRequestTargetProjectId(hook.getMergeRequest().getTargetProjectId())
                 .withTargetBranch(hook.getMergeRequest().getTargetBranch())
                 .withTargetRepoName(hook.getMergeRequest().getTarget().getName())


### PR DESCRIPTION
### What does this PR do?
Populates the `gitlabMergeRequestState` environment variable for Jenkins
builds triggered by **GitLab Merge Request note (comment) webhooks**.
This brings note-triggered builds in line with merge request event triggers.

### Testing done
Manual reasoning-based validation.

- Compared `NoteHookTriggerHandlerImpl` with `MergeRequestHookTriggerHandlerImpl`
- Verified that merge request event handler already populates
  `mergeRequestState` in `CauseData`
- Applied the same field population for note-triggered builds
- Change is deterministic and uses data already present in the webhook payload

Automated tests were not added because:
- The project currently lacks isolated unit tests for webhook trigger handlers
- Setting up Jenkins + GitLab webhook simulation is non-trivial
- The change mirrors existing, production-tested logic

### Related issue
Fixes #1823
