### PR TITLE
Replace jersey3-api which still uses jackson 2 with jackson-jakarta-rs-json-provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
-    <hpi.bundledArtifacts>asyncutil,jakarta.annotation-api,jakarta.validation-api,jboss-jaxrs-api_3.0_spec,jboss-logging,reactive-streams,resteasy-client,resteasy-client-api,resteasy-core,resteasy-core-spi</hpi.bundledArtifacts>
+    <hpi.bundledArtifacts>asyncutil,jackson-jakarta-rs-base,jackson-jakarta-rs-json-provider,jakarta.annotation-api,jakarta.validation-api,jboss-jaxrs-api_3.0_spec,jboss-logging,reactive-streams,resteasy-client,resteasy-client-api,resteasy-core,resteasy-core-spi</hpi.bundledArtifacts>
     <hpi.compatibleSinceVersion>1.4.0</hpi.compatibleSinceVersion>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <mockserver.version>5.15.0</mockserver.version>
@@ -91,10 +91,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>javax-activation-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>jersey3-api</artifactId>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -171,6 +167,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
+    </dependency>
+    <!-- Keep in sync with the jackson version used in the jackson3-api plugin -->
+    <dependency>
+      <groupId>tools.jackson.jakarta.rs</groupId>
+      <artifactId>jackson-jakarta-rs-json-provider</artifactId>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>net.karneim</groupId>

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClientBuilder.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClientBuilder.java
@@ -61,7 +61,6 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.glassfish.jersey.jackson.JacksonFeature;
 import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
 import org.jboss.resteasy.client.jaxrs.ClientHttpEngineBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
@@ -73,6 +72,7 @@ import org.jboss.resteasy.plugins.providers.JaxrsFormProvider;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 @Restricted(NoExternalUse.class)
 public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
@@ -155,7 +155,7 @@ public class ResteasyGitLabClientBuilder extends GitLabClientBuilder {
                 .maxPooledPerRoute(30)
                 .connectTimeout(connectionTimeout, TimeUnit.SECONDS)
                 .readTimeout(readTimeout, TimeUnit.SECONDS)
-                .register(new JacksonFeature())
+                .register(new JacksonJsonProvider())
                 .register(new JacksonConfig())
                 .register(new ApiHeaderTokenFilter(credentialResolver, url))
                 .register(new LoggingFilter())


### PR DESCRIPTION
JacksonFeature was used from jersey3-api to provide the JackonJsonProvider. jersey3-api still uses jackson 2, which created a mismatch with the now used jackson3-api.

This fixes the behavior described/discussed in #1865, which was introduced by the switch to jackson3-api migration in #1877 
This pull request updates the project's dependency management and REST client configuration to use the Jackson JSON provider for Jakarta RS instead of Jersey's Jackson integration.

The plugin itself was migrated to jackson 3.x already. But with the JacksonFeature from jersey3-api, which still uses jackson 2.x, the Jackson 2 Json Provider is used in the RestEasy client. And therefore the default Jackson 2 Mapper is used, instead of the Jackon 3 ObjectMapper already provided by the plugin.

By replacing jersey3-api (Jackson 2.x) with jackson-jakarta-rs-json-provider the only Jackson version the plugin now uses through direct or transitive dependencies is Jackson 3.x now.

jackson-jakarta-rs-json-provider  should be replaced by a jenkins-api-plugin which provides a Jackson 3 JsonProvider, once available.

This will fix the current failing test in #1880.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed (in #1880)
