### PR TITLE
Restore Jackson2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,10 +82,6 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
-      <artifactId>jackson3-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
       <artifactId>jakarta-xml-bind-api</artifactId>
     </dependency>
     <dependency>
@@ -145,6 +141,10 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/JacksonConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/JacksonConfig.java
@@ -1,14 +1,13 @@
 package com.dabsquared.gitlabjenkins.gitlab;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ContextResolver;
 import jakarta.ws.rs.ext.Provider;
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.PropertyNamingStrategies;
-import tools.jackson.databind.cfg.EnumFeature;
-import tools.jackson.databind.json.JsonMapper;
 
 /**
  * @author Robin Müller
@@ -18,9 +17,9 @@ import tools.jackson.databind.json.JsonMapper;
 @Produces(MediaType.APPLICATION_JSON)
 public class JacksonConfig implements ContextResolver<ObjectMapper> {
     public ObjectMapper getContext(Class<?> type) {
-        return JsonMapper.builder()
-                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
-                .configure(EnumFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
-                .build();
+        return new ObjectMapper()
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Awardable.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Awardable.java
@@ -1,13 +1,11 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Awardable {
     private Integer id;
     private String name;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Branch.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Branch.java
@@ -1,6 +1,5 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -10,7 +9,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * @author Robin Müller
  */
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Branch {
 
     private String name;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Commit.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Commit.java
@@ -1,6 +1,5 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Date;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -11,7 +10,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * @author Robin Müller
  */
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Commit {
 
     private String id;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Group.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Group.java
@@ -1,6 +1,5 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -14,7 +13,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * @since Mon, 2022-06-13 - 07:19:01
  */
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Group {
 
     /** Group Hook ID */

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Label.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Label.java
@@ -1,6 +1,5 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -10,7 +9,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * @author Robin Müller
  */
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Label {
     /*
          "name" : "bug",

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/MergeRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/MergeRequest.java
@@ -1,7 +1,6 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.State;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -15,7 +14,6 @@ import org.kohsuke.stapler.export.ExportedBean;
  */
 @ExportedBean
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class MergeRequest {
     private Integer id;
     private Integer iid;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Namespace.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Namespace.java
@@ -1,6 +1,5 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -10,7 +9,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * @author Robin Müller
  */
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Namespace {
 
     private String path;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Note.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Note.java
@@ -1,6 +1,5 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Date;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -8,7 +7,6 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Note {
     private Long id;
     private Integer projectId;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Pipeline.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Pipeline.java
@@ -1,10 +1,8 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Pipeline {
     private Integer id;
     private String sha;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Project.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/Project.java
@@ -1,6 +1,5 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -10,7 +9,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * @author Robin Müller
  */
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Project {
 
     private Integer id;

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/ProjectHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/ProjectHook.java
@@ -1,6 +1,5 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -14,7 +13,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * @since Sun, 2022-06-12 - 12:25:26
  */
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ProjectHook {
 
     /** Hook ID */

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/User.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/model/User.java
@@ -1,6 +1,5 @@
 package com.dabsquared.gitlabjenkins.gitlab.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -10,7 +9,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * @author Robin Müller
  */
 @GeneratePojoBuilder(intoPackage = "*.builder.generated", withFactoryMethod = "*")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class User {
 
     private Integer id;

--- a/src/main/java/com/dabsquared/gitlabjenkins/util/JsonUtil.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/util/JsonUtil.java
@@ -1,43 +1,37 @@
 package com.dabsquared.gitlabjenkins.util;
 
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Locale;
-import tools.jackson.core.JacksonException;
-import tools.jackson.databind.DeserializationContext;
-import tools.jackson.databind.DeserializationFeature;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.PropertyNamingStrategies;
-import tools.jackson.databind.SerializationFeature;
-import tools.jackson.databind.ValueDeserializer;
-import tools.jackson.databind.cfg.EnumFeature;
-import tools.jackson.databind.json.JsonMapper;
-import tools.jackson.databind.module.SimpleModule;
 
 /**
  * @author Robin Müller
  */
 public final class JsonUtil {
 
-    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
-            .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
-            .configure(EnumFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
             .configure(SerializationFeature.INDENT_OUTPUT, true)
-            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            .addModule(new DateModule())
-            .build();
+            .registerModule(new DateModule());
 
     private JsonUtil() {}
 
     public static String toPrettyPrint(String json) {
         try {
             return toPrettyPrint(OBJECT_MAPPER.readValue(json, Object.class));
-        } catch (JacksonException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -45,7 +39,7 @@ public final class JsonUtil {
     public static String toPrettyPrint(Object obj) {
         try {
             return OBJECT_MAPPER.writeValueAsString(obj);
-        } catch (JacksonException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -53,7 +47,7 @@ public final class JsonUtil {
     public static JsonNode readTree(String json) {
         try {
             return OBJECT_MAPPER.readTree(json);
-        } catch (JacksonException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -61,7 +55,7 @@ public final class JsonUtil {
     public static <T> T read(String json, Class<T> type) {
         try {
             return OBJECT_MAPPER.readValue(json, type);
-        } catch (JacksonException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -69,7 +63,7 @@ public final class JsonUtil {
     public static <T> T read(JsonNode json, Class<T> type) {
         try {
             return OBJECT_MAPPER.treeToValue(json, type);
-        } catch (JacksonException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -84,9 +78,10 @@ public final class JsonUtil {
         };
 
         private DateModule() {
-            addDeserializer(Date.class, new ValueDeserializer<Date>() {
+            addDeserializer(Date.class, new com.fasterxml.jackson.databind.JsonDeserializer<Date>() {
                 @Override
-                public Date deserialize(tools.jackson.core.JsonParser p, DeserializationContext ctxt) {
+                public Date deserialize(com.fasterxml.jackson.core.JsonParser p, DeserializationContext ctxt)
+                        throws IOException {
                     for (String format : DATE_FORMATS) {
                         try {
                             return new SimpleDateFormat(format, Locale.US).parse(p.getValueAsString());
@@ -94,9 +89,9 @@ public final class JsonUtil {
                             // nothing to do
                         }
                     }
-                    throw new UncheckedIOException(new IOException("Unparseable date: \""
+                    throw new IOException("Unparseable date: \""
                             + p.getValueAsString() + "\". Supported formats: "
-                            + Arrays.toString(DATE_FORMATS)));
+                            + Arrays.toString(DATE_FORMATS));
                 }
             });
         }

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/ActionResolver.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/ActionResolver.java
@@ -14,6 +14,7 @@ import com.dabsquared.gitlabjenkins.webhook.status.BranchStatusPngAction;
 import com.dabsquared.gitlabjenkins.webhook.status.CommitBuildPageRedirectAction;
 import com.dabsquared.gitlabjenkins.webhook.status.CommitStatusPngAction;
 import com.dabsquared.gitlabjenkins.webhook.status.StatusJsonAction;
+import com.fasterxml.jackson.databind.JsonNode;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
@@ -33,7 +34,6 @@ import jenkins.scm.api.SCMSourceOwner;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
-import tools.jackson.databind.JsonNode;
 
 /**
  * @author Robin Müller
@@ -139,7 +139,7 @@ public class ActionResolver {
         String objectKind = "";
         try {
             jsonTree = JsonUtil.readTree(requestBody);
-            objectKind = jsonTree.path("object_kind").asString("");
+            objectKind = jsonTree.path("object_kind").asText("");
         } catch (RuntimeException exception) {
             LOGGER.log(Level.FINE, "Could not extract object_kind from request body.");
         }

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/MergeRequestBuildAction.java
@@ -7,6 +7,7 @@ import com.dabsquared.gitlabjenkins.gitlab.hook.model.MergeRequestHook;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.MergeRequestObjectAttributes;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.Project;
 import com.dabsquared.gitlabjenkins.util.JsonUtil;
+import com.fasterxml.jackson.databind.JsonNode;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.security.ACL;
@@ -14,7 +15,6 @@ import hudson.util.HttpResponses;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import tools.jackson.databind.JsonNode;
 
 /**
  * @author Robin Müller

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/NoteBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/NoteBuildAction.java
@@ -6,6 +6,7 @@ import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.NoteHook;
 import com.dabsquared.gitlabjenkins.util.JsonUtil;
 import com.dabsquared.gitlabjenkins.webhook.WebHookAction;
+import com.fasterxml.jackson.databind.JsonNode;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.security.ACL;
@@ -14,7 +15,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerResponse2;
-import tools.jackson.databind.JsonNode;
 
 /**
  * @author Nikolay Ustinov

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PipelineBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PipelineBuildAction.java
@@ -5,6 +5,7 @@ import static com.dabsquared.gitlabjenkins.util.JsonUtil.toPrettyPrint;
 import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.*;
 import com.dabsquared.gitlabjenkins.util.JsonUtil;
+import com.fasterxml.jackson.databind.JsonNode;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.security.ACL;
@@ -15,7 +16,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang3.StringUtils;
-import tools.jackson.databind.JsonNode;
 
 /**
  * @author Milena Zachow

--- a/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/webhook/build/PushBuildAction.java
@@ -8,6 +8,7 @@ import com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.Project;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.PushHook;
 import com.dabsquared.gitlabjenkins.util.JsonUtil;
+import com.fasterxml.jackson.databind.JsonNode;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.security.ACL;
@@ -27,7 +28,6 @@ import jenkins.scm.api.trait.SCMTrait;
 import org.acegisecurity.Authentication;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.transport.URIish;
-import tools.jackson.databind.JsonNode;
 
 /**
  * @author Robin Müller


### PR DESCRIPTION
Due to Jersey 3 not supporting Jackson3 (Jersey 4 will include a module for it https://github.com/eclipse-ee4j/jersey/issues/6036)

Revert 5b423b0a5f27323477cbf578777954e2b7b73fc6 and e8f0436d6da4d35a83f461c5a30b6209aa4de7f4

In thoery works with https://github.com/jenkinsci/gitlab-plugin/pull/1881 but maybe will cause other issue

In any case https://github.com/jenkinsci/gitlab-plugin/pull/1880 is needed to avoid future regression in the future

### Testing done

None

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
