### PR TITLE
Add failed-pipeline trigger and enrich pipeline event metadata

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -81,6 +81,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
     private boolean triggerOnMergeRequest = true;
     private boolean triggerOnlyIfNewCommitsPushed = false;
     private boolean triggerOnPipelineEvent = false;
+    private boolean triggerOnFailedPipelineEvent = false;
     private boolean triggerOnAcceptedMergeRequest = false;
     private boolean triggerOnClosedMergeRequest = false;
     private boolean triggerOnApprovedMergeRequest = false;
@@ -512,6 +513,15 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
         this.triggerOnPipelineEvent = triggerOnPipelineEvent;
     }
 
+    public boolean getTriggerOnFailedPipelineEvent() {
+        return triggerOnFailedPipelineEvent;
+    }
+
+    @DataBoundSetter
+    public void setTriggerOnFailedPipelineEvent(boolean triggerOnFailedPipelineEvent) {
+        this.triggerOnFailedPipelineEvent = triggerOnFailedPipelineEvent;
+    }
+
     @DataBoundSetter
     public void setPendingBuildName(String pendingBuildName) {
         this.pendingBuildName = pendingBuildName;
@@ -588,7 +598,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> implements MergeReques
                 triggerToBranchDeleteRequest,
                 triggerOpenMergeRequestOnPush,
                 skipWorkInProgressMergeRequest);
-        pipelineTriggerHandler = newPipelineHookTriggerHandler(triggerOnPipelineEvent);
+        pipelineTriggerHandler = newPipelineHookTriggerHandler(triggerOnPipelineEvent, triggerOnFailedPipelineEvent);
     }
 
     private void initializeBranchFilter() {

--- a/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/cause/CauseData.java
@@ -62,6 +62,17 @@ public final class CauseData {
     private final String finishedAt;
     private final String buildDuration;
     private final String commentAuthor;
+    private final Integer pipelineId;
+    private final Integer pipelineIid;
+    private final String pipelineSource;
+    private final String pipelineUrl;
+    private final String commitMessage;
+    private final String commitTitle;
+    private final String commitAuthorName;
+    private final String commitAuthorEmail;
+    private final String commitUrl;
+    private final String projectWebUrl;
+    private final String projectPathWithNamespace;
 
     @GeneratePojoBuilder(withFactoryMethod = "*")
     CauseData(
@@ -109,7 +120,18 @@ public final class CauseData {
             String createdAt,
             String finishedAt,
             String buildDuration,
-            String commentAuthor) {
+            String commentAuthor,
+            Integer pipelineId,
+            Integer pipelineIid,
+            String pipelineSource,
+            String pipelineUrl,
+            String commitMessage,
+            String commitTitle,
+            String commitAuthorName,
+            String commitAuthorEmail,
+            String commitUrl,
+            String projectWebUrl,
+            String projectPathWithNamespace) {
         this.actionType = Objects.requireNonNull(actionType, "actionType must not be null.");
         this.sourceProjectId = Objects.requireNonNull(sourceProjectId, "sourceProjectId must not be null.");
         this.targetProjectId = Objects.requireNonNull(targetProjectId, "targetProjectId must not be null.");
@@ -155,6 +177,17 @@ public final class CauseData {
         this.finishedAt = finishedAt;
         this.buildDuration = buildDuration;
         this.commentAuthor = commentAuthor;
+        this.pipelineId = pipelineId;
+        this.pipelineIid = pipelineIid;
+        this.pipelineSource = pipelineSource;
+        this.pipelineUrl = pipelineUrl;
+        this.commitMessage = commitMessage;
+        this.commitTitle = commitTitle;
+        this.commitAuthorName = commitAuthorName;
+        this.commitAuthorEmail = commitAuthorEmail;
+        this.commitUrl = commitUrl;
+        this.projectWebUrl = projectWebUrl;
+        this.projectPathWithNamespace = projectPathWithNamespace;
     }
 
     @Exported
@@ -205,6 +238,17 @@ public final class CauseData {
         variables.put("finishedAt", finishedAt);
         variables.put("duration", buildDuration);
         variables.putIfNotNull("gitlabTriggerPhrase", triggerPhrase);
+        variables.putIfNotNull("gitlabPipelineId", pipelineId == null ? null : pipelineId.toString());
+        variables.putIfNotNull("gitlabPipelineIid", pipelineIid == null ? null : pipelineIid.toString());
+        variables.putIfNotNull("gitlabPipelineSource", pipelineSource);
+        variables.putIfNotNull("gitlabPipelineUrl", pipelineUrl);
+        variables.putIfNotNull("gitlabCommitMessage", commitMessage);
+        variables.putIfNotNull("gitlabCommitTitle", commitTitle);
+        variables.putIfNotNull("gitlabCommitAuthorName", commitAuthorName);
+        variables.putIfNotNull("gitlabCommitAuthorEmail", commitAuthorEmail);
+        variables.putIfNotNull("gitlabCommitUrl", commitUrl);
+        variables.putIfNotNull("gitlabProjectWebUrl", projectWebUrl);
+        variables.putIfNotNull("gitlabProjectPathWithNamespace", projectPathWithNamespace);
         return variables;
     }
 
@@ -413,6 +457,61 @@ public final class CauseData {
         return commentAuthor;
     }
 
+    @Exported
+    public Integer getPipelineId() {
+        return pipelineId;
+    }
+
+    @Exported
+    public Integer getPipelineIid() {
+        return pipelineIid;
+    }
+
+    @Exported
+    public String getPipelineSource() {
+        return pipelineSource;
+    }
+
+    @Exported
+    public String getPipelineUrl() {
+        return pipelineUrl;
+    }
+
+    @Exported
+    public String getCommitMessage() {
+        return commitMessage;
+    }
+
+    @Exported
+    public String getCommitTitle() {
+        return commitTitle;
+    }
+
+    @Exported
+    public String getCommitAuthorName() {
+        return commitAuthorName;
+    }
+
+    @Exported
+    public String getCommitAuthorEmail() {
+        return commitAuthorEmail;
+    }
+
+    @Exported
+    public String getCommitUrl() {
+        return commitUrl;
+    }
+
+    @Exported
+    public String getProjectWebUrl() {
+        return projectWebUrl;
+    }
+
+    @Exported
+    public String getProjectPathWithNamespace() {
+        return projectPathWithNamespace;
+    }
+
     String getShortDescription() {
         return actionType.getShortDescription(this);
     }
@@ -505,6 +604,17 @@ public final class CauseData {
                 .append(finishedAt, causeData.getFinishedAt())
                 .append(buildDuration, causeData.getBuildDuration())
                 .append(commentAuthor, causeData.getCommentAuthor())
+                .append(pipelineId, causeData.getPipelineId())
+                .append(pipelineIid, causeData.getPipelineIid())
+                .append(pipelineSource, causeData.getPipelineSource())
+                .append(pipelineUrl, causeData.getPipelineUrl())
+                .append(commitMessage, causeData.getCommitMessage())
+                .append(commitTitle, causeData.getCommitTitle())
+                .append(commitAuthorName, causeData.getCommitAuthorName())
+                .append(commitAuthorEmail, causeData.getCommitAuthorEmail())
+                .append(commitUrl, causeData.getCommitUrl())
+                .append(projectWebUrl, causeData.getProjectWebUrl())
+                .append(projectPathWithNamespace, causeData.getProjectPathWithNamespace())
                 .isEquals();
     }
 
@@ -555,6 +665,17 @@ public final class CauseData {
                 .append(finishedAt)
                 .append(buildDuration)
                 .append(commentAuthor)
+                .append(pipelineId)
+                .append(pipelineIid)
+                .append(pipelineSource)
+                .append(pipelineUrl)
+                .append(commitMessage)
+                .append(commitTitle)
+                .append(commitAuthorName)
+                .append(commitAuthorEmail)
+                .append(commitUrl)
+                .append(projectWebUrl)
+                .append(projectPathWithNamespace)
                 .toHashCode();
     }
 
@@ -605,6 +726,17 @@ public final class CauseData {
                 .append("finishedAt", finishedAt)
                 .append("duration", buildDuration)
                 .append("commentAuthor", commentAuthor)
+                .append("pipelineId", pipelineId)
+                .append("pipelineIid", pipelineIid)
+                .append("pipelineSource", pipelineSource)
+                .append("pipelineUrl", pipelineUrl)
+                .append("commitMessage", commitMessage)
+                .append("commitTitle", commitTitle)
+                .append("commitAuthorName", commitAuthorName)
+                .append("commitAuthorEmail", commitAuthorEmail)
+                .append("commitUrl", commitUrl)
+                .append("projectWebUrl", projectWebUrl)
+                .append("projectPathWithNamespace", projectPathWithNamespace)
                 .toString();
     }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/GitLabClient.java
@@ -88,4 +88,6 @@ public interface GitLabClient {
     List<Label> getLabels(String projectId);
 
     List<Pipeline> getPipelines(String projectName);
+
+    List<MergeRequest> getCommitMergeRequests(String projectId, String sha);
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/AutodetectingGitLabClient.java
@@ -362,6 +362,16 @@ final class AutodetectingGitLabClient implements GitLabClient {
         });
     }
 
+    @Override
+    public List<MergeRequest> getCommitMergeRequests(final String projectId, final String sha) {
+        return execute(new GitLabOperation<List<MergeRequest>>() {
+            @Override
+            List<MergeRequest> execute(GitLabClient client) {
+                return client.getCommitMergeRequests(projectId, sha);
+            }
+        });
+    }
+
     private GitLabClient delegate(boolean reset) {
         if (reset || delegate == null) {
             delegate = autodetectOrDie();

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/GitLabApiProxy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/GitLabApiProxy.java
@@ -81,4 +81,6 @@ interface GitLabApiProxy {
     List<Label> getLabels(String projectId);
 
     List<Pipeline> getPipelines(String projectName);
+
+    List<MergeRequest> getCommitMergeRequests(String projectId, String sha);
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClient.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/ResteasyGitLabClient.java
@@ -197,4 +197,9 @@ final class ResteasyGitLabClient implements GitLabClient {
     public List<Pipeline> getPipelines(String projectName) {
         return api.getPipelines(projectName);
     }
+
+    @Override
+    public List<MergeRequest> getCommitMergeRequests(String projectId, String sha) {
+        return api.getCommitMergeRequests(projectId, sha);
+    }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V3GitLabApiProxy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V3GitLabApiProxy.java
@@ -278,4 +278,11 @@ interface V3GitLabApiProxy extends GitLabApiProxy {
     @Path("/projects/{projectId}/pipelines")
     @Override
     List<Pipeline> getPipelines(@PathParam("projectId") @Encoded String projectId);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/projects/{projectId}/repository/commits/{sha}/merge_requests")
+    @Override
+    List<MergeRequest> getCommitMergeRequests(
+            @PathParam("projectId") @Encoded String projectId, @PathParam("sha") @Encoded String sha);
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V4GitLabApiProxy.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/api/impl/V4GitLabApiProxy.java
@@ -269,4 +269,11 @@ interface V4GitLabApiProxy extends GitLabApiProxy {
     @Path("/projects/{projectId}/pipelines")
     @Override
     List<Pipeline> getPipelines(@PathParam("projectId") @Encoded String projectId);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/projects/{projectId}/repository/commits/{sha}/merge_requests")
+    @Override
+    List<MergeRequest> getCommitMergeRequests(
+            @PathParam("projectId") @Encoded String projectId, @PathParam("sha") @Encoded String sha);
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Commit.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Commit.java
@@ -15,6 +15,7 @@ public class Commit {
 
     private String id;
     private String message;
+    private String title;
     private Date timestamp;
     private String url;
     private User author;
@@ -36,6 +37,14 @@ public class Commit {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
     }
 
     public Date getTimestamp() {

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PipelineEventObjectAttributes.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PipelineEventObjectAttributes.java
@@ -14,15 +14,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 public class PipelineEventObjectAttributes {
 
     private Integer id;
+    private Integer iid;
     private String ref;
     private boolean tag;
     private String sha;
     private String beforeSha;
+    private String source;
     private String status;
     private List<String> stages;
     private Date createdAt;
     private Date finishedAt;
     private int duration;
+    private String url;
 
     public String getRef() {
         return ref;
@@ -104,6 +107,30 @@ public class PipelineEventObjectAttributes {
         this.id = id;
     }
 
+    public Integer getIid() {
+        return iid;
+    }
+
+    public void setIid(Integer iid) {
+        this.iid = iid;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -115,15 +142,18 @@ public class PipelineEventObjectAttributes {
         PipelineEventObjectAttributes that = (PipelineEventObjectAttributes) o;
         return new EqualsBuilder()
                 .append(id, that.id)
+                .append(iid, that.iid)
                 .append(ref, that.ref)
                 .append(tag, that.tag)
                 .append(sha, that.sha)
                 .append(beforeSha, that.beforeSha)
+                .append(source, that.source)
                 .append(status, that.status)
                 .append(stages, that.stages)
                 .append(createdAt, that.createdAt)
                 .append(finishedAt, that.finishedAt)
                 .append(duration, that.duration)
+                .append(url, that.url)
                 .isEquals();
     }
 
@@ -131,15 +161,18 @@ public class PipelineEventObjectAttributes {
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
                 .append(id)
+                .append(iid)
                 .append(ref)
                 .append(tag)
                 .append(sha)
                 .append(beforeSha)
+                .append(source)
                 .append(status)
                 .append(stages)
                 .append(createdAt)
                 .append(finishedAt)
                 .append(duration)
+                .append(url)
                 .toHashCode();
     }
 
@@ -147,15 +180,18 @@ public class PipelineEventObjectAttributes {
     public String toString() {
         return new ToStringBuilder(this)
                 .append("id", id)
+                .append("iid", iid)
                 .append("ref", ref)
                 .append("tag", tag)
                 .append("sha", sha)
                 .append("beforeSha", beforeSha)
+                .append("source", source)
                 .append("status", status)
                 .append("stages", stages)
                 .append("createdAt", createdAt)
                 .append("finishedAt", finishedAt)
                 .append("duration", duration)
+                .append("url", url)
                 .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PipelineHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/PipelineHook.java
@@ -18,9 +18,11 @@ public class PipelineHook extends WebHook {
     @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "API compatibility")
     public Integer projectId;
 
+    private Commit commit;
     private List<Commit> commits;
     private Project project;
     private PipelineEventObjectAttributes objectAttributes;
+    private MergeRequestObjectAttributes mergeRequest;
 
     public Integer getProjectId() {
         return projectId;
@@ -36,6 +38,14 @@ public class PipelineHook extends WebHook {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    public Commit getCommit() {
+        return commit;
+    }
+
+    public void setCommit(Commit commit) {
+        this.commit = commit;
     }
 
     public List<Commit> getCommits() {
@@ -62,6 +72,14 @@ public class PipelineHook extends WebHook {
         this.objectAttributes = objectAttributes;
     }
 
+    public MergeRequestObjectAttributes getMergeRequest() {
+        return mergeRequest;
+    }
+
+    public void setMergeRequest(MergeRequestObjectAttributes mergeRequest) {
+        this.mergeRequest = mergeRequest;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -75,8 +93,10 @@ public class PipelineHook extends WebHook {
                 .append(user, that.user)
                 .append(project, that.project)
                 .append(projectId, that.projectId)
+                .append(commit, that.commit)
                 .append(commits, that.commits)
                 .append(objectAttributes, that.objectAttributes)
+                .append(mergeRequest, that.mergeRequest)
                 .isEquals();
     }
 
@@ -86,8 +106,10 @@ public class PipelineHook extends WebHook {
                 .append(user)
                 .append(projectId)
                 .append(project)
+                .append(commit)
                 .append(commits)
                 .append(objectAttributes)
+                .append(mergeRequest)
                 .toHashCode();
     }
 
@@ -97,8 +119,10 @@ public class PipelineHook extends WebHook {
                 .append("user", user)
                 .append("project", project)
                 .append("projectId", projectId)
+                .append("commit", commit)
                 .append("objectAttributes", objectAttributes)
                 .append("commits", commits)
+                .append("mergeRequest", mergeRequest)
                 .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Project.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/gitlab/hook/model/Project.java
@@ -24,6 +24,8 @@ public class Project {
     private String url;
     private String sshUrl;
     private String httpUrl;
+    private String gitSshUrl;
+    private String gitHttpUrl;
 
     public String getName() {
         return name;
@@ -121,6 +123,22 @@ public class Project {
         this.httpUrl = httpUrl;
     }
 
+    public String getGitSshUrl() {
+        return gitSshUrl;
+    }
+
+    public void setGitSshUrl(String gitSshUrl) {
+        this.gitSshUrl = gitSshUrl;
+    }
+
+    public String getGitHttpUrl() {
+        return gitHttpUrl;
+    }
+
+    public void setGitHttpUrl(String gitHttpUrl) {
+        this.gitHttpUrl = gitHttpUrl;
+    }
+
     public Integer getId() {
         return id;
     }
@@ -152,6 +170,8 @@ public class Project {
                 .append(url, project.url)
                 .append(sshUrl, project.sshUrl)
                 .append(httpUrl, project.httpUrl)
+                .append(gitSshUrl, project.gitSshUrl)
+                .append(gitHttpUrl, project.gitHttpUrl)
                 .isEquals();
     }
 
@@ -171,6 +191,8 @@ public class Project {
                 .append(url)
                 .append(sshUrl)
                 .append(httpUrl)
+                .append(gitSshUrl)
+                .append(gitHttpUrl)
                 .toHashCode();
     }
 
@@ -190,6 +212,8 @@ public class Project {
                 .append("url", url)
                 .append("sshUrl", sshUrl)
                 .append("httpUrl", httpUrl)
+                .append("gitSshUrl", gitSshUrl)
+                .append("gitHttpUrl", gitHttpUrl)
                 .toString();
     }
 }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerFactory.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerFactory.java
@@ -9,21 +9,30 @@ import java.util.List;
 public final class PipelineHookTriggerHandlerFactory {
 
     public static final String SUCCESS = "success";
+    public static final String FAILED = "failed";
 
     private PipelineHookTriggerHandlerFactory() {}
 
-    public static PipelineHookTriggerHandler newPipelineHookTriggerHandler(boolean triggerOnPipelineEvent) {
-        if (triggerOnPipelineEvent) {
-            return new PipelineHookTriggerHandlerImpl(retrieve(triggerOnPipelineEvent));
+    public static PipelineHookTriggerHandler newPipelineHookTriggerHandler(
+            boolean triggerOnPipelineEvent, boolean triggerOnFailedPipeline) {
+        if (triggerOnPipelineEvent || triggerOnFailedPipeline) {
+            return new PipelineHookTriggerHandlerImpl(retrieve(triggerOnPipelineEvent, triggerOnFailedPipeline));
         } else {
             return new NopPipelineHookTriggerHandler();
         }
     }
 
-    private static List<String> retrieve(boolean triggerOnPipelineEvent) {
+    public static PipelineHookTriggerHandler newPipelineHookTriggerHandler(boolean triggerOnPipelineEvent) {
+        return newPipelineHookTriggerHandler(triggerOnPipelineEvent, false);
+    }
+
+    private static List<String> retrieve(boolean triggerOnPipelineEvent, boolean triggerOnFailedPipeline) {
         List<String> result = new ArrayList<>();
         if (triggerOnPipelineEvent) {
             result.add(SUCCESS);
+        }
+        if (triggerOnFailedPipeline) {
+            result.add(FAILED);
         }
         return result;
     }

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImpl.java
@@ -6,6 +6,7 @@ import static com.dabsquared.gitlabjenkins.trigger.handler.builder.generated.Bui
 import com.dabsquared.gitlabjenkins.cause.CauseData;
 import com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty;
 import com.dabsquared.gitlabjenkins.gitlab.api.GitLabClient;
+import com.dabsquared.gitlabjenkins.gitlab.api.model.MergeRequest;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.PipelineEventObjectAttributes;
 import com.dabsquared.gitlabjenkins.gitlab.hook.model.PipelineHook;
 import com.dabsquared.gitlabjenkins.trigger.exception.NoRevisionToBuildException;
@@ -14,7 +15,6 @@ import com.dabsquared.gitlabjenkins.trigger.filter.MergeRequestLabelFilter;
 import com.dabsquared.gitlabjenkins.trigger.handler.AbstractWebHookTriggerHandler;
 import com.dabsquared.gitlabjenkins.util.BuildUtil;
 import com.dabsquared.gitlabjenkins.util.LoggerUtil;
-import hudson.model.AbstractProject;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.plugins.git.GitSCM;
@@ -33,6 +33,7 @@ class PipelineHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<Pipel
     private static final Logger LOGGER = Logger.getLogger(PipelineHookTriggerHandlerImpl.class.getName());
 
     private final List<String> allowedStates;
+    private MergeRequest resolvedMergeRequest;
 
     PipelineHookTriggerHandlerImpl(List<String> allowedStates) {
         this.allowedStates = allowedStates;
@@ -47,20 +48,54 @@ class PipelineHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<Pipel
             MergeRequestLabelFilter mergeRequestLabelFilter) {
         PipelineEventObjectAttributes objectAttributes = hook.getObjectAttributes();
         try {
-            if (job instanceof AbstractProject<?, ?>) {
-                GitLabConnectionProperty property = job.getProperty(GitLabConnectionProperty.class);
+            GitLabConnectionProperty property = job.getProperty(GitLabConnectionProperty.class);
+            if (property != null && property.getClient() != null) {
+                GitLabClient client = property.getClient();
 
-                if (property != null && property.getClient() != null) {
-                    GitLabClient client = property.getClient();
-                    com.dabsquared.gitlabjenkins.gitlab.api.model.Project projectForName =
-                            client.getProject(hook.getProject().getPathWithNamespace());
-                    hook.setProjectId(projectForName.getId());
+                // Resolve project ID
+                if (hook.getProject() != null && hook.getProject().getPathWithNamespace() != null) {
+                    try {
+                        com.dabsquared.gitlabjenkins.gitlab.api.model.Project projectForName =
+                                client.getProject(hook.getProject().getPathWithNamespace());
+                        hook.setProjectId(projectForName.getId());
+                    } catch (Exception e) {
+                        LOGGER.log(
+                                Level.WARNING,
+                                "Failed to communicate with gitlab server to determine project id: " + e.getMessage(),
+                                e);
+                    }
+                }
+
+                // Resolve merge request for the commit SHA
+                if (objectAttributes != null && objectAttributes.getSha() != null) {
+                    try {
+                        String projectPath = hook.getProject() != null
+                                ? hook.getProject().getPathWithNamespace()
+                                : (hook.getProjectId() != null ? hook.getProjectId().toString() : null);
+                        if (projectPath != null) {
+                            List<MergeRequest> mergeRequests =
+                                    client.getCommitMergeRequests(projectPath, objectAttributes.getSha());
+                            if (mergeRequests != null && !mergeRequests.isEmpty()) {
+                                resolvedMergeRequest = mergeRequests.get(0);
+                                LOGGER.log(
+                                        Level.FINE,
+                                        "Resolved merge request IID {0} for commit {1}",
+                                        new Object[] {resolvedMergeRequest.getIid(), objectAttributes.getSha()});
+                            }
+                        }
+                    } catch (Exception e) {
+                        LOGGER.log(
+                                Level.WARNING,
+                                "Failed to look up merge request for commit "
+                                        + objectAttributes.getSha() + ": " + e.getMessage(),
+                                e);
+                    }
                 }
             }
         } catch (WebApplicationException e) {
             LOGGER.log(
                     Level.WARNING,
-                    "Failed to communicate with gitlab server to determine project id: " + e.getMessage(),
+                    "Failed to communicate with gitlab server: " + e.getMessage(),
                     e);
         }
         if (allowedStates.contains(objectAttributes.getStatus()) && !isLastAlreadyBuild(job, hook)) {
@@ -98,6 +133,15 @@ class PipelineHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<Pipel
 
     @Override
     protected String getTargetBranch(PipelineHook hook) {
+        // If the pipeline is associated with a merge request, use the MR target branch
+        if (hook.getMergeRequest() != null && hook.getMergeRequest().getTargetBranch() != null) {
+            return hook.getMergeRequest().getTargetBranch();
+        }
+        // Otherwise fall back to the project's default branch
+        if (hook.getProject() != null && hook.getProject().getDefaultBranch() != null) {
+            return hook.getProject().getDefaultBranch();
+        }
+        // Last resort: use the ref
         return hook.getObjectAttributes().getRef() == null
                 ? null
                 : hook.getObjectAttributes().getRef().replaceFirst("^refs/heads/", "");
@@ -113,27 +157,60 @@ class PipelineHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<Pipel
         return causeData()
                 .withActionType(CauseData.ActionType.PIPELINE)
                 .withSourceProjectId(hook.getProject().getId())
-                .withBranch(getTargetBranch(hook) == null ? "" : getTargetBranch(hook))
-                .withSourceBranch(getTargetBranch(hook) == null ? "" : getTargetBranch(hook))
+                .withBranch(getSourceBranch(hook) == null ? "" : getSourceBranch(hook))
+                .withSourceBranch(getSourceBranch(hook) == null ? "" : getSourceBranch(hook))
                 .withUserName(
                         hook.getUser() == null || hook.getUser().getName() == null
                                 ? ""
                                 : hook.getUser().getName())
-                .withSourceRepoName(
-                        hook.getRepository() == null || hook.getRepository().getName() == null
+                .withUserUsername(
+                        hook.getUser() == null || hook.getUser().getUsername() == null
                                 ? ""
-                                : hook.getRepository().getName())
+                                : hook.getUser().getUsername())
+                .withUserEmail(
+                        hook.getUser() == null || hook.getUser().getEmail() == null
+                                ? ""
+                                : hook.getUser().getEmail())
+                .withSourceRepoHomepage(
+                        hook.getProject() == null || hook.getProject().getWebUrl() == null
+                                ? ""
+                                : hook.getProject().getWebUrl())
+                .withSourceRepoName(
+                        hook.getProject() == null || hook.getProject().getName() == null
+                                ? (hook.getRepository() == null || hook.getRepository().getName() == null
+                                        ? ""
+                                        : hook.getRepository().getName())
+                                : hook.getProject().getName())
                 .withSourceNamespace(
                         hook.getProject() == null || hook.getProject().getNamespace() == null
                                 ? ""
                                 : hook.getProject().getNamespace())
                 .withSourceRepoSshUrl(
-                        hook.getRepository() == null || hook.getRepository().getGitSshUrl() == null
-                                ? ""
-                                : hook.getRepository().getGitSshUrl())
+                        hook.getProject() != null && hook.getProject().getGitSshUrl() != null
+                                ? hook.getProject().getGitSshUrl()
+                                : (hook.getRepository() == null || hook.getRepository().getGitSshUrl() == null
+                                        ? ""
+                                        : hook.getRepository().getGitSshUrl()))
                 .withSourceRepoHttpUrl(
-                        hook.getRepository() == null ? "" : hook.getRepository().getGitHttpUrl())
-                .withMergeRequestTitle("")
+                        hook.getProject() != null && hook.getProject().getGitHttpUrl() != null
+                                ? hook.getProject().getGitHttpUrl()
+                                : (hook.getRepository() == null || hook.getRepository().getGitHttpUrl() == null
+                                        ? ""
+                                        : hook.getRepository().getGitHttpUrl()))
+                .withMergeRequestTitle(
+                        resolvedMergeRequest != null && resolvedMergeRequest.getTitle() != null
+                                ? resolvedMergeRequest.getTitle()
+                                : (hook.getMergeRequest() != null && hook.getMergeRequest().getTitle() != null
+                                        ? hook.getMergeRequest().getTitle()
+                                        : ""))
+                .withMergeRequestIid(
+                        resolvedMergeRequest != null
+                                ? resolvedMergeRequest.getIid()
+                                : (hook.getMergeRequest() != null ? hook.getMergeRequest().getIid() : null))
+                .withMergeRequestId(
+                        resolvedMergeRequest != null
+                                ? resolvedMergeRequest.getId()
+                                : (hook.getMergeRequest() != null ? hook.getMergeRequest().getId() : null))
                 .withTargetProjectId(hook.getProject().getId())
                 .withTargetBranch(getTargetBranch(hook) == null ? "" : getTargetBranch(hook))
                 .withTargetRepoName("")
@@ -174,6 +251,42 @@ class PipelineHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<Pipel
                                 ? ""
                                 : hook.getObjectAttributes().getFinishedAt().toString())
                 .withBuildDuration(String.valueOf(hook.getObjectAttributes().getDuration()))
+                .withPipelineId(hook.getObjectAttributes().getId())
+                .withPipelineIid(hook.getObjectAttributes().getIid())
+                .withPipelineSource(hook.getObjectAttributes().getSource())
+                .withPipelineUrl(hook.getObjectAttributes().getUrl())
+                .withCommitMessage(
+                        hook.getCommit() == null || hook.getCommit().getMessage() == null
+                                ? null
+                                : hook.getCommit().getMessage())
+                .withCommitTitle(
+                        hook.getCommit() == null || hook.getCommit().getTitle() == null
+                                ? null
+                                : hook.getCommit().getTitle())
+                .withCommitAuthorName(
+                        hook.getCommit() == null
+                                        || hook.getCommit().getAuthor() == null
+                                        || hook.getCommit().getAuthor().getName() == null
+                                ? null
+                                : hook.getCommit().getAuthor().getName())
+                .withCommitAuthorEmail(
+                        hook.getCommit() == null
+                                        || hook.getCommit().getAuthor() == null
+                                        || hook.getCommit().getAuthor().getEmail() == null
+                                ? null
+                                : hook.getCommit().getAuthor().getEmail())
+                .withCommitUrl(
+                        hook.getCommit() == null || hook.getCommit().getUrl() == null
+                                ? null
+                                : hook.getCommit().getUrl())
+                .withProjectWebUrl(
+                        hook.getProject() == null || hook.getProject().getWebUrl() == null
+                                ? null
+                                : hook.getProject().getWebUrl())
+                .withProjectPathWithNamespace(
+                        hook.getProject() == null || hook.getProject().getPathWithNamespace() == null
+                                ? null
+                                : hook.getProject().getPathWithNamespace())
                 .build();
     }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImpl.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImpl.java
@@ -71,34 +71,34 @@ class PipelineHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<Pipel
                     try {
                         String projectPath = hook.getProject() != null
                                 ? hook.getProject().getPathWithNamespace()
-                                : (hook.getProjectId() != null ? hook.getProjectId().toString() : null);
+                                : (hook.getProjectId() != null
+                                        ? hook.getProjectId().toString()
+                                        : null);
                         if (projectPath != null) {
                             List<MergeRequest> mergeRequests =
                                     client.getCommitMergeRequests(projectPath, objectAttributes.getSha());
                             if (mergeRequests != null && !mergeRequests.isEmpty()) {
                                 resolvedMergeRequest = mergeRequests.get(0);
-                                LOGGER.log(
-                                        Level.FINE,
-                                        "Resolved merge request IID {0} for commit {1}",
-                                        new Object[] {resolvedMergeRequest.getIid(), objectAttributes.getSha()});
+                                LOGGER.log(Level.FINE, "Resolved merge request IID {0} for commit {1}", new Object[] {
+                                    resolvedMergeRequest.getIid(), objectAttributes.getSha()
+                                });
                             }
                         }
                     } catch (Exception e) {
                         LOGGER.log(
                                 Level.WARNING,
-                                "Failed to look up merge request for commit "
-                                        + objectAttributes.getSha() + ": " + e.getMessage(),
+                                "Failed to look up merge request for commit " + objectAttributes.getSha() + ": "
+                                        + e.getMessage(),
                                 e);
                     }
                 }
             }
         } catch (WebApplicationException e) {
-            LOGGER.log(
-                    Level.WARNING,
-                    "Failed to communicate with gitlab server: " + e.getMessage(),
-                    e);
+            LOGGER.log(Level.WARNING, "Failed to communicate with gitlab server: " + e.getMessage(), e);
         }
-        if (allowedStates.contains(objectAttributes.getStatus()) && !isLastAlreadyBuild(job, hook)) {
+        if (objectAttributes != null
+                && allowedStates.contains(objectAttributes.getStatus())
+                && !isLastAlreadyBuild(job, hook)) {
             if (ciSkip && isCiSkip(hook)) {
                 LOGGER.log(Level.INFO, "Skipping due to ci-skip.");
                 return;
@@ -177,7 +177,8 @@ class PipelineHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<Pipel
                                 : hook.getProject().getWebUrl())
                 .withSourceRepoName(
                         hook.getProject() == null || hook.getProject().getName() == null
-                                ? (hook.getRepository() == null || hook.getRepository().getName() == null
+                                ? (hook.getRepository() == null
+                                                || hook.getRepository().getName() == null
                                         ? ""
                                         : hook.getRepository().getName())
                                 : hook.getProject().getName())
@@ -188,29 +189,36 @@ class PipelineHookTriggerHandlerImpl extends AbstractWebHookTriggerHandler<Pipel
                 .withSourceRepoSshUrl(
                         hook.getProject() != null && hook.getProject().getGitSshUrl() != null
                                 ? hook.getProject().getGitSshUrl()
-                                : (hook.getRepository() == null || hook.getRepository().getGitSshUrl() == null
+                                : (hook.getRepository() == null
+                                                || hook.getRepository().getGitSshUrl() == null
                                         ? ""
                                         : hook.getRepository().getGitSshUrl()))
                 .withSourceRepoHttpUrl(
                         hook.getProject() != null && hook.getProject().getGitHttpUrl() != null
                                 ? hook.getProject().getGitHttpUrl()
-                                : (hook.getRepository() == null || hook.getRepository().getGitHttpUrl() == null
+                                : (hook.getRepository() == null
+                                                || hook.getRepository().getGitHttpUrl() == null
                                         ? ""
                                         : hook.getRepository().getGitHttpUrl()))
                 .withMergeRequestTitle(
                         resolvedMergeRequest != null && resolvedMergeRequest.getTitle() != null
                                 ? resolvedMergeRequest.getTitle()
-                                : (hook.getMergeRequest() != null && hook.getMergeRequest().getTitle() != null
+                                : (hook.getMergeRequest() != null
+                                                && hook.getMergeRequest().getTitle() != null
                                         ? hook.getMergeRequest().getTitle()
                                         : ""))
                 .withMergeRequestIid(
                         resolvedMergeRequest != null
                                 ? resolvedMergeRequest.getIid()
-                                : (hook.getMergeRequest() != null ? hook.getMergeRequest().getIid() : null))
+                                : (hook.getMergeRequest() != null
+                                        ? hook.getMergeRequest().getIid()
+                                        : null))
                 .withMergeRequestId(
                         resolvedMergeRequest != null
                                 ? resolvedMergeRequest.getId()
-                                : (hook.getMergeRequest() != null ? hook.getMergeRequest().getId() : null))
+                                : (hook.getMergeRequest() != null
+                                        ? hook.getMergeRequest().getId()
+                                        : null))
                 .withTargetProjectId(hook.getProject().getId())
                 .withTargetBranch(getTargetBranch(hook) == null ? "" : getTargetBranch(hook))
                 .withTargetRepoName("")

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -53,6 +53,9 @@
     <f:entry title="Build on successful pipeline events" field="triggerOnPipelineEvent">
       <f:checkbox default="false"/>
     </f:entry>
+    <f:entry title="Build on failed pipeline events" field="triggerOnFailedPipelineEvent">
+      <f:checkbox default="false"/>
+    </f:entry>
     <f:entry title="Pending build name for pipeline" help="/plugin/gitlab-plugin/help/help-pendingBuildName.html">
       <f:textbox field="pendingBuildName"/>
     </f:entry>

--- a/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabClientStub.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/service/GitLabClientStub.java
@@ -215,4 +215,9 @@ class GitLabClientStub implements GitLabClient {
     public List<Pipeline> getPipelines(String projectName) {
         return Collections.emptyList();
     }
+
+    @Override
+    public List<MergeRequest> getCommitMergeRequests(String projectId, String sha) {
+        return Collections.emptyList();
+    }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImplTest.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/trigger/handler/pipeline/PipelineHookTriggerHandlerImplTest.java
@@ -151,4 +151,122 @@ class PipelineHookTriggerHandlerImplTest {
         assertThat(buildTriggered.isSignaled(), is(true));
         jenkins.assertBuildStatusSuccess(jenkins.waitForCompletion(buildHolder.get()));
     }
+
+    @Test
+    void pipeline_build_on_failed_event() throws Exception {
+        List<String> failedStates = new ArrayList<>();
+        failedStates.add("failed");
+        PipelineHookTriggerHandler failedHandler = new PipelineHookTriggerHandlerImpl(failedStates);
+
+        Git git = Git.open(tmp);
+        ObjectId head = git.getRepository().resolve(Constants.HEAD);
+
+        User user = new User();
+        user.setName("test");
+        user.setId(1);
+
+        PipelineHook failedPipelineHook = pipelineHook()
+                .withUser(user)
+                .withRepository(repository()
+                        .withName("test")
+                        .withHomepage("https://gitlab.org/test")
+                        .withUrl("git@gitlab.org:test.git")
+                        .withGitSshUrl("git@gitlab.org:test.git")
+                        .withGitHttpUrl("https://gitlab.org/test.git")
+                        .build())
+                .withProject(project()
+                        .withNamespace("test-namespace")
+                        .withWebUrl("https://gitlab.org/test")
+                        .withId(1)
+                        .build())
+                .withObjectAttributes(pipelineEventObjectAttributes()
+                        .withId(2)
+                        .withStatus("failed")
+                        .withSha("bcbb5ec396a2c0f828686f14fac9b80b780504f2")
+                        .withStages(new ArrayList<String>())
+                        .withRef("refs/heads/" + git.nameRev().add(head).call().get(head))
+                        .build())
+                .build();
+        git.close();
+
+        final OneShotEvent buildTriggered = new OneShotEvent();
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        final AtomicReference<FreeStyleBuild> buildHolder = new AtomicReference<>();
+        project.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+                buildHolder.set((FreeStyleBuild) build);
+                buildTriggered.signal();
+                return true;
+            }
+        });
+        project.setQuietPeriod(0);
+
+        failedHandler.handle(
+                project,
+                failedPipelineHook,
+                false,
+                newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
+
+        buildTriggered.block(10000);
+        assertThat(buildTriggered.isSignaled(), is(true));
+        jenkins.assertBuildStatusSuccess(jenkins.waitForCompletion(buildHolder.get()));
+    }
+
+    @Test
+    void pipeline_build_ignores_failed_when_not_configured() throws Exception {
+        // Default handler only allows "success" — a "failed" event should NOT trigger a build
+        Git git = Git.open(tmp);
+        ObjectId head = git.getRepository().resolve(Constants.HEAD);
+
+        User user = new User();
+        user.setName("test");
+        user.setId(1);
+
+        PipelineHook failedPipelineHook = pipelineHook()
+                .withUser(user)
+                .withRepository(repository()
+                        .withName("test")
+                        .withHomepage("https://gitlab.org/test")
+                        .withUrl("git@gitlab.org:test.git")
+                        .withGitSshUrl("git@gitlab.org:test.git")
+                        .withGitHttpUrl("https://gitlab.org/test.git")
+                        .build())
+                .withProject(project()
+                        .withNamespace("test-namespace")
+                        .withWebUrl("https://gitlab.org/test")
+                        .withId(1)
+                        .build())
+                .withObjectAttributes(pipelineEventObjectAttributes()
+                        .withId(2)
+                        .withStatus("failed")
+                        .withSha("bcbb5ec396a2c0f828686f14fac9b80b780504f2")
+                        .withStages(new ArrayList<String>())
+                        .withRef("refs/heads/" + git.nameRev().add(head).call().get(head))
+                        .build())
+                .build();
+        git.close();
+
+        final OneShotEvent buildTriggered = new OneShotEvent();
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        project.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+                buildTriggered.signal();
+                return true;
+            }
+        });
+        project.setQuietPeriod(0);
+
+        pipelineHookTriggerHandler.handle(
+                project,
+                failedPipelineHook,
+                false,
+                newBranchFilter(branchFilterConfig().build(BranchFilterType.All)),
+                newMergeRequestLabelFilter(null));
+
+        buildTriggered.block(5000);
+        assertThat(buildTriggered.isSignaled(), is(false));
+    }
 }

--- a/src/test/java/com/dabsquared/gitlabjenkins/util/GitLabClientStub.java
+++ b/src/test/java/com/dabsquared/gitlabjenkins/util/GitLabClientStub.java
@@ -174,4 +174,9 @@ class GitLabClientStub implements GitLabClient {
     public List<Pipeline> getPipelines(String projectName) {
         return null;
     }
+
+    @Override
+    public List<MergeRequest> getCommitMergeRequests(String projectId, String sha) {
+        return null;
+    }
 }


### PR DESCRIPTION
### What this does
Makes GitLab pipeline (CI) event handling useful beyond "build only on success":

- **Trigger:** new "Build on failed pipeline events" option, so failed pipelines
  no longer go unnoticed. The trigger now derives its allowed pipeline states
  from the success and failed flags independently.
- **Merge request resolution:** new `getCommitMergeRequests(projectId, sha)`
  (GitLab v3/v4 `/repository/commits/{sha}/merge_requests`) so a pipeline event
  is associated with its MR; used to resolve MR title/iid/id and the target
  branch (MR target → project default branch → ref).
- **Env vars:** richer build env exposing pipeline id/iid/source/url, commit
  message/title/author name/email/url, and project web URL / path-with-namespace.

### Testing
**Automated** — added to `PipelineHookTriggerHandlerImplTest`:
- `pipeline_build_on_failed_event` — a `failed` event triggers when enabled
- `pipeline_build_ignores_failed_when_not_configured` — `failed` ignored when disabled

Result: `Tests run: 4, Failures: 0, Errors: 0` (Maven 3.9.9 / JDK 21); `hpi` packages cleanly.

**Manual** — deployed the built `.hpi` against a live GitLab:
- Failed pipeline event triggers a build with the option on; only successful with it off.
- MR-linked pipeline resolves the MR and builds the MR target branch.
- Confirmed `gitlabPipeline*`, `gitlabCommit*`, `gitlabProject*` env vars populated.

The model/API additions have no dedicated unit tests as they are plain
payload/proxy mappings exercised by the above; let me know if you'd like the env-var mapping unit-tested.

### Submitter checklist
- [x] Opening from a topic/feature/bugfix branch (not master)
- [x] PR title represents the desired changelog entry
- [x] Described what I did
- [ ] Link to relevant issues
- [ ] Link to relevant PRs
- [x] Provided tests demonstrating the feature