### PR TITLE
Remove redundant DataBoundConstructor / DataBoundSetter on GitLabConnectionConfig

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfig.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/connection/GitLabConnectionConfig.java
@@ -10,8 +10,6 @@ import java.util.List;
 import java.util.Map;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest2;
 
 /**
@@ -24,7 +22,6 @@ public class GitLabConnectionConfig extends GlobalConfiguration {
     private List<GitLabConnection> connections = new ArrayList<>();
     private transient Map<String, GitLabConnection> connectionMap = new HashMap<>();
 
-    @DataBoundConstructor
     public GitLabConnectionConfig() {
         load();
         refreshConnectionMap();
@@ -34,7 +31,6 @@ public class GitLabConnectionConfig extends GlobalConfiguration {
         return useAuthenticatedEndpoint;
     }
 
-    @DataBoundSetter
     public void setUseAuthenticatedEndpoint(boolean useAuthenticatedEndpoint) {
         this.useAuthenticatedEndpoint = useAuthenticatedEndpoint;
         save();
@@ -58,7 +54,6 @@ public class GitLabConnectionConfig extends GlobalConfiguration {
         addConnection(connections, connectionMap, connection);
     }
 
-    @DataBoundSetter
     public void setConnections(List<GitLabConnection> newConnections) {
         List<GitLabConnection> tempConnections = new ArrayList<>();
         Map<String, GitLabConnection> tempConnectionMap = new HashMap<>();


### PR DESCRIPTION
## Remove redundant DataBoundConstructor on GitLabConnectionConfig

The object is already an Extension.  It does not need a DataBoundConstructor or DataBoundSetter.

### Testing done

* Automated tests pass, including the configuration as code automated test
* Interactive testing checked the system configuration page by adding a GitLab connection with a legacy API token and pressing the Test Connection button.  The test passed with the legacy API token.
* Interactive testing checked the system configuration page by adding a GitLab connection with a fine-grained API token and pressing the Test Connection button.  The test failed with the fine-grained API token.  I assume that I had incorrect definitions on the fine-grained API token

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
